### PR TITLE
test(front-core): add KUtils unit tests [TASK-004]

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -2,6 +2,25 @@
 
 新记录追加在顶部。
 
+## 2026-04-23 15:40 UTC
+task: TASK-004
+agent: coordinator
+branch: codex/TASK-004-front-core-audit
+status: review
+summary:
+- 审计 knife4j-front/knife4j-core 测试覆盖，发现 KUtils（wrapLine/basicType/basicTypeValue）零覆盖
+- 新增 src/__tests__/utils/kutils.test.ts，13 个定向单元测试
+- 测试数从 8 增加到 21，全部通过；lint 和 build 无报错
+- 分支已推送，PR 待人工创建（gh CLI 未认证）
+validation:
+- ./scripts/test-front-core.sh: 8 suites, 21 tests, all pass
+next:
+- 维护者通过 gh auth login 或直接在 GitHub 开 PR
+- PR compare URL: https://github.com/songxychn/knife4j-next/compare/codex/TASK-004-front-core-audit
+- 后续可补充 utils/openapi3.ts、utils/swagger2.ts、SpecParserFactory 的测试
+blockers:
+- gh CLI 未认证，无法自动开 PR；需要维护者手动操作或配置 GH_TOKEN
+
 ## 模板
 
 ```md

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -30,7 +30,7 @@ notes:
 ## 队列
 
 ### TASK-001
-status: review
+status: done
 area: repo
 title: 增加 fork 专属的贡献流程和自治维护文档
 branch: codex/TASK-001-agent-docs
@@ -70,7 +70,7 @@ notes:
 - 在显著扩大矩阵范围或运行成本前，需要人工确认。
 
 ### TASK-004
-status: ready
+status: review
 area: front-core
 title: 审计 parser-core 测试和 lint 覆盖缺口
 branch: codex/TASK-004-front-core-audit
@@ -82,3 +82,5 @@ done_when:
 - 结果写回 `.agent/PROGRESS.md`
 notes:
 - 保持为一个小修复或一个具体审计结果，不要变成重写。
+- 分支已推送，PR 待人工通过 gh auth login 后创建，或直接在 GitHub 上开 PR。
+- PR compare URL: https://github.com/songxychn/knife4j-next/compare/codex/TASK-004-front-core-audit

--- a/knife4j-front/knife4j-core/src/__tests__/utils/kutils.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/utils/kutils.test.ts
@@ -1,0 +1,63 @@
+import KUtils from '../../models/knife4j/utils/KUtils';
+
+describe('KUtils.wrapLine', () => {
+  test('returns empty string for empty input', () => {
+    expect(KUtils.wrapLine('')).toBe('');
+  });
+
+  test('returns string unchanged when no newlines', () => {
+    expect(KUtils.wrapLine('hello world')).toBe('hello world');
+  });
+
+  test('replaces \\n with literal \\\\n', () => {
+    expect(KUtils.wrapLine('line1\nline2')).toBe('line1\\nline2');
+  });
+
+  test('replaces \\r\\n with literal \\\\n', () => {
+    expect(KUtils.wrapLine('line1\r\nline2')).toBe('line1\\nline2');
+  });
+
+  test('replaces \\r with literal \\\\n', () => {
+    expect(KUtils.wrapLine('line1\rline2')).toBe('line1\\nline2');
+  });
+});
+
+describe('KUtils.basicType', () => {
+  test('returns true for known basic types', () => {
+    const types = ['string', 'integer', 'number', 'object', 'boolean', 'int32', 'int64', 'float', 'double'];
+    for (const t of types) {
+      expect(KUtils.basicType(t)).toBe(true);
+    }
+  });
+
+  test('returns false for unknown type', () => {
+    expect(KUtils.basicType('file')).toBe(false);
+    expect(KUtils.basicType('binary')).toBe(false);
+  });
+
+  test('returns false for empty string', () => {
+    expect(KUtils.basicType('')).toBe(false);
+  });
+});
+
+describe('KUtils.basicTypeValue', () => {
+  test('returns 0 for integer', () => {
+    expect(KUtils.basicTypeValue('integer')).toBe(0);
+  });
+
+  test('returns true for boolean', () => {
+    expect(KUtils.basicTypeValue('boolean')).toBe(true);
+  });
+
+  test('returns empty object for object', () => {
+    expect(KUtils.basicTypeValue('object')).toEqual({});
+  });
+
+  test('returns 0 for number', () => {
+    expect(KUtils.basicTypeValue('number')).toBe(0);
+  });
+
+  test('returns undefined for unknown type', () => {
+    expect(KUtils.basicTypeValue('string')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
审计 parser-core 测试覆盖缺口，新增 KUtils 13 个单元测试。\n\n- wrapLine / basicType / basicTypeValue 零覆盖 → 已补齐\n- test-front-core.sh 通过：8 suites，21 tests\n\nCloses TASK-004