### PR TITLE
feat(ui-react): implement SwaggerModels page [TASK-015]

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -1,12 +1,163 @@
+import { Badge, Collapse, Table, Tag, Typography } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+
+const { Title, Text } = Typography;
+
+// ---- 类型定义 ----
+
+interface SchemaField {
+  key: string;
+  name: string;
+  type: string;
+  format?: string;
+  required: boolean;
+  description: string;
+  children?: SchemaField[];
+}
+
+interface ModelDef {
+  name: string;
+  description?: string;
+  fields: SchemaField[];
+}
+
+// ---- mock 数据（对标 components.schemas 结构）----
+
+const MOCK_SCHEMAS: ModelDef[] = [
+  {
+    name: 'UserVO',
+    description: '用户视图对象',
+    fields: [
+      { key: 'id', name: 'id', type: 'integer', format: 'int64', required: true, description: '用户 ID' },
+      { key: 'username', name: 'username', type: 'string', required: true, description: '用户名' },
+      { key: 'email', name: 'email', type: 'string', format: 'email', required: false, description: '邮箱地址' },
+      { key: 'role', name: 'role', type: 'string', required: false, description: '角色，枚举：ADMIN / USER' },
+      { key: 'createdAt', name: 'createdAt', type: 'string', format: 'date-time', required: false, description: '创建时间' },
+    ],
+  },
+  {
+    name: 'PageResult',
+    description: '分页结果包装',
+    fields: [
+      { key: 'total', name: 'total', type: 'integer', format: 'int64', required: true, description: '总记录数' },
+      { key: 'pageNum', name: 'pageNum', type: 'integer', format: 'int32', required: true, description: '当前页码' },
+      { key: 'pageSize', name: 'pageSize', type: 'integer', format: 'int32', required: true, description: '每页大小' },
+      {
+        key: 'list', name: 'list', type: 'array', required: false, description: '数据列表',
+        children: [
+          { key: 'list.item', name: 'item', type: 'object', required: false, description: '列表元素' },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'ApiResponse',
+    description: '统一响应结构',
+    fields: [
+      { key: 'code', name: 'code', type: 'integer', format: 'int32', required: true, description: '业务状态码' },
+      { key: 'message', name: 'message', type: 'string', required: false, description: '提示信息' },
+      { key: 'data', name: 'data', type: 'object', required: false, description: '响应数据' },
+      { key: 'timestamp', name: 'timestamp', type: 'integer', format: 'int64', required: false, description: '响应时间戳' },
+    ],
+  },
+  {
+    name: 'CreateUserRequest',
+    description: '创建用户请求体',
+    fields: [
+      { key: 'username', name: 'username', type: 'string', required: true, description: '用户名，3-32 字符' },
+      { key: 'password', name: 'password', type: 'string', format: 'password', required: true, description: '密码，至少 8 位' },
+      { key: 'email', name: 'email', type: 'string', format: 'email', required: false, description: '邮箱' },
+      { key: 'role', name: 'role', type: 'string', required: false, description: '角色，默认 USER' },
+    ],
+  },
+];
+
+// ---- 类型颜色映射 ----
+
+const TYPE_COLOR: Record<string, string> = {
+  integer: 'blue',
+  number: 'cyan',
+  string: 'green',
+  boolean: 'orange',
+  array: 'purple',
+  object: 'geekblue',
+};
+
+// ---- 字段表格列定义 ----
+
+const fieldColumns: ColumnsType<SchemaField> = [
+  {
+    title: '字段名',
+    dataIndex: 'name',
+    width: 180,
+    render: (v) => <Text code>{v}</Text>,
+  },
+  {
+    title: '类型',
+    dataIndex: 'type',
+    width: 100,
+    render: (v) => <Tag color={TYPE_COLOR[v] ?? 'default'}>{v}</Tag>,
+  },
+  {
+    title: '格式',
+    dataIndex: 'format',
+    width: 110,
+    render: (v) => v ? <Text type="secondary">{v}</Text> : <Text type="secondary">—</Text>,
+  },
+  {
+    title: '必填',
+    dataIndex: 'required',
+    width: 70,
+    render: (v) => v
+      ? <Badge status="error" text="是" />
+      : <Badge status="default" text="否" />,
+  },
+  {
+    title: '说明',
+    dataIndex: 'description',
+  },
+];
+
+// ---- Collapse items ----
+
+const collapseItems = MOCK_SCHEMAS.map((model) => ({
+  key: model.name,
+  label: (
+    <span>
+      <Text strong style={{ fontSize: 14 }}>{model.name}</Text>
+      {model.description && (
+        <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
+          {model.description}
+        </Text>
+      )}
+      <Tag style={{ marginLeft: 12 }} color="default">{model.fields.length} 字段</Tag>
+    </span>
+  ),
+  children: (
+    <Table<SchemaField>
+      columns={fieldColumns}
+      dataSource={model.fields}
+      pagination={false}
+      size="small"
+      bordered
+      expandable={{
+        childrenColumnName: 'children',
+        defaultExpandAllRows: true,
+      }}
+    />
+  ),
+}));
+
+// ---- 页面 ----
 
 export default function Schema() {
-
-    return (
-        <div id="knife4j-schema-page">
-            <h1>我是Schema页面</h1>
-            <p>我是Schema页面</p>
-            <p>
-            </p>
-        </div>
-    );
+  return (
+    <div style={{ padding: '24px', maxWidth: 1100 }}>
+      <Title level={4} style={{ marginBottom: 16 }}>数据模型</Title>
+      <Collapse
+        items={collapseItems}
+        defaultActiveKey={MOCK_SCHEMAS.map((m) => m.name)}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## TASK-015: 实现 SwaggerModels 数据模型展示页

### 变更内容
- 重写 `src/pages/Schema.tsx`，实现完整的数据模型展示页
- 使用 antd `Collapse` 展示所有 schema，默认全部展开
- 每个 model 内用 `Table` 展示字段：字段名、类型（带颜色 Tag）、格式、是否必填、说明
- 支持嵌套字段（array 类型的 children）
- mock 数据包含 4 个典型 schema：UserVO、PageResult、ApiResponse、CreateUserRequest

### 验证
```
cd knife4j-front/knife4j-ui-react && npm ci && npm run build  ✓
```

### 对标
Vue2 `views/settings/SwaggerModels.vue` 的 Collapse + Table 结构