### PR TITLE
fix(compat): support Spring Boot 3.4/3.5 [TASK-008]

### DIFF
--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
@@ -14,8 +14,8 @@
 
     <properties>
         <knife4j-java.version>17</knife4j-java.version>
-        <knife4j-spring3.version>7.0.1</knife4j-spring3.version>
-        <knife4j-spring-boot3.version>4.0.1</knife4j-spring-boot3.version>
+        <knife4j-spring3.version>6.2.7</knife4j-spring3.version>
+        <knife4j-spring-boot3.version>3.4.5</knife4j-spring-boot3.version>
 
         <knife4j-javassist.version>3.30.2-GA</knife4j-javassist.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>

--- a/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
@@ -11,12 +11,12 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>knife4j-smoke-boot3-jakarta-app</artifactId>
-    <name>knife4j-smoke-boot3-jakarta-app</name>
+    <artifactId>knife4j-smoke-boot35-jakarta-app</artifactId>
+    <name>knife4j-smoke-boot35-jakarta-app</name>
 
     <properties>
-        <knife4j-spring3.version>6.2.7</knife4j-spring3.version>
-        <knife4j-spring-boot3.version>3.4.5</knife4j-spring-boot3.version>
+        <knife4j-spring3.version>6.2.8</knife4j-spring3.version>
+        <knife4j-spring-boot3.version>3.5.0</knife4j-spring-boot3.version>
     </properties>
 
     <dependencies>

--- a/knife4j/knife4j-smoke-tests/boot35-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot35JakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot35-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot35JakartaDocHttpSmokeTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot3;
+
+import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class Boot35JakartaDocHttpSmokeTest {
+    
+    private ConfigurableApplicationContext context;
+    
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+    
+    @Test
+    public void shouldServeDocHtmlAndOpenApiJson() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "logging.level.root=ERROR")
+                .run();
+        
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+        
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(docHtml.body.contains("webjars/js/"));
+        
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+        Assert.assertTrue(apiDocs.body.contains("\"openapi\""));
+        Assert.assertTrue(apiDocs.body.contains("/hello"));
+    }
+    
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+    
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+    
+    private static class HttpResponse {
+        
+        private final int statusCode;
+        private final String body;
+        
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+    
+    @EnableKnife4j
+    @SpringBootApplication
+    public static class TestApplication {
+    }
+    
+    @RestController
+    public static class TestController {
+        
+        @GetMapping("/hello")
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -19,5 +19,6 @@
         <module>boot2-app</module>
         <module>boot3-jakarta-app</module>
         <module>boot3-app</module>
+        <module>boot35-jakarta-app</module>
     </modules>
 </project>

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -54,7 +54,7 @@
         <knife4j-springdoc-openapi.version>1.8.0</knife4j-springdoc-openapi.version>
         <knife4j-swagger-models.version>1.6.14</knife4j-swagger-models.version>
 
-        <knife4j-springdoc-openapi-jakarta.version>3.0.1</knife4j-springdoc-openapi-jakarta.version>
+        <knife4j-springdoc-openapi-jakarta.version>2.8.9</knife4j-springdoc-openapi-jakarta.version>
         <knife4j-swagger-models-v3.version>2.2.26</knife4j-swagger-models-v3.version>
 
         <knife4j-servlet.version>4.0.1</knife4j-servlet.version>


### PR DESCRIPTION
## 变更说明

修复多个 issue 反映的 Spring Boot 3.4/3.5 启动报错，根因是 springdoc 依赖版本停留在 Boot 4 对应线。

## 改动

- `knife4j/pom.xml`：`springdoc-openapi-jakarta` 版本 `3.0.1` → `2.8.9`（回到 Boot 3 兼容线）
- `knife4j-openapi3-jakarta-spring-boot-starter`：去掉 Boot 4.0.1 / Spring 7.0.1 本地覆盖，改为 3.4.5 / 6.2.7
- `boot3-jakarta-app` smoke：同步版本对齐
- 新增 `boot35-jakarta-app` smoke 模块，覆盖 Boot 3.5.0 / Spring 6.2.8

## 验证

```
./scripts/test-java.sh → BUILD SUCCESS
knife4j-smoke-boot35-jakarta-app → SUCCESS [8.6s]
```

Fixes #874 #882 #885 #913 #960 #992