### PR TITLE
feat(smoke): add boot3-app smoke module for knife4j-openapi3-spring-boot-starter [TASK-003]

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -21,6 +21,26 @@ blockers:
 - blocker，如无则写 none
 ```
 
+## 2026-04-23 19:27 UTC
+task: TASK-003
+agent: knife4j-next-bot
+branch: codex/TASK-003-java-smoke-coverage
+status: review
+summary:
+- 新增 knife4j-smoke-tests/boot3-app 子模块
+- 使用 knife4j-openapi3-spring-boot-starter（Boot 2.x + OpenAPI 3，非 jakarta）
+- Spring Boot 版本 2.7.18（TASK notes 中 4.0.1 有误，已修正）
+- Boot3DocHttpSmokeTest 验证 /doc.html 和 /v3/api-docs 返回 200
+- 注册到 knife4j-smoke-tests/pom.xml modules
+validation:
+- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -B -ntp -Dknife4j-skipTests=false verify` → BUILD SUCCESS（全部 17 模块）
+next:
+- 等待人工 review PR #7
+- PR 合并后可推进 TASK-008（Boot 3.4/3.5 兼容性）
+blockers:
+- 无
+pr: https://github.com/songxychn/knife4j-next/pull/7
+
 ## 2026-04-23 21:58 UTC
 task: TASK-009
 agent: knife4j-next-bot

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -69,7 +69,7 @@ notes:
 - 保留历史署名和感谢，只修复容易造成归属误解的表述。
 
 ### TASK-003
-status: ready
+status: review
 area: java
 title: 新增 boot3-app smoke 模块（knife4j-openapi3-spring-boot-starter）
 branch: codex/TASK-003-java-smoke-coverage
@@ -82,9 +82,10 @@ done_when:
 - mvn verify 在该模块通过
 notes:
 - 参考现有 boot3-jakarta-app 的结构，只换 starter 依赖
-- Spring Boot 版本与 boot3-jakarta-app 保持一致（4.0.1）
+- Spring Boot 版本使用 ${knife4j-spring-boot.version}=2.7.18（非 4.0.1，notes 有误）
 - WebFlux 变体优先级低，本任务不涉及
 - 维护者已确认此为当前优先补齐的组合
+- PR: https://github.com/songxychn/knife4j-next/pull/7
 
 ### TASK-004
 status: done

--- a/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>4.6.0.1</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-boot3-app</artifactId>
+    <name>knife4j-smoke-boot3-app</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${knife4j-spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/knife4j/knife4j-smoke-tests/boot3-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3DocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot3-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3DocHttpSmokeTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot3;
+
+import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.context.WebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class Boot3DocHttpSmokeTest {
+    
+    private ConfigurableApplicationContext context;
+    
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+    
+    @Test
+    public void shouldServeDocHtmlAndOpenApiJson() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "logging.level.root=ERROR")
+                .run();
+        
+        int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+        
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(docHtml.body.contains("webjars/js/"));
+        
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+        Assert.assertTrue(apiDocs.body.contains("\"openapi\""));
+        Assert.assertTrue(apiDocs.body.contains("/hello"));
+    }
+    
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+    
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+    
+    private static class HttpResponse {
+        
+        private final int statusCode;
+        private final String body;
+        
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+    
+    @EnableKnife4j
+    @SpringBootApplication
+    public static class TestApplication {
+    }
+    
+    @RestController
+    public static class TestController {
+        
+        @GetMapping("/hello")
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -18,5 +18,6 @@
     <modules>
         <module>boot2-app</module>
         <module>boot3-jakarta-app</module>
+        <module>boot3-app</module>
     </modules>
 </project>


### PR DESCRIPTION
## TASK-003: 新增 boot3-app smoke 模块

### 范围
新增 `knife4j-smoke-tests/boot3-app` 子模块，覆盖 `knife4j-openapi3-spring-boot-starter`（Spring Boot 2.x + OpenAPI 3，非 jakarta）的 smoke 测试。

### 变更
- `knife4j/knife4j-smoke-tests/boot3-app/pom.xml`：新模块，使用 `knife4j-openapi3-spring-boot-starter` + Spring Boot `2.7.18`
- `Boot3DocHttpSmokeTest.java`：验证 `/doc.html` 和 `/v3/api-docs` 返回 200
- `knife4j/knife4j-smoke-tests/pom.xml`：注册新模块

### 验证
```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -B -ntp -Dknife4j-skipTests=false verify
```
结果：BUILD SUCCESS（全部 17 模块，含新 knife4j-smoke-boot3-app）

### 备注
- TASK-003 notes 中提到版本 4.0.1 有误；`knife4j-openapi3-spring-boot-starter` 是 Boot 2.x starter，正确版本为 `${knife4j-spring-boot.version}=2.7.18`
- TASK-008（Boot 3.4/3.5 兼容性）depends_on 本任务，可在本 PR 合并后推进