### PR TITLE
feat(demo): add knife4j-demo online preview site [TASK-011]

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -51,17 +51,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  deploy:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to server
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.DEMO_SERVER_HOST }}
-          username: root
-          key: ${{ secrets.DEMO_SERVER_SSH_KEY }}
-          script: |
-            cd /opt/knife4j-demo
-            docker compose pull
-            docker compose up -d
+

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,67 @@
+name: Build and Deploy Demo
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/knife4j-demo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build jar
+        run: mvn -B -ntp -pl knife4j/knife4j-demo -am package -DskipTests
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: knife4j/knife4j-demo
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEMO_SERVER_HOST }}
+          username: root
+          key: ${{ secrets.DEMO_SERVER_SSH_KEY }}
+          script: |
+            cd /opt/knife4j-demo
+            docker compose pull
+            docker compose up -d

--- a/knife4j/knife4j-demo/Caddyfile.snippet
+++ b/knife4j/knife4j-demo/Caddyfile.snippet
@@ -1,0 +1,3 @@
+demo.knife4jnext.com {
+    reverse_proxy localhost:8090
+}

--- a/knife4j/knife4j-demo/Dockerfile
+++ b/knife4j/knife4j-demo/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY target/knife4j-demo-*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/knife4j/knife4j-demo/docker-compose.yml
+++ b/knife4j/knife4j-demo/docker-compose.yml
@@ -5,3 +5,5 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:8090:8080"
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"

--- a/knife4j/knife4j-demo/docker-compose.yml
+++ b/knife4j/knife4j-demo/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  knife4j-demo:
+    image: ghcr.io/songxychn/knife4j-next/knife4j-demo:latest
+    container_name: knife4j-demo
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8090:8080"

--- a/knife4j/knife4j-demo/pom.xml
+++ b/knife4j/knife4j-demo/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j</artifactId>
+        <version>4.6.0.1</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-demo</artifactId>
+    <name>knife4j-demo</name>
+    <description>knife4j-next online demo application</description>
+
+    <properties>
+        <knife4j-spring-boot3.version>3.4.5</knife4j-spring-boot3.version>
+        <start-class>com.baizhukui.knife4j.demo.DemoApplication</start-class>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${knife4j-spring-boot3.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${knife4j-spring-boot3.version}</version>
+                <configuration>
+                    <mainClass>${start-class}</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/DemoApplication.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/DemoApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UserController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UserController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "用户接口", description = "用户相关示例接口")
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+    
+    @Operation(summary = "获取用户列表")
+    @GetMapping("/list")
+    public List<Map<String, Object>> list() {
+        return List.of(
+                Map.of("id", 1, "name", "张三", "email", "zhangsan@example.com"),
+                Map.of("id", 2, "name", "李四", "email", "lisi@example.com"));
+    }
+    
+    @Operation(summary = "根据 ID 获取用户")
+    @GetMapping("/{id}")
+    public Map<String, Object> getById(
+                                       @Parameter(description = "用户 ID") @PathVariable Long id) {
+        return Map.of("id", id, "name", "张三", "email", "zhangsan@example.com");
+    }
+    
+    @Operation(summary = "创建用户")
+    @PostMapping
+    public Map<String, Object> create(@RequestBody Map<String, Object> body) {
+        body.put("id", 3);
+        return body;
+    }
+    
+    @Operation(summary = "删除用户")
+    @DeleteMapping("/{id}")
+    public Map<String, Object> delete(
+                                      @Parameter(description = "用户 ID") @PathVariable Long id) {
+        return Map.of("success", true, "id", id);
+    }
+}

--- a/knife4j/knife4j-demo/src/main/resources/application.yml
+++ b/knife4j/knife4j-demo/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8080
+
+knife4j:
+  enable: true
+  setting:
+    language: zh_cn
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+  info:
+    title: knife4j-next Demo
+    description: knife4j-next 在线预览示例，展示常用功能
+    version: "@project.version@"
+    contact:
+      name: knife4j-next
+      url: https://knife4jnext.com

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -20,6 +20,7 @@
         <module>knife4j-openapi3-webflux-spring-boot-starter</module>
         <module>knife4j-openapi3-webflux-jakarta-spring-boot-starter</module>
         <module>knife4j-smoke-tests</module>
+        <module>knife4j-demo</module>
     </modules>
     <packaging>pom</packaging>
     <name>knife4j</name>


### PR DESCRIPTION
## 变更说明

新增 `knife4j-demo` 模块，提供在线预览站，方便用户体验 knife4j-next 效果。

## 内容

- `knife4j/knife4j-demo`：最小 Spring Boot 应用，包含用户示例 CRUD 接口
- `Dockerfile`：基于 `eclipse-temurin:17-jre-alpine`
- `docker-compose.yml`：服务器部署用，监听 `127.0.0.1:8090`
- `Caddyfile.snippet`：反代配置，`demo.knife4jnext.com → localhost:8090`
- `.github/workflows/deploy-demo.yml`：tag 触发，构建推送 GHCR，SSH 部署到服务器

## 服务器部署步骤

1. 添加 DNS A 记录：`demo.knife4jnext.com → 服务器 IP`
2. 服务器上：
   ```bash
   mkdir -p /opt/knife4j-demo
   # 把 docker-compose.yml 放到 /opt/knife4j-demo/
   ```
3. 在 GitHub 仓库 Secrets 中添加：
   - `DEMO_SERVER_HOST`：服务器 IP
   - `DEMO_SERVER_SSH_KEY`：SSH 私钥
4. 把 `Caddyfile.snippet` 内容追加到服务器 Caddyfile，`caddy reload`
5. 打一个 tag（`git tag v4.6.0.1 && git push origin v4.6.0.1`）触发自动部署

## 验证

```
mvn -pl knife4j-demo -am package -DskipTests → BUILD SUCCESS
```