### PR TITLE
[TASK-022] feat(ui-react): ApiDoc 补全 requestBody 渲染

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -1,5 +1,6 @@
 import { Badge, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { SchemaObject, SwaggerDoc } from '../../types/swagger';
 
 const { Title, Paragraph, Text } = Typography;
 
@@ -21,25 +22,82 @@ interface ResponseRow {
   schema: string;
 }
 
+interface BodyRow {
+  key: string;
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+}
+
 const MOCK_OPERATION = {
-  url: '/api/user/{id}',
-  methodType: 'GET',
-  summary: '查询用户详情',
-  description: '根据用户 ID 查询用户的基本信息，包含姓名、邮箱和角色。',
+  url: '/api/user',
+  methodType: 'POST',
+  summary: '创建用户',
+  description: '创建一个新用户，请求体包含用户基本信息。',
   deprecated: false,
   parameters: [
-    { key: '1', name: 'id', in: 'path', type: 'integer', required: true, description: '用户 ID' },
-    { key: '2', name: 'Authorization', in: 'header', type: 'string', required: true, description: 'Bearer token' },
-    { key: '3', name: 'fields', in: 'query', type: 'string', required: false, description: '需要返回的字段，逗号分隔' },
+    { key: '1', name: 'Authorization', in: 'header', type: 'string', required: true, description: 'Bearer token' },
   ] as ParamRow[],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/CreateUserRequest',
+        },
+      },
+    },
+  },
   responses: [
     { key: '200', statusCode: '200', description: '成功', schema: 'UserVO' },
-    { key: '404', statusCode: '404', description: '用户不存在', schema: '' },
+    { key: '400', statusCode: '400', description: '参数错误', schema: '' },
     { key: '401', statusCode: '401', description: '未授权', schema: '' },
   ] as ResponseRow[],
 };
 
-// ---- 请求参数表格 ----
+const MOCK_SWAGGER_DOC: Pick<SwaggerDoc, 'components'> = {
+  components: {
+    schemas: {
+      CreateUserRequest: {
+        type: 'object',
+        required: ['username', 'email'],
+        properties: {
+          username: { type: 'string', description: '用户名，3-20 个字符' },
+          email: { type: 'string', format: 'email', description: '邮箱地址' },
+          role: { type: 'string', description: '角色，默认 user', enum: ['user', 'admin'] },
+          age: { type: 'integer', description: '年龄' },
+        },
+      },
+    },
+  },
+};
+
+// ---- $ref 解析 ----
+
+function resolveRef(ref: string, doc: Pick<SwaggerDoc, 'components'>): SchemaObject | undefined {
+  const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
+  if (!match) return undefined;
+  return (doc.components?.schemas ?? {})[match[1]];
+}
+
+function schemaToBodyRows(
+  schema: SchemaObject,
+  doc: Pick<SwaggerDoc, 'components'>,
+): BodyRow[] {
+  const resolved = schema.$ref ? resolveRef(schema.$ref, doc) : schema;
+  if (!resolved?.properties) return [];
+  const requiredSet = new Set(resolved.required ?? []);
+  return Object.entries(resolved.properties).map(([name, prop]) => ({
+    key: name,
+    name,
+    type: prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object'),
+    required: requiredSet.has(name),
+    description: prop.description ?? '',
+  }));
+}
+
+// ---- 请求参数表格列 ----
 
 const paramColumns: ColumnsType<ParamRow> = [
   {
@@ -69,7 +127,26 @@ const paramColumns: ColumnsType<ParamRow> = [
   { title: '说明', dataIndex: 'description' },
 ];
 
-// ---- 响应结构表格 ----
+// ---- 请求体字段表格列 ----
+
+const bodyColumns: ColumnsType<BodyRow> = [
+  {
+    title: '字段名',
+    dataIndex: 'name',
+    width: 160,
+    render: (v) => <Text code>{v}</Text>,
+  },
+  { title: '类型', dataIndex: 'type', width: 100 },
+  {
+    title: '必填',
+    dataIndex: 'required',
+    width: 70,
+    render: (v) => v ? <Badge status="error" text="是" /> : <Badge status="default" text="否" />,
+  },
+  { title: '说明', dataIndex: 'description' },
+];
+
+// ---- 响应结构表格列 ----
 
 const responseColumns: ColumnsType<ResponseRow> = [
   {
@@ -98,6 +175,15 @@ const METHOD_COLOR: Record<string, string> = {
 
 export default function ApiDoc() {
   const op = MOCK_OPERATION;
+  const doc = MOCK_SWAGGER_DOC;
+
+  const bodyRows: BodyRow[] = (() => {
+    const rb = op.requestBody;
+    if (!rb) return [];
+    const jsonContent = rb.content?.['application/json'];
+    if (!jsonContent?.schema) return [];
+    return schemaToBodyRows(jsonContent.schema as SchemaObject, doc);
+  })();
 
   return (
     <div style={{ padding: '24px', maxWidth: 960 }}>
@@ -114,14 +200,32 @@ export default function ApiDoc() {
       {op.description && <Paragraph type="secondary">{op.description}</Paragraph>}
 
       {/* 请求参数 */}
-      <Title level={5} style={{ marginTop: 24 }}>请求参数</Title>
-      <Table<ParamRow>
-        columns={paramColumns}
-        dataSource={op.parameters}
-        pagination={false}
-        size="small"
-        bordered
-      />
+      {op.parameters.length > 0 && (
+        <>
+          <Title level={5} style={{ marginTop: 24 }}>请求参数</Title>
+          <Table<ParamRow>
+            columns={paramColumns}
+            dataSource={op.parameters}
+            pagination={false}
+            size="small"
+            bordered
+          />
+        </>
+      )}
+
+      {/* 请求体 */}
+      {bodyRows.length > 0 && (
+        <>
+          <Title level={5} style={{ marginTop: 24 }}>请求体（application/json）</Title>
+          <Table<BodyRow>
+            columns={bodyColumns}
+            dataSource={bodyRows}
+            pagination={false}
+            size="small"
+            bordered
+          />
+        </>
+      )}
 
       {/* 响应结构 */}
       <Title level={5} style={{ marginTop: 24 }}>响应结构</Title>

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -75,15 +75,15 @@ const MOCK_SWAGGER_DOC: Pick<SwaggerDoc, 'components'> = {
 
 // ---- $ref 解析 ----
 
-function resolveRef(ref: string, doc: Pick<SwaggerDoc, 'components'>): SchemaObject | undefined {
+function resolveRef(ref: string, doc: Pick<SwaggerDoc, 'components' | 'definitions'>): SchemaObject | undefined {
   const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
   if (!match) return undefined;
-  return (doc.components?.schemas ?? {})[match[1]];
+  return (doc.components?.schemas ?? (doc.definitions as Record<string, SchemaObject> | undefined) ?? {})[match[1]];
 }
 
 function schemaToBodyRows(
   schema: SchemaObject,
-  doc: Pick<SwaggerDoc, 'components'>,
+  doc: Pick<SwaggerDoc, 'components' | 'definitions'>,
 ): BodyRow[] {
   const resolved = schema.$ref ? resolveRef(schema.$ref, doc) : schema;
   if (!resolved?.properties) return [];

--- a/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
@@ -1,7 +1,7 @@
 import { Button, Space, Typography, Alert } from 'antd';
 import { FileTextOutlined, FileWordOutlined } from '@ant-design/icons';
 import { useGroup } from '../../context/GroupContext';
-import type { SwaggerDoc, MenuTag, OperationObject, ParameterObject } from '../../types/swagger';
+import type { SwaggerDoc, MenuTag, OperationObject, ParameterObject, SchemaObject } from '../../types/swagger';
 
 const { Title, Paragraph } = Typography;
 
@@ -59,9 +59,52 @@ function renderParamTable(params: ParameterObject[]): string {
     </table>`;
 }
 
-function renderOperation(path: string, method: string, op: OperationObject): string {
+function resolveRef(ref: string, doc: SwaggerDoc): SchemaObject | undefined {
+  const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
+  if (!match) return undefined;
+  return (doc.components?.schemas ?? (doc.definitions as Record<string, SchemaObject> | undefined) ?? {})[match[1]];
+}
+
+function renderRequestBodyTable(op: OperationObject, doc: SwaggerDoc, borderStyle: string): string {
+  const rb = op.requestBody;
+  if (!rb) return '';
+  const jsonContent = rb.content?.['application/json'];
+  if (!jsonContent?.schema) return '';
+  let schema = jsonContent.schema;
+  if (schema.$ref) {
+    const resolved = resolveRef(schema.$ref, doc);
+    if (!resolved) return '';
+    schema = resolved;
+  }
+  if (!schema.properties) return '';
+  const requiredSet = new Set(schema.required ?? []);
+  const rows = Object.entries(schema.properties).map(([name, prop]) => {
+    const type = prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object');
+    return `
+    <tr>
+      <td style="${borderStyle}">${escapeHtml(name)}</td>
+      <td style="${borderStyle}">${escapeHtml(type)}</td>
+      <td style="${borderStyle}">${requiredSet.has(name) ? 'Yes' : 'No'}</td>
+      <td style="${borderStyle}">${escapeHtml(prop.description)}</td>
+    </tr>`;
+  }).join('');
+  return `
+    <p style="margin:6px 0 2px;font-size:13px;font-weight:600;">Request Body (application/json)</p>
+    <table style="width:100%;border-collapse:collapse;margin:4px 0;font-size:13px;">
+      <thead><tr style="background:#f5f5f5;">
+        <th style="${borderStyle}text-align:left;">Field</th>
+        <th style="${borderStyle}text-align:left;">Type</th>
+        <th style="${borderStyle}text-align:left;">Required</th>
+        <th style="${borderStyle}text-align:left;">Description</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+}
+
+function renderOperation(path: string, method: string, op: OperationObject, doc: SwaggerDoc): string {
   const color = methodColor(method);
   const params = op.parameters ?? [];
+  const bodyHtml = renderRequestBodyTable(op, doc, 'border:1px solid #ddd;padding:5px 8px;');
   return `
     <div style="margin:14px 0;border:1px solid #e8e8e8;border-radius:4px;overflow:hidden;">
       <div style="padding:8px 12px;background:#fafafa;display:flex;align-items:center;gap:10px;">
@@ -72,12 +115,13 @@ function renderOperation(path: string, method: string, op: OperationObject): str
       ${op.summary ? `<div style="padding:5px 12px;font-size:14px;">${escapeHtml(op.summary)}</div>` : ''}
       ${op.description ? `<div style="padding:3px 12px;font-size:13px;color:#666;">${escapeHtml(op.description)}</div>` : ''}
       ${params.length ? `<div style="padding:5px 12px;">${renderParamTable(params)}</div>` : ''}
+      ${bodyHtml ? `<div style="padding:5px 12px;">${bodyHtml}</div>` : ''}
     </div>`;
 }
 
 function buildHtmlDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
   const sections = tags.map((t) => {
-    const ops = t.operations.map((op) => renderOperation(op.path, op.method, op.operation)).join('');
+    const ops = t.operations.map((op) => renderOperation(op.path, op.method, op.operation, doc)).join('');
     return `
       <div style="margin-bottom:28px;">
         <h2 style="border-left:4px solid #00ab6d;padding-left:10px;margin:20px 0 10px;">${escapeHtml(t.tag)}</h2>
@@ -135,11 +179,13 @@ function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
           </tr></thead>
           <tbody>${paramRows}</tbody>
         </table>` : '';
+      const bodyHtml = renderRequestBodyTable(op.operation, doc, 'border:1px solid #000;padding:4px 6px;');
       return `
         <div style="margin:10px 0;padding:8px;border:1px solid #ccc;">
           <p style="margin:0 0 4px;"><strong style="color:${methodColor(op.method)};">[${escapeHtml(op.method.toUpperCase())}]</strong> <code>${escapeHtml(op.path)}</code>${op.operation.deprecated ? ' <em style="color:red;">[Deprecated]</em>' : ''}</p>
           ${op.operation.summary ? `<p style="margin:2px 0;font-size:13px;">${escapeHtml(op.operation.summary)}</p>` : ''}
           ${paramTable}
+          ${bodyHtml}
         </div>`;
     }).join('');
     return `


### PR DESCRIPTION
## 变更内容

ApiDoc 和离线导出补全 requestBody schema 渲染，POST/PUT/PATCH 接口现在能展示请求体字段。

### ApiDoc.tsx
- 新增 `resolveRef` 函数，支持 `#/components/schemas/` 和 `#/definitions/`（OAS2）两种格式
- 新增 `schemaToBodyRows` 将 schema 展开为字段行
- 对有 requestBody 的接口条件渲染「请求体（application/json）」表格，风格与参数表格一致

### OfficeDoc.tsx
- 新增 `renderRequestBodyTable` 函数，HTML/Word 两种格式复用
- `renderOperation` 补上 requestBody 内容

### 验证
```
cd knife4j-front/knife4j-ui-react && npm run build
✓ built in 10.81s，无 TypeScript 错误
```

Closes TASK-022