### PR TITLE
[TASK-021] feat(demo): 完善接口文档 DTO + @Schema 注解

### DIFF
--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UserController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UserController.java
@@ -25,6 +25,7 @@ import com.baizhukui.knife4j.demo.dto.UserVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -44,14 +45,11 @@ public class UserController {
     
     @Operation(summary = "分页查询用户")
     @GetMapping("/page")
-    public PageResult<UserVO> page(
-                                   @Parameter(description = "页码（从 1 开始）") @RequestParam(defaultValue = "1") int pageNum,
-                                   @Parameter(description = "每页条数") @RequestParam(defaultValue = "10") int pageSize,
-                                   @Parameter(description = "关键词（模糊搜索用户名或邮箱）") @RequestParam(required = false) String keyword) {
+    public PageResult<UserVO> page(@ParameterObject PageQuery query) {
         List<UserVO> data = List.of(
                 new UserVO(1L, "张三", "zhangsan@example.com"),
                 new UserVO(2L, "李四", "lisi@example.com"));
-        return new PageResult<>(pageNum, pageSize, data.size(), data);
+        return new PageResult<>(query.getPageNum(), query.getPageSize(), data.size(), data);
     }
     
     @Operation(summary = "根据 ID 获取用户")

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UserController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UserController.java
@@ -17,13 +17,17 @@
 
 package com.baizhukui.knife4j.demo;
 
+import com.baizhukui.knife4j.demo.dto.PageQuery;
+import com.baizhukui.knife4j.demo.dto.PageResult;
+import com.baizhukui.knife4j.demo.dto.UserCreateRequest;
+import com.baizhukui.knife4j.demo.dto.UserUpdateRequest;
+import com.baizhukui.knife4j.demo.dto.UserVO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @Tag(name = "用户接口", description = "用户相关示例接口")
 @RestController
@@ -32,30 +36,49 @@ public class UserController {
     
     @Operation(summary = "获取用户列表")
     @GetMapping("/list")
-    public List<Map<String, Object>> list() {
+    public List<UserVO> list() {
         return List.of(
-                Map.of("id", 1, "name", "张三", "email", "zhangsan@example.com"),
-                Map.of("id", 2, "name", "李四", "email", "lisi@example.com"));
+                new UserVO(1L, "张三", "zhangsan@example.com"),
+                new UserVO(2L, "李四", "lisi@example.com"));
+    }
+    
+    @Operation(summary = "分页查询用户")
+    @GetMapping("/page")
+    public PageResult<UserVO> page(
+                                   @Parameter(description = "页码（从 1 开始）") @RequestParam(defaultValue = "1") int pageNum,
+                                   @Parameter(description = "每页条数") @RequestParam(defaultValue = "10") int pageSize,
+                                   @Parameter(description = "关键词（模糊搜索用户名或邮箱）") @RequestParam(required = false) String keyword) {
+        List<UserVO> data = List.of(
+                new UserVO(1L, "张三", "zhangsan@example.com"),
+                new UserVO(2L, "李四", "lisi@example.com"));
+        return new PageResult<>(pageNum, pageSize, data.size(), data);
     }
     
     @Operation(summary = "根据 ID 获取用户")
     @GetMapping("/{id}")
-    public Map<String, Object> getById(
-                                       @Parameter(description = "用户 ID") @PathVariable Long id) {
-        return Map.of("id", id, "name", "张三", "email", "zhangsan@example.com");
+    public UserVO getById(
+                          @Parameter(description = "用户 ID") @PathVariable Long id) {
+        return new UserVO(id, "张三", "zhangsan@example.com");
     }
     
     @Operation(summary = "创建用户")
     @PostMapping
-    public Map<String, Object> create(@RequestBody Map<String, Object> body) {
-        body.put("id", 3);
-        return body;
+    public UserVO create(@RequestBody UserCreateRequest request) {
+        return new UserVO(3L, request.getName(), request.getEmail());
+    }
+    
+    @Operation(summary = "更新用户")
+    @PutMapping("/{id}")
+    public UserVO update(
+                         @Parameter(description = "用户 ID") @PathVariable Long id,
+                         @RequestBody UserUpdateRequest request) {
+        return new UserVO(id, request.getName(), request.getEmail());
     }
     
     @Operation(summary = "删除用户")
     @DeleteMapping("/{id}")
-    public Map<String, Object> delete(
-                                      @Parameter(description = "用户 ID") @PathVariable Long id) {
-        return Map.of("success", true, "id", id);
+    public UserVO delete(
+                         @Parameter(description = "用户 ID") @PathVariable Long id) {
+        return new UserVO(id, "张三", "zhangsan@example.com");
     }
 }

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/PageQuery.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/PageQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "分页查询参数")
+public class PageQuery {
+    
+    @Schema(description = "页码（从 1 开始）", example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private int pageNum = 1;
+    
+    @Schema(description = "每页条数", example = "10", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private int pageSize = 10;
+    
+    @Schema(description = "关键词（模糊搜索用户名或邮箱）", example = "张", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String keyword;
+    
+    public PageQuery() {
+    }
+    
+    public int getPageNum() {
+        return pageNum;
+    }
+    public void setPageNum(int pageNum) {
+        this.pageNum = pageNum;
+    }
+    
+    public int getPageSize() {
+        return pageSize;
+    }
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+    
+    public String getKeyword() {
+        return keyword;
+    }
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/PageResult.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/PageResult.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "分页结果")
+public class PageResult<T> {
+    
+    @Schema(description = "当前页码", example = "1")
+    private int pageNum;
+    
+    @Schema(description = "每页条数", example = "10")
+    private int pageSize;
+    
+    @Schema(description = "总记录数", example = "100")
+    private long total;
+    
+    @Schema(description = "数据列表")
+    private List<T> list;
+    
+    public PageResult() {
+    }
+    
+    public PageResult(int pageNum, int pageSize, long total, List<T> list) {
+        this.pageNum = pageNum;
+        this.pageSize = pageSize;
+        this.total = total;
+        this.list = list;
+    }
+    
+    public int getPageNum() {
+        return pageNum;
+    }
+    public void setPageNum(int pageNum) {
+        this.pageNum = pageNum;
+    }
+    
+    public int getPageSize() {
+        return pageSize;
+    }
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+    
+    public long getTotal() {
+        return total;
+    }
+    public void setTotal(long total) {
+        this.total = total;
+    }
+    
+    public List<T> getList() {
+        return list;
+    }
+    public void setList(List<T> list) {
+        this.list = list;
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserCreateRequest.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserCreateRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "创建用户请求")
+public class UserCreateRequest {
+    
+    @Schema(description = "用户名", example = "张三", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+    
+    @Schema(description = "邮箱地址", example = "zhangsan@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String email;
+    
+    public UserCreateRequest() {
+    }
+    
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserUpdateRequest.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserUpdateRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "更新用户请求")
+public class UserUpdateRequest {
+    
+    @Schema(description = "用户名", example = "李四", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String name;
+    
+    @Schema(description = "邮箱地址", example = "lisi@example.com", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String email;
+    
+    public UserUpdateRequest() {
+    }
+    
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserVO.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserVO.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "用户视图对象")
+public class UserVO {
+    
+    @Schema(description = "用户 ID", example = "1")
+    private Long id;
+    
+    @Schema(description = "用户名", example = "张三")
+    private String name;
+    
+    @Schema(description = "邮箱地址", example = "zhangsan@example.com")
+    private String email;
+    
+    public UserVO() {
+    }
+    
+    public UserVO(Long id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+    
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}


### PR DESCRIPTION
## 变更内容

完善 knife4j-demo 的接口文档，让调试者在 Swagger UI 里能看到清晰的字段说明和示例值。

### 新增 DTO
- `UserVO` — 用户响应对象
- `UserCreateRequest` — 创建用户请求体
- `UserUpdateRequest` — 更新用户请求体
- `PageQuery` — 分页查询参数（pageNum、pageSize、keyword）
- `PageResult<T>` — 分页响应包装

所有字段均含 `@Schema(description, example, requiredMode)`。

### UserController 变更
- 所有 `Map<String, Object>` 参数和返回值替换为具名 DTO
- 新增 `GET /api/user/page`（分页查询，使用 `@ParameterObject PageQuery`）
- 新增 `PUT /api/user/{id}`（更新用户）

### 验证
```
cd knife4j && mvn -pl knife4j-demo -am -q package -DskipTests -Dmaven.javadoc.skip=true
BUILD SUCCESS
```

Closes TASK-021