### PR TITLE
feat(ui-react): real API data layer [TASK-017]

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -1,0 +1,95 @@
+/**
+ * Knife4j API Client
+ * 负责拉取 group 列表和 api-docs 文档
+ */
+
+import type { SwaggerDoc, SwaggerGroup, MenuTag, MenuOperation } from '../types/swagger';
+
+const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
+
+/** 拉取 group 列表（兼容 springfox / springdoc） */
+export async function fetchGroups(): Promise<SwaggerGroup[]> {
+  // 优先尝试 springdoc: v3/api-docs/swagger-config
+  try {
+    const res = await fetch('v3/api-docs/swagger-config');
+    if (res.ok) {
+      const data = await res.json();
+      // springdoc 格式: { urls: [{name, url}] } 或单文档
+      if (data.urls && Array.isArray(data.urls)) {
+        return data.urls.map((u: { name: string; url: string }) => ({
+          name: u.name,
+          url: u.url,
+        }));
+      }
+      // 单文档，无分组
+      return [{ name: 'default', url: 'v3/api-docs' }];
+    }
+  } catch (_) { /* ignore */ }
+
+  // fallback: springfox swagger-resources
+  try {
+    const res = await fetch('swagger-resources');
+    if (res.ok) {
+      const data: Array<{ name: string; location: string; swaggerVersion?: string }> = await res.json();
+      return data.map((g) => ({
+        name: g.name,
+        url: g.location,
+        swaggerVersion: g.swaggerVersion,
+      }));
+    }
+  } catch (_) { /* ignore */ }
+
+  return [];
+}
+
+/** 拉取指定 group 的 api-docs */
+export async function fetchSwaggerDoc(url: string): Promise<SwaggerDoc | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return await res.json() as SwaggerDoc;
+  } catch (_) {
+    return null;
+  }
+}
+
+/** 将 SwaggerDoc 解析为侧边栏菜单结构 */
+export function parseMenuTags(doc: SwaggerDoc): MenuTag[] {
+  const tagMap = new Map<string, MenuTag>();
+
+  // 初始化 tag 列表（保持顺序）
+  (doc.tags ?? []).forEach((t) => {
+    tagMap.set(t.name, { tag: t.name, description: t.description, operations: [] });
+  });
+
+  Object.entries(doc.paths ?? {}).forEach(([path, pathItem]) => {
+    HTTP_METHODS.forEach((method) => {
+      const op = pathItem[method];
+      if (!op) return;
+
+      const tags = op.tags?.length ? op.tags : ['default'];
+      tags.forEach((tag) => {
+        if (!tagMap.has(tag)) {
+          tagMap.set(tag, { tag, operations: [] });
+        }
+        const menuOp: MenuOperation = {
+          key: `${tag}/${op.operationId ?? path}`,
+          path,
+          method,
+          summary: op.summary ?? path,
+          operationId: op.operationId,
+          deprecated: op.deprecated,
+          operation: op,
+        };
+        tagMap.get(tag)!.operations.push(menuOp);
+      });
+    });
+  });
+
+  return Array.from(tagMap.values());
+}
+
+/** 获取 components.schemas（OAS3）或 definitions（OAS2） */
+export function getSchemas(doc: SwaggerDoc): Record<string, import('../types/swagger').SchemaObject> {
+  return doc.components?.schemas ?? doc.definitions ?? {};
+}

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -1,4 +1,8 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { fetchGroups, fetchSwaggerDoc, parseMenuTags, getSchemas } from '../api/knife4jClient';
+import type { SwaggerGroup, SwaggerDoc, MenuTag, SchemaObject } from '../types/swagger';
+
+// ---- 兼容旧接口的 ApiItem / ApiGroup 类型 ----
 
 export interface ApiItem {
   key: string;
@@ -6,6 +10,8 @@ export interface ApiItem {
   path: string;
   summary: string;
   tag: string;
+  operationId?: string;
+  deprecated?: boolean;
 }
 
 export interface ApiGroup {
@@ -14,51 +20,110 @@ export interface ApiGroup {
   apis: ApiItem[];
 }
 
-// Mock data: two swagger document sources
-const MOCK_GROUPS: ApiGroup[] = [
-  {
-    value: 'petstore',
-    label: 'Petstore API (v3)',
-    apis: [
-      { key: '/group/petstore/pet/findByStatus', method: 'GET', path: '/pet/findByStatus', summary: '按状态查询宠物', tag: 'pet' },
-      { key: '/group/petstore/pet/findByTags', method: 'GET', path: '/pet/findByTags', summary: '按标签查询宠物', tag: 'pet' },
-      { key: '/group/petstore/pet', method: 'POST', path: '/pet', summary: '新增宠物', tag: 'pet' },
-      { key: '/group/petstore/pet/update', method: 'PUT', path: '/pet', summary: '更新宠物信息', tag: 'pet' },
-      { key: '/group/petstore/store/inventory', method: 'GET', path: '/store/inventory', summary: '查询库存', tag: 'store' },
-      { key: '/group/petstore/store/order', method: 'POST', path: '/store/order', summary: '下单', tag: 'store' },
-      { key: '/group/petstore/user/login', method: 'GET', path: '/user/login', summary: '用户登录', tag: 'user' },
-      { key: '/group/petstore/user/logout', method: 'GET', path: '/user/logout', summary: '用户登出', tag: 'user' },
-      { key: '/group/petstore/user', method: 'POST', path: '/user', summary: '创建用户', tag: 'user' },
-    ],
-  },
-  {
-    value: 'admin',
-    label: '管理后台 API (v1)',
-    apis: [
-      { key: '/group/admin/users', method: 'GET', path: '/admin/users', summary: '获取用户列表', tag: '用户管理' },
-      { key: '/group/admin/users/create', method: 'POST', path: '/admin/users', summary: '创建用户', tag: '用户管理' },
-      { key: '/group/admin/users/delete', method: 'DELETE', path: '/admin/users/{id}', summary: '删除用户', tag: '用户管理' },
-      { key: '/group/admin/roles', method: 'GET', path: '/admin/roles', summary: '获取角色列表', tag: '角色管理' },
-      { key: '/group/admin/roles/assign', method: 'POST', path: '/admin/roles/assign', summary: '分配角色', tag: '角色管理' },
-      { key: '/group/admin/logs', method: 'GET', path: '/admin/logs', summary: '操作日志', tag: '系统' },
-    ],
-  },
-];
+// ---- mock fallback（真实接口不可用时降级） ----
+
+import { MOCK_GROUPS } from '../data/mockGroups';
+
+// ---- context 类型 ----
 
 interface GroupContextValue {
+  // group 列表（兼容旧接口）
   groups: ApiGroup[];
   activeGroup: ApiGroup;
   setActiveGroupValue: (value: string) => void;
+
+  // 真实数据
+  swaggerDoc: SwaggerDoc | null;
+  menuTags: MenuTag[];
+  schemas: Record<string, SchemaObject>;
+  loading: boolean;
+  usingMock: boolean;
 }
 
 const GroupContext = createContext<GroupContextValue | null>(null);
 
 export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [activeGroupValue, setActiveGroupValue] = useState(MOCK_GROUPS[0].value);
-  const activeGroup = MOCK_GROUPS.find((g) => g.value === activeGroupValue) ?? MOCK_GROUPS[0];
+  const [rawGroups, setRawGroups] = useState<SwaggerGroup[]>([]);
+  const [activeGroupValue, setActiveGroupValue] = useState<string>('');
+  const [swaggerDoc, setSwaggerDoc] = useState<SwaggerDoc | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [usingMock, setUsingMock] = useState(false);
+
+  // 初始化：拉取 group 列表
+  useEffect(() => {
+    fetchGroups().then((groups) => {
+      if (groups.length > 0) {
+        setRawGroups(groups);
+        setActiveGroupValue(groups[0].name);
+      } else {
+        setUsingMock(true);
+        setLoading(false);
+      }
+    });
+  }, []);
+
+  // 切换 group 时拉取对应 api-docs
+  useEffect(() => {
+    if (usingMock || !activeGroupValue) return;
+    const group = rawGroups.find((g) => g.name === activeGroupValue);
+    if (!group) return;
+
+    setLoading(true);
+    fetchSwaggerDoc(group.url).then((doc) => {
+      if (doc) {
+        setSwaggerDoc(doc);
+      } else {
+        setUsingMock(true);
+      }
+      setLoading(false);
+    });
+  }, [activeGroupValue, rawGroups, usingMock]);
+
+  // 派生数据
+  const menuTags: MenuTag[] = swaggerDoc ? parseMenuTags(swaggerDoc) : [];
+  const schemas: Record<string, SchemaObject> = swaggerDoc ? getSchemas(swaggerDoc) : {};
+
+  // 兼容旧接口：将真实数据转换为 ApiGroup[]
+  const groups: ApiGroup[] = usingMock || !swaggerDoc
+    ? MOCK_GROUPS
+    : rawGroups.map((g) => {
+        const isActive = g.name === activeGroupValue;
+        const apis: ApiItem[] = isActive
+          ? menuTags.flatMap((t) =>
+              t.operations.map((op) => ({
+                key: `/${activeGroupValue}/${op.key}`,
+                method: op.method.toUpperCase(),
+                path: op.path,
+                summary: op.summary,
+                tag: t.tag,
+                operationId: op.operationId,
+                deprecated: op.deprecated,
+              }))
+            )
+          : [];
+        return { value: g.name, label: g.name, apis };
+      });
+
+  const activeGroup =
+    groups.find((g) => g.value === activeGroupValue) ?? groups[0] ?? MOCK_GROUPS[0];
+
+  const handleSetActiveGroup = useCallback((value: string) => {
+    setActiveGroupValue(value);
+  }, []);
 
   return (
-    <GroupContext.Provider value={{ groups: MOCK_GROUPS, activeGroup, setActiveGroupValue }}>
+    <GroupContext.Provider
+      value={{
+        groups,
+        activeGroup,
+        setActiveGroupValue: handleSetActiveGroup,
+        swaggerDoc,
+        menuTags,
+        schemas,
+        loading,
+        usingMock,
+      }}
+    >
       {children}
     </GroupContext.Provider>
   );

--- a/knife4j-front/knife4j-ui-react/src/data/mockGroups.ts
+++ b/knife4j-front/knife4j-ui-react/src/data/mockGroups.ts
@@ -1,56 +1,44 @@
 // Mock multi-group data for TASK-014 development
 // Each group represents one swagger document source
+// Types are defined in GroupContext to avoid duplication
 
-export interface ApiItem {
-  operationId: string;
-  tag: string;
-  method: string;
-  path: string;
-  summary: string;
-}
-
-export interface ApiGroup {
-  value: string;
-  label: string;
-  apis: ApiItem[];
-}
+import type { ApiGroup } from '../context/GroupContext';
 
 export const MOCK_GROUPS: ApiGroup[] = [
   {
     value: 'petstore',
     label: 'Petstore API (v1.0.11)',
     apis: [
-      { operationId: 'updatePet', tag: 'pet', method: 'PUT', path: '/pet', summary: 'Update an existing pet' },
-      { operationId: 'addPet', tag: 'pet', method: 'POST', path: '/pet', summary: 'Add a new pet to the store' },
-      { operationId: 'findPetsByStatus', tag: 'pet', method: 'GET', path: '/pet/findByStatus', summary: 'Finds Pets by status' },
-      { operationId: 'findPetsByTags', tag: 'pet', method: 'GET', path: '/pet/findByTags', summary: 'Finds Pets by tags' },
-      { operationId: 'getPetById', tag: 'pet', method: 'GET', path: '/pet/{petId}', summary: 'Find pet by ID' },
-      { operationId: 'updatePetWithForm', tag: 'pet', method: 'POST', path: '/pet/{petId}', summary: 'Updates a pet in the store with form data' },
-      { operationId: 'deletePet', tag: 'pet', method: 'DELETE', path: '/pet/{petId}', summary: 'Deletes a pet' },
-      { operationId: 'uploadFile', tag: 'pet', method: 'POST', path: '/pet/{petId}/uploadImage', summary: 'Uploads an image' },
-      { operationId: 'getInventory', tag: 'store', method: 'GET', path: '/store/inventory', summary: 'Returns pet inventories by status' },
-      { operationId: 'placeOrder', tag: 'store', method: 'POST', path: '/store/order', summary: 'Place an order for a pet' },
-      { operationId: 'getOrderById', tag: 'store', method: 'GET', path: '/store/order/{orderId}', summary: 'Find purchase order by ID' },
-      { operationId: 'deleteOrder', tag: 'store', method: 'DELETE', path: '/store/order/{orderId}', summary: 'Delete purchase order by ID' },
-      { operationId: 'createUser', tag: 'user', method: 'POST', path: '/user', summary: 'Create user' },
-      { operationId: 'createUsersWithListInput', tag: 'user', method: 'POST', path: '/user/createWithList', summary: 'Creates list of users with given input array' },
-      { operationId: 'loginUser', tag: 'user', method: 'GET', path: '/user/login', summary: 'Logs user into the system' },
-      { operationId: 'logoutUser', tag: 'user', method: 'GET', path: '/user/logout', summary: 'Logs out current logged in user session' },
-      { operationId: 'getUserByName', tag: 'user', method: 'GET', path: '/user/{username}', summary: 'Get user by user name' },
-      { operationId: 'updateUser', tag: 'user', method: 'PUT', path: '/user/{username}', summary: 'Update user' },
-      { operationId: 'deleteUser', tag: 'user', method: 'DELETE', path: '/user/{username}', summary: 'Delete user' },
+      { key: '/group/petstore/updatePet', operationId: 'updatePet', tag: 'pet', method: 'PUT', path: '/pet', summary: 'Update an existing pet' },
+      { key: '/group/petstore/addPet', operationId: 'addPet', tag: 'pet', method: 'POST', path: '/pet', summary: 'Add a new pet to the store' },
+      { key: '/group/petstore/findPetsByStatus', operationId: 'findPetsByStatus', tag: 'pet', method: 'GET', path: '/pet/findByStatus', summary: 'Finds Pets by status' },
+      { key: '/group/petstore/findPetsByTags', operationId: 'findPetsByTags', tag: 'pet', method: 'GET', path: '/pet/findByTags', summary: 'Finds Pets by tags' },
+      { key: '/group/petstore/getPetById', operationId: 'getPetById', tag: 'pet', method: 'GET', path: '/pet/{petId}', summary: 'Find pet by ID' },
+      { key: '/group/petstore/updatePetWithForm', operationId: 'updatePetWithForm', tag: 'pet', method: 'POST', path: '/pet/{petId}', summary: 'Updates a pet in the store with form data' },
+      { key: '/group/petstore/deletePet', operationId: 'deletePet', tag: 'pet', method: 'DELETE', path: '/pet/{petId}', summary: 'Deletes a pet' },
+      { key: '/group/petstore/uploadFile', operationId: 'uploadFile', tag: 'pet', method: 'POST', path: '/pet/{petId}/uploadImage', summary: 'Uploads an image' },
+      { key: '/group/petstore/getInventory', operationId: 'getInventory', tag: 'store', method: 'GET', path: '/store/inventory', summary: 'Returns pet inventories by status' },
+      { key: '/group/petstore/placeOrder', operationId: 'placeOrder', tag: 'store', method: 'POST', path: '/store/order', summary: 'Place an order for a pet' },
+      { key: '/group/petstore/getOrderById', operationId: 'getOrderById', tag: 'store', method: 'GET', path: '/store/order/{orderId}', summary: 'Find purchase order by ID' },
+      { key: '/group/petstore/deleteOrder', operationId: 'deleteOrder', tag: 'store', method: 'DELETE', path: '/store/order/{orderId}', summary: 'Delete purchase order by ID' },
+      { key: '/group/petstore/createUser', operationId: 'createUser', tag: 'user', method: 'POST', path: '/user', summary: 'Create user' },
+      { key: '/group/petstore/loginUser', operationId: 'loginUser', tag: 'user', method: 'GET', path: '/user/login', summary: 'Logs user into the system' },
+      { key: '/group/petstore/logoutUser', operationId: 'logoutUser', tag: 'user', method: 'GET', path: '/user/logout', summary: 'Logs out current logged in user session' },
+      { key: '/group/petstore/getUserByName', operationId: 'getUserByName', tag: 'user', method: 'GET', path: '/user/{username}', summary: 'Get user by user name' },
+      { key: '/group/petstore/updateUser', operationId: 'updateUser', tag: 'user', method: 'PUT', path: '/user/{username}', summary: 'Update user' },
+      { key: '/group/petstore/deleteUser', operationId: 'deleteUser', tag: 'user', method: 'DELETE', path: '/user/{username}', summary: 'Delete user' },
     ],
   },
   {
     value: 'order-service',
     label: 'Order Service (v2.0.0)',
     apis: [
-      { operationId: 'listOrders', tag: 'orders', method: 'GET', path: '/orders', summary: 'List all orders' },
-      { operationId: 'createOrder', tag: 'orders', method: 'POST', path: '/orders', summary: 'Create a new order' },
-      { operationId: 'getOrder', tag: 'orders', method: 'GET', path: '/orders/{id}', summary: 'Get order by ID' },
-      { operationId: 'cancelOrder', tag: 'orders', method: 'DELETE', path: '/orders/{id}', summary: 'Cancel an order' },
-      { operationId: 'listProducts', tag: 'products', method: 'GET', path: '/products', summary: 'List all products' },
-      { operationId: 'getProduct', tag: 'products', method: 'GET', path: '/products/{id}', summary: 'Get product by ID' },
+      { key: '/group/order-service/listOrders', operationId: 'listOrders', tag: 'orders', method: 'GET', path: '/orders', summary: 'List all orders' },
+      { key: '/group/order-service/createOrder', operationId: 'createOrder', tag: 'orders', method: 'POST', path: '/orders', summary: 'Create a new order' },
+      { key: '/group/order-service/getOrder', operationId: 'getOrder', tag: 'orders', method: 'GET', path: '/orders/{id}', summary: 'Get order by ID' },
+      { key: '/group/order-service/cancelOrder', operationId: 'cancelOrder', tag: 'orders', method: 'DELETE', path: '/orders/{id}', summary: 'Cancel an order' },
+      { key: '/group/order-service/listProducts', operationId: 'listProducts', tag: 'products', method: 'GET', path: '/products', summary: 'List all products' },
+      { key: '/group/order-service/getProduct', operationId: 'getProduct', tag: 'products', method: 'GET', path: '/products/{id}', summary: 'Get product by ID' },
     ],
   },
 ];

--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -1,5 +1,7 @@
-import { Badge, Collapse, Table, Tag, Typography } from 'antd';
+import { Badge, Collapse, Spin, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import { useGroup } from '../context/GroupContext';
+import type { SchemaObject } from '../types/swagger';
 
 const { Title, Text } = Typography;
 
@@ -21,7 +23,35 @@ interface ModelDef {
   fields: SchemaField[];
 }
 
-// ---- mock 数据（对标 components.schemas 结构）----
+// ---- 将 SchemaObject 转换为字段列表 ----
+
+function schemaToFields(schema: SchemaObject, requiredSet: Set<string>): SchemaField[] {
+  const props = schema.properties ?? {};
+  return Object.entries(props).map(([name, prop]) => {
+    const field: SchemaField = {
+      key: name,
+      name,
+      type: prop.type ?? (prop.$ref ? 'object' : 'string'),
+      format: prop.format,
+      required: requiredSet.has(name),
+      description: prop.description ?? '',
+    };
+    if (prop.type === 'object' && prop.properties) {
+      field.children = schemaToFields(prop, new Set(prop.required ?? []));
+    }
+    return field;
+  });
+}
+
+function schemasToModels(schemas: Record<string, SchemaObject>): ModelDef[] {
+  return Object.entries(schemas).map(([name, schema]) => ({
+    name,
+    description: schema.description,
+    fields: schemaToFields(schema, new Set(schema.required ?? [])),
+  }));
+}
+
+// ---- mock 数据 fallback ----
 
 const MOCK_SCHEMAS: ModelDef[] = [
   {
@@ -118,46 +148,56 @@ const fieldColumns: ColumnsType<SchemaField> = [
   },
 ];
 
-// ---- Collapse items ----
-
-const collapseItems = MOCK_SCHEMAS.map((model) => ({
-  key: model.name,
-  label: (
-    <span>
-      <Text strong style={{ fontSize: 14 }}>{model.name}</Text>
-      {model.description && (
-        <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
-          {model.description}
-        </Text>
-      )}
-      <Tag style={{ marginLeft: 12 }} color="default">{model.fields.length} 字段</Tag>
-    </span>
-  ),
-  children: (
-    <Table<SchemaField>
-      columns={fieldColumns}
-      dataSource={model.fields}
-      pagination={false}
-      size="small"
-      bordered
-      expandable={{
-        childrenColumnName: 'children',
-        defaultExpandAllRows: true,
-      }}
-    />
-  ),
-}));
-
 // ---- 页面 ----
 
 export default function Schema() {
+  const { schemas, loading, usingMock } = useGroup();
+  const models: ModelDef[] = usingMock || Object.keys(schemas).length === 0
+    ? MOCK_SCHEMAS
+    : schemasToModels(schemas);
+
+  const collapseItems = models.map((model) => ({
+    key: model.name,
+    label: (
+      <span>
+        <Text strong style={{ fontSize: 14 }}>{model.name}</Text>
+        {model.description && (
+          <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
+            {model.description}
+          </Text>
+        )}
+        <Tag style={{ marginLeft: 12 }} color="default">{model.fields.length} 字段</Tag>
+      </span>
+    ),
+    children: (
+      <Table<SchemaField>
+        columns={fieldColumns}
+        dataSource={model.fields}
+        pagination={false}
+        size="small"
+        bordered
+        expandable={{
+          childrenColumnName: 'children',
+          defaultExpandAllRows: true,
+        }}
+      />
+    ),
+  }));
+
   return (
     <div style={{ padding: '24px', maxWidth: 1100 }}>
-      <Title level={4} style={{ marginBottom: 16 }}>数据模型</Title>
-      <Collapse
-        items={collapseItems}
-        defaultActiveKey={MOCK_SCHEMAS.map((m) => m.name)}
-      />
+      <Title level={4} style={{ marginBottom: 16 }}>
+        数据模型
+        {usingMock && <Tag color="orange" style={{ marginLeft: 8, fontSize: 11 }}>mock</Tag>}
+      </Title>
+      {loading ? (
+        <Spin />
+      ) : (
+        <Collapse
+          items={collapseItems}
+          defaultActiveKey={models.map((m) => m.name)}
+        />
+      )}
     </div>
   );
 }

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -1,0 +1,105 @@
+/**
+ * OpenAPI 数据类型定义
+ * 兼容 OAS3（/v3/api-docs）和 Swagger2（/v2/api-docs）
+ */
+
+export interface SwaggerGroup {
+  name: string;
+  url: string;       // api-docs 地址
+  swaggerVersion?: string;
+  location?: string; // swagger-resources 格式
+}
+
+export interface SwaggerInfo {
+  title: string;
+  version: string;
+  description?: string;
+}
+
+export interface SwaggerTag {
+  name: string;
+  description?: string;
+}
+
+export interface SchemaObject {
+  type?: string;
+  format?: string;
+  description?: string;
+  properties?: Record<string, SchemaObject>;
+  items?: SchemaObject;
+  $ref?: string;
+  required?: string[];
+  enum?: unknown[];
+}
+
+export interface ParameterObject {
+  name: string;
+  in: 'query' | 'header' | 'path' | 'cookie' | 'body' | 'formData';
+  required?: boolean;
+  description?: string;
+  schema?: SchemaObject;
+  type?: string;   // OAS2
+  format?: string; // OAS2
+}
+
+export interface RequestBodyObject {
+  description?: string;
+  required?: boolean;
+  content?: Record<string, { schema?: SchemaObject }>;
+}
+
+export interface ResponseObject {
+  description?: string;
+  content?: Record<string, { schema?: SchemaObject }>;
+  schema?: SchemaObject; // OAS2
+}
+
+export interface OperationObject {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: ParameterObject[];
+  requestBody?: RequestBodyObject;
+  responses?: Record<string, ResponseObject>;
+  deprecated?: boolean;
+}
+
+export interface PathItemObject {
+  get?: OperationObject;
+  post?: OperationObject;
+  put?: OperationObject;
+  delete?: OperationObject;
+  patch?: OperationObject;
+  head?: OperationObject;
+  options?: OperationObject;
+}
+
+export interface SwaggerDoc {
+  openapi?: string;   // OAS3
+  swagger?: string;   // OAS2
+  info: SwaggerInfo;
+  tags?: SwaggerTag[];
+  paths: Record<string, PathItemObject>;
+  components?: {
+    schemas?: Record<string, SchemaObject>;
+  };
+  definitions?: Record<string, SchemaObject>; // OAS2
+}
+
+/** 解析后的菜单项（tag + operations） */
+export interface MenuOperation {
+  key: string;       // e.g. "UserController/getUserById"
+  path: string;
+  method: string;
+  summary: string;
+  operationId?: string;
+  deprecated?: boolean;
+  operation: OperationObject;
+}
+
+export interface MenuTag {
+  tag: string;
+  description?: string;
+  operations: MenuOperation[];
+}


### PR DESCRIPTION
## TASK-017: 真实数据对接

### 变更内容
- **types/swagger.ts** — OAS3/OAS2 完整类型定义（SwaggerDoc、OperationObject、SchemaObject 等）
- **api/knife4jClient.ts** — API client：
  - `fetchGroups()`：优先 springdoc `v3/api-docs/swagger-config`，fallback springfox `swagger-resources`
  - `fetchSwaggerDoc(url)`：拉取指定 group 的 api-docs
  - `parseMenuTags(doc)`：解析为侧边栏菜单结构（tag + operations）
  - `getSchemas(doc)`：兼容 OAS3 `components.schemas` 和 OAS2 `definitions`
- **GroupContext.tsx** — 重写：真实接口优先，失败自动降级 mock；暴露 `swaggerDoc / menuTags / schemas / loading / usingMock`
- **Schema.tsx** — 消费真实 schemas，有 loading 状态和 mock badge 提示
- **mockGroups.ts** — 类型统一从 GroupContext 导入，补全 `key` 字段

### 验证
```
npm run build  ✓
```