### PR TITLE
[TASK-016] feat(ui-react): 离线文档导出（HTML/Word）

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
@@ -5,14 +5,18 @@ import type { SwaggerDoc, MenuTag, OperationObject, ParameterObject } from '../.
 
 const { Title, Paragraph } = Typography;
 
+function sanitizeFilename(name: string): string {
+  return name.replace(/[/\\:*?"<>|]/g, '_').trim() || 'document';
+}
+
 function downloadBlob(content: string, filename: string, mime: string) {
   const blob = new Blob([content], { type: mime });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = filename;
+  a.download = sanitizeFilename(filename);
   a.click();
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 function escapeHtml(s: string | undefined | null): string {
@@ -203,7 +207,7 @@ export default function OfficeDoc() {
           type="primary"
           icon={<FileTextOutlined />}
           onClick={handleDownloadHtml}
-          disabled={loading || !swaggerDoc}
+          disabled={loading || !swaggerDoc || usingMock}
           loading={loading}
         >
           下载 HTML
@@ -211,7 +215,7 @@ export default function OfficeDoc() {
         <Button
           icon={<FileWordOutlined />}
           onClick={handleDownloadWord}
-          disabled={loading || !swaggerDoc}
+          disabled={loading || !swaggerDoc || usingMock}
           loading={loading}
         >
           下载 Word (.doc)

--- a/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
@@ -1,11 +1,222 @@
+import { Button, Space, Typography, Alert } from 'antd';
+import { FileTextOutlined, FileWordOutlined } from '@ant-design/icons';
+import { useGroup } from '../../context/GroupContext';
+import type { SwaggerDoc, MenuTag, OperationObject, ParameterObject } from '../../types/swagger';
+
+const { Title, Paragraph } = Typography;
+
+function downloadBlob(content: string, filename: string, mime: string) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function escapeHtml(s: string | undefined | null): string {
+  if (!s) return '';
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function methodColor(method: string): string {
+  const map: Record<string, string> = {
+    GET: '#61affe', POST: '#49cc90', PUT: '#fca130',
+    DELETE: '#f93e3e', PATCH: '#50e3c2', HEAD: '#9012fe', OPTIONS: '#0d5aa7',
+  };
+  return map[method.toUpperCase()] ?? '#999';
+}
+
+function renderParamTable(params: ParameterObject[]): string {
+  if (!params.length) return '';
+  const rows = params.map((p) => `
+    <tr>
+      <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.name)}</td>
+      <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.in)}</td>
+      <td style="border:1px solid #ddd;padding:5px 8px;">${p.required ? 'Yes' : 'No'}</td>
+      <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.schema?.type ?? p.type ?? '')}</td>
+      <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.description)}</td>
+    </tr>`).join('');
+  return `
+    <table style="width:100%;border-collapse:collapse;margin:8px 0;font-size:13px;">
+      <thead><tr style="background:#f5f5f5;">
+        <th style="border:1px solid #ddd;padding:5px 8px;text-align:left;">Name</th>
+        <th style="border:1px solid #ddd;padding:5px 8px;text-align:left;">In</th>
+        <th style="border:1px solid #ddd;padding:5px 8px;text-align:left;">Required</th>
+        <th style="border:1px solid #ddd;padding:5px 8px;text-align:left;">Type</th>
+        <th style="border:1px solid #ddd;padding:5px 8px;text-align:left;">Description</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+}
+
+function renderOperation(path: string, method: string, op: OperationObject): string {
+  const color = methodColor(method);
+  const params = op.parameters ?? [];
+  return `
+    <div style="margin:14px 0;border:1px solid #e8e8e8;border-radius:4px;overflow:hidden;">
+      <div style="padding:8px 12px;background:#fafafa;display:flex;align-items:center;gap:10px;">
+        <span style="background:${color};color:#fff;padding:2px 8px;border-radius:3px;font-size:12px;font-weight:600;min-width:56px;text-align:center;">${escapeHtml(method.toUpperCase())}</span>
+        <span style="font-family:monospace;font-size:14px;">${escapeHtml(path)}</span>
+        ${op.deprecated ? '<span style="color:#f93e3e;font-size:12px;margin-left:8px;">[Deprecated]</span>' : ''}
+      </div>
+      ${op.summary ? `<div style="padding:5px 12px;font-size:14px;">${escapeHtml(op.summary)}</div>` : ''}
+      ${op.description ? `<div style="padding:3px 12px;font-size:13px;color:#666;">${escapeHtml(op.description)}</div>` : ''}
+      ${params.length ? `<div style="padding:5px 12px;">${renderParamTable(params)}</div>` : ''}
+    </div>`;
+}
+
+function buildHtmlDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
+  const sections = tags.map((t) => {
+    const ops = t.operations.map((op) => renderOperation(op.path, op.method, op.operation)).join('');
+    return `
+      <div style="margin-bottom:28px;">
+        <h2 style="border-left:4px solid #00ab6d;padding-left:10px;margin:20px 0 10px;">${escapeHtml(t.tag)}</h2>
+        ${t.description ? `<p style="color:#666;margin-bottom:10px;">${escapeHtml(t.description)}</p>` : ''}
+        ${ops}
+      </div>`;
+  }).join('');
+
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>${escapeHtml(doc.info.title)}</title>
+  <style>
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;margin:0;padding:0;color:#333;}
+    .wrap{max-width:960px;margin:0 auto;padding:24px;}
+    h1{text-align:center;color:#00ab6d;}
+    .info{background:#f9f9f9;border:1px solid #e8e8e8;border-radius:4px;padding:14px;margin-bottom:20px;}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>${escapeHtml(doc.info.title)}</h1>
+    <div class="info">
+      <p><strong>Version:</strong> ${escapeHtml(doc.info.version)}</p>
+      ${doc.info.description ? `<p><strong>Description:</strong> ${escapeHtml(doc.info.description)}</p>` : ''}
+    </div>
+    ${sections}
+  </div>
+</body>
+</html>`;
+}
+
+function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
+  const sections = tags.map((t) => {
+    const ops = t.operations.map((op) => {
+      const params = op.operation.parameters ?? [];
+      const paramRows = params.map((p) => `
+        <tr>
+          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.name)}</td>
+          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.in)}</td>
+          <td style="border:1px solid #000;padding:4px 6px;">${p.required ? 'Yes' : 'No'}</td>
+          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.schema?.type ?? p.type ?? '')}</td>
+          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.description)}</td>
+        </tr>`).join('');
+      const paramTable = params.length ? `
+        <table style="width:100%;border-collapse:collapse;margin:6px 0;font-size:12px;">
+          <thead><tr style="background:#e8e8e8;">
+            <th style="border:1px solid #000;padding:4px 6px;">Name</th>
+            <th style="border:1px solid #000;padding:4px 6px;">In</th>
+            <th style="border:1px solid #000;padding:4px 6px;">Required</th>
+            <th style="border:1px solid #000;padding:4px 6px;">Type</th>
+            <th style="border:1px solid #000;padding:4px 6px;">Description</th>
+          </tr></thead>
+          <tbody>${paramRows}</tbody>
+        </table>` : '';
+      return `
+        <div style="margin:10px 0;padding:8px;border:1px solid #ccc;">
+          <p style="margin:0 0 4px;"><strong style="color:${methodColor(op.method)};">[${escapeHtml(op.method.toUpperCase())}]</strong> <code>${escapeHtml(op.path)}</code>${op.operation.deprecated ? ' <em style="color:red;">[Deprecated]</em>' : ''}</p>
+          ${op.operation.summary ? `<p style="margin:2px 0;font-size:13px;">${escapeHtml(op.operation.summary)}</p>` : ''}
+          ${paramTable}
+        </div>`;
+    }).join('');
+    return `
+      <h2 style="border-left:4px solid #00ab6d;padding-left:8px;margin:20px 0 8px;">${escapeHtml(t.tag)}</h2>
+      ${ops}`;
+  }).join('');
+
+  return `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <title>${escapeHtml(doc.info.title)}</title>
+  <style>
+    body{font-family:"宋体",serif;font-size:14px;margin:20px;}
+    h1{text-align:center;}
+    code{font-family:monospace;}
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(doc.info.title)}</h1>
+  <p><strong>Version:</strong> ${escapeHtml(doc.info.version)}</p>
+  ${doc.info.description ? `<p><strong>Description:</strong> ${escapeHtml(doc.info.description)}</p>` : ''}
+  <hr/>
+  ${sections}
+</body>
+</html>`;
+}
 
 export default function OfficeDoc() {
+  const { swaggerDoc, menuTags, loading, usingMock } = useGroup();
 
-    return (
-        <div id="knife4j-office-doc-page">
-            <h1>我是离线文档</h1>
-            <p>
-            </p>
-        </div>
-    );
+  function handleDownloadHtml() {
+    if (!swaggerDoc) return;
+    const html = buildHtmlDoc(swaggerDoc, menuTags);
+    const title = swaggerDoc.info.title || 'api-docs';
+    downloadBlob(html, `${title}.html`, 'text/html;charset=utf-8');
+  }
+
+  function handleDownloadWord() {
+    if (!swaggerDoc) return;
+    const html = buildWordDoc(swaggerDoc, menuTags);
+    const title = swaggerDoc.info.title || 'api-docs';
+    downloadBlob(html, `${title}.doc`, 'application/msword');
+  }
+
+  const noData = !loading && (!swaggerDoc || usingMock);
+
+  return (
+    <div id="knife4j-office-doc-page" style={{ padding: 24, maxWidth: 800 }}>
+      <Title level={4} style={{ marginBottom: 8 }}>离线文档导出</Title>
+      <Paragraph type="secondary" style={{ marginBottom: 20 }}>
+        将当前接口文档导出为可下载的离线文件，支持 HTML 和 Word（.doc）格式。
+      </Paragraph>
+
+      {noData && (
+        <Alert
+          type="warning"
+          message="当前使用 Mock 数据或文档未加载，导出内容可能不完整。"
+          style={{ marginBottom: 16 }}
+        />
+      )}
+
+      <Space size="middle">
+        <Button
+          type="primary"
+          icon={<FileTextOutlined />}
+          onClick={handleDownloadHtml}
+          disabled={loading || !swaggerDoc}
+          loading={loading}
+        >
+          下载 HTML
+        </Button>
+        <Button
+          icon={<FileWordOutlined />}
+          onClick={handleDownloadWord}
+          disabled={loading || !swaggerDoc}
+          loading={loading}
+        >
+          下载 Word (.doc)
+        </Button>
+      </Space>
+    </div>
+  );
 }


### PR DESCRIPTION
## 变更内容

实现离线文档导出页面，替换原有占位实现。

### 功能
- **HTML 导出**：生成带样式的自包含 HTML 文件，包含 API 信息、tag 分组、参数表格，触发浏览器下载
- **Word 导出**：生成 Word 兼容的 HTML blob（.doc），无需额外依赖，与 Vue2 wordTransform 同一思路
- 数据来自 `useGroup()`（swaggerDoc + menuTags）
- loading / mock 状态有 Alert 提示，mock 时禁用导出按钮

### 修复（reviewer 反馈）
- `URL.revokeObjectURL` 延迟到 setTimeout 后执行，修复 Firefox 下载失败问题
- 文件名做特殊字符清理（去除 `/ \ : * ? " < > |`）
- mock 数据时禁用导出按钮，与警告提示保持一致

### 已知限制
- Word (.doc) 为 HTML blob 格式，LibreOffice 正常，Microsoft Word 可能显示兼容性警告（与 Vue2 实现相同）
- requestBody 渲染可在后续任务中补充

### 验证
```
cd knife4j-front/knife4j-ui-react && npm ci && npm run build
✓ built in 10.57s，无 TypeScript 错误
```

Closes TASK-016