### PR TITLE
feat(ui-react): settings drawer with Authorize/GlobalParam/OfflineDoc tabs [TASK-024]

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { GroupProvider, useGroup } from './context/GroupContext';
 import { AuthProvider } from './context/AuthContext';
 import SidebarSearchMenu from './compoents/SidebarSearchMenu';
+import SettingsDrawer from './compoents/SettingsDrawer';
 
 const { Header, Sider, Content, Footer } = Layout;
 type TargetKey = React.MouseEvent | React.KeyboardEvent | string;
@@ -27,6 +28,7 @@ const footerStyle: React.CSSProperties = {
 // Inner component so it can use GroupProvider context
 const AppInner: React.FC = () => {
   const [collapsed, setCollapsed] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [siderWidth, setSiderWidth] = useState(320);
   const navigate = useNavigate();
   const { groups, setActiveGroupValue } = useGroup();
@@ -152,10 +154,13 @@ const AppInner: React.FC = () => {
             <Button
               type="text"
               icon={<SettingOutlined />}
+              onClick={() => setSettingsOpen(true)}
               style={{ fontSize: 16, width: 48, height: 48 }}
             />
           </span>
         </Header>
+
+        <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)} />
 
         <Content
           style={{

--- a/knife4j-front/knife4j-ui-react/src/compoents/SettingsDrawer.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SettingsDrawer.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Drawer, Tabs } from 'antd';
+import Authorize from '../pages/Authorize';
+import GlobalParam from '../pages/document/GlobalParam';
+import OfficeDoc from '../pages/document/OfficeDoc';
+
+interface SettingsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SettingsDrawer: React.FC<SettingsDrawerProps> = ({ open, onClose }) => {
+  const tabItems = [
+    { key: 'authorize', label: 'Authorize', children: <Authorize /> },
+    { key: 'globalParam', label: '全局参数', children: <GlobalParam /> },
+    { key: 'officeDoc', label: '离线文档', children: <OfficeDoc /> },
+  ];
+
+  return (
+    <Drawer
+      title="设置"
+      placement="right"
+      width={600}
+      open={open}
+      onClose={onClose}
+    >
+      <Tabs items={tabItems} />
+    </Drawer>
+  );
+};
+
+export default SettingsDrawer;


### PR DESCRIPTION
## 变更内容

Header 右上角 SettingOutlined 按钮现在可以点击，弹出设置抽屉。

### 新增
- `src/compoents/SettingsDrawer.tsx`：Ant Design Drawer，宽度 600，右侧弹出，内含三个 Tab
  - Authorize
  - 全局参数
  - 离线文档

### 修改
- `src/App.tsx`：引入 SettingsDrawer，添加 settingsOpen 状态，SettingOutlined 按钮 onClick 打开抽屉

### 验证
- `npm run build` 通过，2763 modules transformed

Closes TASK-024