### PR TITLE
fix(gateway): fix context-path missing leading slash in host concatenation [TASK-009]

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -21,7 +21,24 @@ blockers:
 - blocker，如无则写 none
 ```
 
-## 2026-04-23 16:50 UTC
+## 2026-04-23 21:58 UTC
+task: TASK-009
+agent: knife4j-next-bot
+branch: codex/TASK-009-fix-gateway-context-path
+status: review
+summary:
+- PathUtils.processContextPath 加前导斜杠保护，防止 host 拼接缺少 /
+- OpenAPIEndpoint.configUrl 改为 PathUtils.append(basePath, "/v3/api-docs/swagger-config")
+- 新增 PathUtilsTest.test_processContextPath_leadingSlash 回归测试
+validation:
+- JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -B -ntp -Dknife4j-skipTests=false verify → BUILD SUCCESS（16 模块）
+next:
+- 等待人工 review PR #8
+blockers:
+- 无
+pr: https://github.com/songxychn/knife4j-next/pull/8
+
+## 2026-04-23 19:27 UTC
 task: TASK-007
 agent: knife4j-next-bot subagent
 branch: codex/TASK-007-fix-basic-auth-bypass

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -149,7 +149,7 @@ notes:
 - Boot 4.x 兼容性单独立任务，本任务聚焦 3.4/3.5
 
 ### TASK-009
-status: ready
+status: review
 area: java
 title: 修复 gateway context-path 导致 host 缺少斜杠的 bug（#954）
 branch: codex/TASK-009-fix-gateway-context-path
@@ -161,6 +161,7 @@ done_when:
 notes:
 - 上游 issue #954：knife4j-gateway-spring-boot-starter 4.5.0 配置 context-path 后 host 少个 /
 - 影响所有使用 gateway 聚合且配置了 context-path 的用户
+- PR: https://github.com/songxychn/knife4j-next/pull/8
 
 ### TASK-010
 status: blocked

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/OpenAPIEndpoint.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/OpenAPIEndpoint.java
@@ -58,7 +58,7 @@ public class OpenAPIEndpoint {
         OpenAPI3Response response = new OpenAPI3Response();
         final String basePath = PathUtils.getDefaultContextPath(request);
         log.debug("base-path:{}", basePath);
-        response.setConfigUrl("/v3/api-docs/swagger-config");
+        response.setConfigUrl(PathUtils.append(basePath, "/v3/api-docs/swagger-config"));
         response.setOauth2RedirectUrl(this.knife4jGatewayProperties.getDiscover().getOas3().getOauth2RedirectUrl());
         response.setValidatorUrl(this.knife4jGatewayProperties.getDiscover().getOas3().getValidatorUrl());
         // 设置排序规则,add at 2023/07/02 11:30:00

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/utils/PathUtils.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/utils/PathUtils.java
@@ -113,6 +113,10 @@ public class PathUtils {
             // 去除尾部/字符
             validateContextPath = validateContextPath.substring(0, validateContextPath.length() - 1);
         }
+        // 确保非空路径有前导斜杠，防止拼接 host 时缺少 /
+        if (StringUtils.hasLength(validateContextPath) && !validateContextPath.startsWith(DEFAULT_CONTEXT_PATH)) {
+            validateContextPath = DEFAULT_CONTEXT_PATH + validateContextPath;
+        }
         return validateContextPath;
     }
     

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/utils/PathUtilsTest.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/utils/PathUtilsTest.java
@@ -61,6 +61,20 @@ public class PathUtilsTest {
     }
     
     @Test
+    public void test_processContextPath_leadingSlash() {
+        // 无前导斜杠的 contextPath 应被修正，防止 host 拼接缺少 /
+        Assert.assertEquals("/api", PathUtils.processContextPath("api"));
+        Assert.assertEquals("/api", PathUtils.processContextPath("api/"));
+        // 已有前导斜杠的不变
+        Assert.assertEquals("/api", PathUtils.processContextPath("/api"));
+        Assert.assertEquals("/api", PathUtils.processContextPath("/api/"));
+        // 根路径返回空字符串
+        Assert.assertEquals("", PathUtils.processContextPath("/"));
+        // 空字符串不变
+        Assert.assertEquals("", PathUtils.processContextPath(""));
+    }
+    
+    @Test
     public void test_append1() {
         String path = "//abc";
         String appendPath = PathUtils.append(path, "//v2/api-dcos");


### PR DESCRIPTION
## TASK-009: 修复 gateway context-path 导致 host 缺少斜杠的 bug

### 问题
上游 issue #954：`knife4j-gateway-spring-boot-starter` 配置 `context-path` 后，gateway 聚合的 host 拼接缺少 `/`，导致 Swagger UI 请求路径错误。

### 根因
两处问题：
1. `PathUtils.processContextPath`：只处理尾部斜杠，不处理前导斜杠。若输入为 `api`（无前导斜杠），输出也是 `api`，拼接 host 后变成 `http://localhost:8080api/...`
2. `OpenAPIEndpoint.swaggerConfig`：`configUrl` 硬编码为 `/v3/api-docs/swagger-config`，未加 `basePath` 前缀，配置了 context-path 时 Swagger UI 无法正确请求 config

### 修复
- `PathUtils.processContextPath`：非空结果确保有前导斜杠
- `OpenAPIEndpoint`：`configUrl` 改为 `PathUtils.append(basePath, "/v3/api-docs/swagger-config")`
- 新增 `PathUtilsTest.test_processContextPath_leadingSlash` 回归测试（6 个用例）

### 验证
```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn -B -ntp -Dknife4j-skipTests=false verify
```
结果：BUILD SUCCESS（全部 16 模块）