### PR TITLE
feat(ui-react): implement Authorize page [TASK-018]

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -8,6 +8,7 @@ import { Layout, Button, Select, ConfigProvider, Tabs, theme } from 'antd';
 import { Resizable } from 'react-resizable';
 import { useNavigate } from 'react-router-dom';
 import { GroupProvider, useGroup } from './context/GroupContext';
+import { AuthProvider } from './context/AuthContext';
 import SidebarSearchMenu from './compoents/SidebarSearchMenu';
 
 const { Header, Sider, Content, Footer } = Layout;
@@ -187,9 +188,11 @@ const AppInner: React.FC = () => {
 
 const App: React.FC = () => (
   <ConfigProvider>
-    <GroupProvider>
-      <AppInner />
-    </GroupProvider>
+    <AuthProvider>
+      <GroupProvider>
+        <AppInner />
+      </GroupProvider>
+    </AuthProvider>
   </ConfigProvider>
 );
 

--- a/knife4j-front/knife4j-ui-react/src/context/AuthContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/AuthContext.tsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const STORAGE_KEY = 'knife4j_auth';
+
+export interface BearerAuth {
+  type: 'bearer';
+  token: string;
+}
+
+export interface BasicAuth {
+  type: 'basic';
+  username: string;
+  password: string;
+}
+
+export type AuthConfig = BearerAuth | BasicAuth | null;
+
+interface AuthContextValue {
+  auth: AuthConfig;
+  setAuth: (auth: AuthConfig) => void;
+  clearAuth: () => void;
+}
+
+function loadAuth(): AuthConfig {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as AuthConfig) : null;
+  } catch {
+    return null;
+  }
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [auth, setAuthState] = useState<AuthConfig>(loadAuth);
+
+  const setAuth = (newAuth: AuthConfig) => {
+    setAuthState(newAuth);
+    if (newAuth) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newAuth));
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  };
+
+  const clearAuth = () => setAuth(null);
+
+  return (
+    <AuthContext.Provider value={{ auth, setAuth, clearAuth }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextValue => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider');
+  return ctx;
+};

--- a/knife4j-front/knife4j-ui-react/src/pages/Authorize.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Authorize.tsx
@@ -1,12 +1,74 @@
+import { Tabs, Form, Input, Button, message } from 'antd';
+import { useAuth } from '../context/AuthContext';
 
 export default function Authorize() {
+  const { auth, setAuth, clearAuth } = useAuth();
+  const [bearerForm] = Form.useForm();
+  const [basicForm] = Form.useForm();
 
-    return (
-        <div id="knife4j-authorize">
-            <h1>我是Authorize主页!</h1>
-            <p>我是主页的介绍信息</p>
-            <p>
-            </p>
-        </div>
-    );
+  const initialBearer = auth?.type === 'bearer' ? { token: auth.token } : {};
+  const initialBasic = auth?.type === 'basic' ? { username: auth.username, password: auth.password } : {};
+
+  const onSaveBearer = (values: { token: string }) => {
+    setAuth({ type: 'bearer', token: values.token });
+    message.success('Bearer token saved');
+  };
+
+  const onSaveBasic = (values: { username: string; password: string }) => {
+    setAuth({ type: 'basic', username: values.username, password: values.password });
+    message.success('Basic auth saved');
+  };
+
+  const onClear = () => {
+    clearAuth();
+    bearerForm.resetFields();
+    basicForm.resetFields();
+    message.success('Auth cleared');
+  };
+
+  const tabs = [
+    {
+      key: 'bearer',
+      label: 'Bearer Token',
+      children: (
+        <Form form={bearerForm} initialValues={initialBearer} onFinish={onSaveBearer} layout="vertical">
+          <Form.Item name="token" label="Token" rules={[{ required: true, message: 'Please enter token' }]}>
+            <Input.Password placeholder="Enter Bearer token" />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit">Save</Button>
+          </Form.Item>
+        </Form>
+      ),
+    },
+    {
+      key: 'basic',
+      label: 'Basic Auth',
+      children: (
+        <Form form={basicForm} initialValues={initialBasic} onFinish={onSaveBasic} layout="vertical">
+          <Form.Item name="username" label="Username" rules={[{ required: true, message: 'Please enter username' }]}>
+            <Input placeholder="Username" />
+          </Form.Item>
+          <Form.Item name="password" label="Password" rules={[{ required: true, message: 'Please enter password' }]}>
+            <Input.Password placeholder="Password" />
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit">Save</Button>
+          </Form.Item>
+        </Form>
+      ),
+    },
+  ];
+
+  return (
+    <div id="knife4j-authorize" style={{ maxWidth: 480, padding: 24 }}>
+      <h2>Authorization</h2>
+      <Tabs items={tabs} />
+      {auth && (
+        <Button danger onClick={onClear} style={{ marginTop: 8 }}>
+          Clear Auth
+        </Button>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## TASK-018: Authorize 鉴权配置页

### 变更内容
- **src/context/AuthContext.tsx** — `AuthProvider` + `useAuth()` hook，鉴权配置持久化到 localStorage（key: `knife4j_auth`）
- **src/pages/Authorize.tsx** — Bearer Token / Basic Auth 两个 tab，antd Form + Input
- **src/App.tsx** — `AuthProvider` 包裹 `GroupProvider`

### 验证
```
npm run build  ✓
```

### 后续
TASK-019（GlobalParam）可以复用同样的 context 模式；ApiDebug 接入 `useAuth()` 在 TASK-017 合并后进行。