### PR TITLE
feat(ui-react): implement GlobalParam page [TASK-019]

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/context/GlobalParamContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GlobalParamContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const STORAGE_KEY = 'knife4j_global_params';
+
+export interface GlobalParamItem {
+  id: string;
+  name: string;
+  value: string;
+  in: 'header' | 'query';
+}
+
+interface GlobalParamContextValue {
+  params: GlobalParamItem[];
+  addParam: (param: Omit<GlobalParamItem, 'id'>) => void;
+  removeParam: (id: string) => void;
+}
+
+const GlobalParamContext = createContext<GlobalParamContextValue | null>(null);
+
+function loadFromStorage(): GlobalParamItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export const GlobalParamProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [params, setParams] = useState<GlobalParamItem[]>(loadFromStorage);
+
+  const addParam = (param: Omit<GlobalParamItem, 'id'>) => {
+    const next = [...params, { ...param, id: crypto.randomUUID() }];
+    setParams(next);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  };
+
+  const removeParam = (id: string) => {
+    const next = params.filter((p) => p.id !== id);
+    setParams(next);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  };
+
+  return (
+    <GlobalParamContext.Provider value={{ params, addParam, removeParam }}>
+      {children}
+    </GlobalParamContext.Provider>
+  );
+};
+
+export const useGlobalParam = (): GlobalParamContextValue => {
+  const ctx = useContext(GlobalParamContext);
+  if (!ctx) throw new Error('useGlobalParam must be used inside GlobalParamProvider');
+  return ctx;
+};

--- a/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
@@ -1,11 +1,85 @@
+import { useState } from 'react';
+import { Table, Form, Input, Select, Button, Space } from 'antd';
+import { DeleteOutlined } from '@ant-design/icons';
+import { GlobalParamProvider, useGlobalParam, GlobalParamItem } from '../../context/GlobalParamContext';
+
+export { useGlobalParam };
+
+const columns = (onDelete: (id: string) => void) => [
+  { title: 'Name', dataIndex: 'name', key: 'name' },
+  { title: 'Value', dataIndex: 'value', key: 'value' },
+  { title: 'In', dataIndex: 'in', key: 'in' },
+  {
+    title: 'Action',
+    key: 'action',
+    render: (_: unknown, record: GlobalParamItem) => (
+      <Button
+        type="text"
+        danger
+        icon={<DeleteOutlined />}
+        onClick={() => onDelete(record.id)}
+      />
+    ),
+  },
+];
+
+function GlobalParamInner() {
+  const { params, addParam, removeParam } = useGlobalParam();
+  const [form] = Form.useForm();
+  const [loading, setLoading] = useState(false);
+
+  const onFinish = (values: { name: string; value: string; in: 'header' | 'query' }) => {
+    setLoading(true);
+    addParam(values);
+    form.resetFields();
+    setLoading(false);
+  };
+
+  return (
+    <div id="knife4j-global-param-page" style={{ padding: 16 }}>
+      <Form
+        form={form}
+        layout="inline"
+        onFinish={onFinish}
+        initialValues={{ in: 'header' }}
+        style={{ marginBottom: 16 }}
+      >
+        <Form.Item name="name" rules={[{ required: true, message: 'Name required' }]}>
+          <Input placeholder="Parameter name" />
+        </Form.Item>
+        <Form.Item name="value" rules={[{ required: true, message: 'Value required' }]}>
+          <Input placeholder="Parameter value" />
+        </Form.Item>
+        <Form.Item name="in">
+          <Select style={{ width: 100 }}>
+            <Select.Option value="header">header</Select.Option>
+            <Select.Option value="query">query</Select.Option>
+          </Select>
+        </Form.Item>
+        <Form.Item>
+          <Space>
+            <Button type="primary" htmlType="submit" loading={loading}>
+              Add
+            </Button>
+          </Space>
+        </Form.Item>
+      </Form>
+
+      <Table
+        dataSource={params}
+        columns={columns(removeParam)}
+        rowKey="id"
+        pagination={false}
+        size="small"
+      />
+    </div>
+  );
+}
 
 export default function GlobalParam() {
-
-    return (
-        <div id="knife4j-global-param-page">
-            <h1>我是全局参数</h1>
-            <p>
-            </p>
-        </div>
-    );
+  return (
+    <GlobalParamProvider>
+      <GlobalParamInner />
+    </GlobalParamProvider>
+  );
 }


### PR DESCRIPTION
## TASK-019: GlobalParam 全局参数页

### 变更内容
- **src/context/GlobalParamContext.tsx** — `GlobalParamProvider` + `useGlobalParam()` hook，持久化到 localStorage（key: `knife4j_global_params`）
- **src/pages/document/GlobalParam.tsx** — 参数列表表格 + 新增表单（name/value/in: header|query）
- **src/App.tsx** — 注册 `GlobalParamProvider`

### 验证
```
npm run build  ✓
```