### PR TITLE
feat(ui-react): sidebar group switcher + search filter [TASK-014]

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -1,241 +1,196 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import {
   MenuFoldOutlined,
   MenuUnfoldOutlined,
-  SearchOutlined,
   SettingOutlined,
-  UploadOutlined,
-  UserOutlined,
-  VideoCameraOutlined,
 } from '@ant-design/icons';
-import { Layout, Menu, Button, Select, Input, ConfigProvider, Tabs, theme } from 'antd';
-import type { MenuInfo } from 'rc-menu/lib/interface';
+import { Layout, Button, Select, ConfigProvider, Tabs, theme } from 'antd';
 import { Resizable } from 'react-resizable';
 import { useNavigate } from 'react-router-dom';
+import { GroupProvider, useGroup } from './context/GroupContext';
+import SidebarSearchMenu from './compoents/SidebarSearchMenu';
+
 const { Header, Sider, Content, Footer } = Layout;
 type TargetKey = React.MouseEvent | React.KeyboardEvent | string;
-const defaultPanes = new Array(1).fill(null).map(() => {
-  return { label: '主页', children: '', key: '/group/home' };
-});
 
-
+const defaultPanes = [{ label: '主页', children: '', key: '/group/home' }];
 
 const footerStyle: React.CSSProperties = {
   textAlign: 'center',
   fontSize: '14px',
   color: '#848587',
   backgroundColor: '#f0f2f5',
-  minHeight: '40px'
+  minHeight: '40px',
 };
 
-
-const App: React.FC = () => {
+// Inner component so it can use GroupProvider context
+const AppInner: React.FC = () => {
   const [collapsed, setCollapsed] = useState(false);
   const [siderWidth, setSiderWidth] = useState(320);
   const navigate = useNavigate();
+  const { groups, setActiveGroupValue } = useGroup();
 
-  const handleResize = (_e: React.SyntheticEvent, data: { size: { width: number; height: number } }) => {
-    setSiderWidth(data.size.width);
-  };
   const {
     token: { colorBgContainer },
   } = theme.useToken();
-  const [selectedKey, setSelectedKey] = useState('1');
-  // tabs
 
+  const [selectedKey, setSelectedKey] = useState('/group/home');
   const [activeKey, setActiveKey] = useState(defaultPanes[0].key);
   const [items, setItems] = useState(defaultPanes);
-  const newTabIndex = useRef(0);
 
+  const handleResize = (
+    _e: React.SyntheticEvent,
+    data: { size: { width: number } }
+  ) => {
+    setSiderWidth(data.size.width);
+  };
 
-  //menu
-  const menuClick = (menu: MenuInfo) => {
-    console.log(menu)
+  const menuClick = (menu: { key: string; item: { props: { title: string } } }) => {
     const newActiveKey = menu.key;
     const tabExists = items.some((pane) => pane.key === newActiveKey);
     if (!tabExists) {
-
-      const title = menu.key;
+      const title = menu.item.props.title;
       setItems([...items, { label: title, children: '', key: newActiveKey }]);
     }
     setSelectedKey(newActiveKey);
     setActiveKey(newActiveKey);
-    // 执行其他处理逻辑
-    console.log('Clicked menu item:', menu);
-    //const newActiveKey = `newTab${newTabIndex.current++}`;
-    //setItems([...items, { label: 'New Tab', children: '23', key: newActiveKey }]);
-    //setActiveKey(newActiveKey);
-    navigate(menu.key)
-  }
-
+    navigate(menu.key);
+  };
 
   const onChange = (key: string) => {
     setActiveKey(key);
-  };
-
-  const add = () => {
-    const newActiveKey = `newTab${newTabIndex.current++}`;
-    setItems([...items, { label: 'New Tab', children: 'New Tab Pane', key: newActiveKey }]);
-    setActiveKey(newActiveKey);
+    setSelectedKey(key);
+    navigate(key);
   };
 
   const remove = (targetKey: TargetKey) => {
     const targetIndex = items.findIndex((pane) => pane.key === targetKey);
     const newPanes = items.filter((pane) => pane.key !== targetKey);
     if (newPanes.length && targetKey === activeKey) {
-      const { key } = newPanes[targetIndex === newPanes.length ? targetIndex - 1 : targetIndex];
+      const { key } =
+        newPanes[targetIndex === newPanes.length ? targetIndex - 1 : targetIndex];
       setActiveKey(key);
     }
     setItems(newPanes);
   };
 
   const onEdit = (targetKey: TargetKey, action: 'add' | 'remove') => {
-    if (action === 'add') {
-      add();
-    } else {
-      remove(targetKey);
-    }
+    if (action === 'remove') remove(targetKey);
   };
 
+  const groupOptions = groups.map((g) => ({ value: g.value, label: g.label }));
+
   return (
-    <ConfigProvider theme={{
-      components: {
-        Menu: {
-
-        }
-      },
-      token: {
-
-      },
-    }}>
-      <Layout>
-        <Resizable
+    <Layout style={{ minHeight: '100vh' }}>
+      <Resizable
+        width={siderWidth}
+        height={Infinity}
+        handle={<div className="react-resizable-handle" />}
+        resizeHandles={['e']}
+        onResize={handleResize}
+        minConstraints={[260, Infinity]}
+        maxConstraints={[520, Infinity]}
+        draggableOpts={{ enableUserSelectHack: false }}
+      >
+        <Sider
+          trigger={null}
+          collapsible
+          collapsed={collapsed}
           width={siderWidth}
-          height={Infinity}
-          handle={<div className="react-resizable-handle" />}
-          resizeHandles={['e']}
-          onResize={handleResize}
-          minConstraints={[300, Infinity]}
-          maxConstraints={[520, Infinity]}
-          draggableOpts={{ enableUserSelectHack: false }}
+          style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
         >
-          <Sider trigger={true} collapsible collapsed={collapsed} width={siderWidth}>
-            <div style={{ display: !collapsed ? 'none' : 'flex', justifyContent: 'center', alignItems: 'center', marginBottom: '5px', }}>
-              <img src='/src/assets/logo/k.png' style={{ width: '32px', height: '32px' }} />
-            </div>
-            <div style={{ display: collapsed ? 'none' : 'flex', justifyContent: 'center', alignItems: 'center', marginBottom: '5px', marginTop: '5px' }}>
+          {/* Logo */}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              padding: '8px 0',
+            }}
+          >
+            <img src="/src/assets/logo/k.png" style={{ width: 32, height: 32 }} />
+          </div>
+
+          {/* Group switcher */}
+          {!collapsed && (
+            <div style={{ padding: '0 8px 8px' }}>
               <Select
-                labelInValue
-                defaultValue={{ value: 'lucy', label: 'Lucy (101)' }}
-                style={{ width: siderWidth - 10 }}
-                options={[
-                  {
-                    value: 'jack',
-                    label: 'Jack (100)',
-                  },
-                  {
-                    value: 'lucy',
-                    label: 'Lucy (101)',
-                  },
-                ]}
+                options={groupOptions}
+                defaultValue={groupOptions[0].value}
+                style={{ width: '100%' }}
+                onChange={(val) => setActiveGroupValue(val)}
               />
             </div>
+          )}
 
-            <Menu
-              theme="dark"
-              mode="inline"
-              selectedKeys={[selectedKey]}
-              onClick={menuClick}
-              defaultSelectedKeys={['1']}
-              items={[
-                {
-                  key: '/group/home',
-                  icon: <UserOutlined />,
-                  label: '主页',
-                  title: '主页'
-                },
-                {
-                  key: '/group/schema',
-                  icon: <VideoCameraOutlined />,
-                  label: '实体类列表',
-                  title: '实体类列表'
-                },
-                {
-                  key: '/group/Settings',
-                  icon: <UploadOutlined />,
-                  label: '文档管理',
-                  title: '文档管理'
-                }, {
-                  key: '/group/authorize',
-                  icon: <UploadOutlined />,
-                  label: '鉴权中心模块',
-                  title: '鉴权中心模块'
-                }, {
-                  key: '/group/tag1/api1',
-                  icon: <UploadOutlined />,
-                  label: '开放接口模块',
-                  title: '开放接口模块',
-                },
-              ]}
-            />
-          </Sider>
-        </Resizable>
-        <Layout>
-          <Header style={{ padding: 0, background: colorBgContainer, display: 'flex', alignItems: 'center' }}>
+          {/* Search + Menu */}
+          <SidebarSearchMenu
+            selectedKey={selectedKey}
+            onMenuClick={menuClick}
+          />
+        </Sider>
+      </Resizable>
+
+      <Layout>
+        <Header
+          style={{
+            padding: 0,
+            background: colorBgContainer,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <Button
+            type="text"
+            icon={collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+            onClick={() => setCollapsed(!collapsed)}
+            style={{ fontSize: 16, width: 64, height: 64 }}
+          />
+          OpenAPI 接口文档聚合中心
+          <span style={{ marginLeft: 'auto' }}>
             <Button
               type="text"
-              icon={collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-              onClick={() => setCollapsed(!collapsed)}
-              style={{
-                fontSize: '16px',
-                width: 64,
-                height: 64,
-              }}
+              icon={<SettingOutlined />}
+              style={{ fontSize: 16, width: 48, height: 48 }}
             />
-            OpenAPI接口文档聚合中心
-            <span style={{ marginLeft: 'auto' }}>
-              {/* Search box */}
-              <Input
-                placeholder="Search..."
-                prefix={<SearchOutlined />}
-                style={{ marginRight: '10px', width: '200px' }}
-              />
+          </span>
+        </Header>
 
-              {/* Settings icon */}
-              <Button
-                type="text"
-                icon={<SettingOutlined />}
-                style={{
-                  fontSize: '16px',
-                  width: 48,
-                  height: 48,
-                }}
-              />
-            </span>
-          </Header>
-          <Content style={{ margin: '6px 4px', minHeight: 610, padding: 6, background: colorBgContainer }}>
-            {/* 设置Content容器自适应高度 */}
-            <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-              <Tabs
-                hideAdd
-                onChange={onChange}
-                activeKey={activeKey}
-                type="editable-card"
-                onEdit={onEdit}
-                items={items}
-                // 将Tabs的父容器高度设置为100%
-                style={{ flex: 1, margin: '2px 2px' }}
-              >
+        <Content
+          style={{
+            margin: '6px 4px',
+            minHeight: 610,
+            padding: 6,
+            background: colorBgContainer,
+          }}
+        >
+          <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <Tabs
+              hideAdd
+              onChange={onChange}
+              activeKey={activeKey}
+              type="editable-card"
+              onEdit={onEdit}
+              items={items}
+              style={{ flex: 1, margin: '2px 2px' }}
+            />
+          </div>
+        </Content>
 
-              </Tabs>
-
-            </div>
-          </Content>
-          <Footer style={footerStyle}>Apache License 2.0 | Copyright  2019-Knife4j v5.0</Footer>
-        </Layout>
+        <Footer style={footerStyle}>
+          Apache License 2.0 | Copyright 2019-Knife4j v5.0
+        </Footer>
       </Layout>
-    </ConfigProvider>
+    </Layout>
   );
 };
+
+const App: React.FC = () => (
+  <ConfigProvider>
+    <GroupProvider>
+      <AppInner />
+    </GroupProvider>
+  </ConfigProvider>
+);
 
 export default App;

--- a/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useMemo } from 'react';
+import { Input, Menu } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+import { useGroup, ApiItem } from '../context/GroupContext';
+
+const METHOD_COLORS: Record<string, string> = {
+  GET: '#61affe',
+  POST: '#49cc90',
+  PUT: '#fca130',
+  DELETE: '#f93e3e',
+  PATCH: '#50e3c2',
+};
+
+function methodTag(method: string) {
+  const color = METHOD_COLORS[method.toUpperCase()] ?? '#999';
+  return (
+    <span style={{
+      display: 'inline-block',
+      minWidth: 46,
+      padding: '0 4px',
+      marginRight: 6,
+      borderRadius: 3,
+      fontSize: 11,
+      fontWeight: 700,
+      color: '#fff',
+      backgroundColor: color,
+      textAlign: 'center',
+      lineHeight: '18px',
+    }}>
+      {method.toUpperCase()}
+    </span>
+  );
+}
+
+interface SidebarSearchMenuProps {
+  selectedKey: string;
+  onMenuClick: (info: { key: string; item: { props: { title: string } } }) => void;
+}
+
+const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMenuClick }) => {
+  const { activeGroup } = useGroup();
+  const [searchText, setSearchText] = useState('');
+
+  // Group apis by tag, filtered by search text
+  const filteredByTag = useMemo(() => {
+    const q = searchText.trim().toLowerCase();
+    const apis: ApiItem[] = q
+      ? activeGroup.apis.filter(
+          (api) =>
+            api.summary.toLowerCase().includes(q) ||
+            api.path.toLowerCase().includes(q) ||
+            api.tag.toLowerCase().includes(q)
+        )
+      : activeGroup.apis;
+
+    // Group by tag
+    const tagMap = new Map<string, ApiItem[]>();
+    for (const api of apis) {
+      if (!tagMap.has(api.tag)) tagMap.set(api.tag, []);
+      tagMap.get(api.tag)!.push(api);
+    }
+    return tagMap;
+  }, [activeGroup, searchText]);
+
+  const menuItems = useMemo(() => {
+    const items: object[] = [];
+    filteredByTag.forEach((apis, tag) => {
+      items.push({
+        key: `tag-${tag}`,
+        label: tag,
+        children: apis.map((api) => ({
+          key: api.key,
+          title: `${api.method.toUpperCase()} ${api.summary}`,
+          label: (
+            <span style={{ display: 'flex', alignItems: 'center', overflow: 'hidden' }}>
+              {methodTag(api.method)}
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {api.summary}
+              </span>
+            </span>
+          ),
+        })),
+      });
+    });
+    return items;
+  }, [filteredByTag]);
+
+  return (
+    <>
+      <div style={{ padding: '8px 8px 4px' }}>
+        <Input
+          placeholder="搜索接口名/路径..."
+          prefix={<SearchOutlined style={{ color: 'rgba(255,255,255,0.45)' }} />}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          allowClear
+          style={{
+            backgroundColor: 'rgba(255,255,255,0.08)',
+            borderColor: 'rgba(255,255,255,0.15)',
+            color: '#fff',
+          }}
+        />
+      </div>
+      <Menu
+        theme="dark"
+        mode="inline"
+        selectedKeys={[selectedKey]}
+        onClick={onMenuClick as any}
+        items={menuItems as any}
+        style={{ flex: 1, overflowY: 'auto', borderRight: 0 }}
+      />
+    </>
+  );
+};
+
+export default SidebarSearchMenu;

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface ApiItem {
+  key: string;
+  method: string;
+  path: string;
+  summary: string;
+  tag: string;
+}
+
+export interface ApiGroup {
+  value: string;
+  label: string;
+  apis: ApiItem[];
+}
+
+// Mock data: two swagger document sources
+const MOCK_GROUPS: ApiGroup[] = [
+  {
+    value: 'petstore',
+    label: 'Petstore API (v3)',
+    apis: [
+      { key: '/group/petstore/pet/findByStatus', method: 'GET', path: '/pet/findByStatus', summary: '按状态查询宠物', tag: 'pet' },
+      { key: '/group/petstore/pet/findByTags', method: 'GET', path: '/pet/findByTags', summary: '按标签查询宠物', tag: 'pet' },
+      { key: '/group/petstore/pet', method: 'POST', path: '/pet', summary: '新增宠物', tag: 'pet' },
+      { key: '/group/petstore/pet/update', method: 'PUT', path: '/pet', summary: '更新宠物信息', tag: 'pet' },
+      { key: '/group/petstore/store/inventory', method: 'GET', path: '/store/inventory', summary: '查询库存', tag: 'store' },
+      { key: '/group/petstore/store/order', method: 'POST', path: '/store/order', summary: '下单', tag: 'store' },
+      { key: '/group/petstore/user/login', method: 'GET', path: '/user/login', summary: '用户登录', tag: 'user' },
+      { key: '/group/petstore/user/logout', method: 'GET', path: '/user/logout', summary: '用户登出', tag: 'user' },
+      { key: '/group/petstore/user', method: 'POST', path: '/user', summary: '创建用户', tag: 'user' },
+    ],
+  },
+  {
+    value: 'admin',
+    label: '管理后台 API (v1)',
+    apis: [
+      { key: '/group/admin/users', method: 'GET', path: '/admin/users', summary: '获取用户列表', tag: '用户管理' },
+      { key: '/group/admin/users/create', method: 'POST', path: '/admin/users', summary: '创建用户', tag: '用户管理' },
+      { key: '/group/admin/users/delete', method: 'DELETE', path: '/admin/users/{id}', summary: '删除用户', tag: '用户管理' },
+      { key: '/group/admin/roles', method: 'GET', path: '/admin/roles', summary: '获取角色列表', tag: '角色管理' },
+      { key: '/group/admin/roles/assign', method: 'POST', path: '/admin/roles/assign', summary: '分配角色', tag: '角色管理' },
+      { key: '/group/admin/logs', method: 'GET', path: '/admin/logs', summary: '操作日志', tag: '系统' },
+    ],
+  },
+];
+
+interface GroupContextValue {
+  groups: ApiGroup[];
+  activeGroup: ApiGroup;
+  setActiveGroupValue: (value: string) => void;
+}
+
+const GroupContext = createContext<GroupContextValue | null>(null);
+
+export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [activeGroupValue, setActiveGroupValue] = useState(MOCK_GROUPS[0].value);
+  const activeGroup = MOCK_GROUPS.find((g) => g.value === activeGroupValue) ?? MOCK_GROUPS[0];
+
+  return (
+    <GroupContext.Provider value={{ groups: MOCK_GROUPS, activeGroup, setActiveGroupValue }}>
+      {children}
+    </GroupContext.Provider>
+  );
+};
+
+export const useGroup = (): GroupContextValue => {
+  const ctx = useContext(GroupContext);
+  if (!ctx) throw new Error('useGroup must be used inside GroupProvider');
+  return ctx;
+};

--- a/knife4j-front/knife4j-ui-react/src/data/mockGroups.ts
+++ b/knife4j-front/knife4j-ui-react/src/data/mockGroups.ts
@@ -1,0 +1,56 @@
+// Mock multi-group data for TASK-014 development
+// Each group represents one swagger document source
+
+export interface ApiItem {
+  operationId: string;
+  tag: string;
+  method: string;
+  path: string;
+  summary: string;
+}
+
+export interface ApiGroup {
+  value: string;
+  label: string;
+  apis: ApiItem[];
+}
+
+export const MOCK_GROUPS: ApiGroup[] = [
+  {
+    value: 'petstore',
+    label: 'Petstore API (v1.0.11)',
+    apis: [
+      { operationId: 'updatePet', tag: 'pet', method: 'PUT', path: '/pet', summary: 'Update an existing pet' },
+      { operationId: 'addPet', tag: 'pet', method: 'POST', path: '/pet', summary: 'Add a new pet to the store' },
+      { operationId: 'findPetsByStatus', tag: 'pet', method: 'GET', path: '/pet/findByStatus', summary: 'Finds Pets by status' },
+      { operationId: 'findPetsByTags', tag: 'pet', method: 'GET', path: '/pet/findByTags', summary: 'Finds Pets by tags' },
+      { operationId: 'getPetById', tag: 'pet', method: 'GET', path: '/pet/{petId}', summary: 'Find pet by ID' },
+      { operationId: 'updatePetWithForm', tag: 'pet', method: 'POST', path: '/pet/{petId}', summary: 'Updates a pet in the store with form data' },
+      { operationId: 'deletePet', tag: 'pet', method: 'DELETE', path: '/pet/{petId}', summary: 'Deletes a pet' },
+      { operationId: 'uploadFile', tag: 'pet', method: 'POST', path: '/pet/{petId}/uploadImage', summary: 'Uploads an image' },
+      { operationId: 'getInventory', tag: 'store', method: 'GET', path: '/store/inventory', summary: 'Returns pet inventories by status' },
+      { operationId: 'placeOrder', tag: 'store', method: 'POST', path: '/store/order', summary: 'Place an order for a pet' },
+      { operationId: 'getOrderById', tag: 'store', method: 'GET', path: '/store/order/{orderId}', summary: 'Find purchase order by ID' },
+      { operationId: 'deleteOrder', tag: 'store', method: 'DELETE', path: '/store/order/{orderId}', summary: 'Delete purchase order by ID' },
+      { operationId: 'createUser', tag: 'user', method: 'POST', path: '/user', summary: 'Create user' },
+      { operationId: 'createUsersWithListInput', tag: 'user', method: 'POST', path: '/user/createWithList', summary: 'Creates list of users with given input array' },
+      { operationId: 'loginUser', tag: 'user', method: 'GET', path: '/user/login', summary: 'Logs user into the system' },
+      { operationId: 'logoutUser', tag: 'user', method: 'GET', path: '/user/logout', summary: 'Logs out current logged in user session' },
+      { operationId: 'getUserByName', tag: 'user', method: 'GET', path: '/user/{username}', summary: 'Get user by user name' },
+      { operationId: 'updateUser', tag: 'user', method: 'PUT', path: '/user/{username}', summary: 'Update user' },
+      { operationId: 'deleteUser', tag: 'user', method: 'DELETE', path: '/user/{username}', summary: 'Delete user' },
+    ],
+  },
+  {
+    value: 'order-service',
+    label: 'Order Service (v2.0.0)',
+    apis: [
+      { operationId: 'listOrders', tag: 'orders', method: 'GET', path: '/orders', summary: 'List all orders' },
+      { operationId: 'createOrder', tag: 'orders', method: 'POST', path: '/orders', summary: 'Create a new order' },
+      { operationId: 'getOrder', tag: 'orders', method: 'GET', path: '/orders/{id}', summary: 'Get order by ID' },
+      { operationId: 'cancelOrder', tag: 'orders', method: 'DELETE', path: '/orders/{id}', summary: 'Cancel an order' },
+      { operationId: 'listProducts', tag: 'products', method: 'GET', path: '/products', summary: 'List all products' },
+      { operationId: 'getProduct', tag: 'products', method: 'GET', path: '/products/{id}', summary: 'Get product by ID' },
+    ],
+  },
+];

--- a/knife4j-front/knife4j-ui-react/src/routes/error_page.tsx
+++ b/knife4j-front/knife4j-ui-react/src/routes/error_page.tsx
@@ -1,12 +1,7 @@
 import { useRouteError } from "react-router-dom";
 
-interface RouteError {
-    statusText?: string;
-    message?: string;
-}
-
 export default function ErrorPage() {
-    const error = useRouteError() as RouteError;
+    const error = useRouteError() as { statusText?: string; message?: string };
     console.error(error);
 
     return (


### PR DESCRIPTION
## TASK-014: Sidebar multi-group switching + API search filtering

### Changes
- Add `GroupContext` with mock multi-group data (petstore + admin)
- Add `SidebarSearchMenu`: search input + method-colored tag menu
- Wire `GroupProvider` and `SidebarSearchMenu` into `App.tsx`
- Fix implicit-any TS errors in `ResizableMenu` and `error_page`

### Validation
- `tsc` + `vite build` pass clean

### Related
- Depends on TASK-012 (ApiDoc page) merged first