### PR TITLE
feat(demo): redirect / to /doc.html

### DIFF
--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/RootRedirectController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/RootRedirectController.java
@@ -1,0 +1,13 @@
+package com.baizhukui.knife4j.demo;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class RootRedirectController {
+
+    @GetMapping("/")
+    public String redirectToDoc() {
+        return "redirect:/doc.html";
+    }
+}


### PR DESCRIPTION
访问 demo.knife4jnext.com 根路径时自动跳转到 /doc.html。

新增 `RootRedirectController`，`GET /` → `redirect:/doc.html`。