### PR TITLE
Improve React doc.html demo navigation and debug

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -185,3 +185,134 @@ next:
 - 如需启用，可将 PNG 上传为 Telegram Bot 头像。
 blockers:
 - none
+
+## 2026-04-25 16:05 CST
+task: ad-hoc react doc.html starter demo
+agent: codex
+branch: codex/ad-hoc-react-doc-html-router
+status: done
+summary:
+- 排查 `knife4j-demo` 集成 starter 后访问 `/doc.html` 出现 React Router `Unexpected Application Error! 404 Not Found`。
+- 确认后端 `/doc.html`、`/v3/api-docs` 和 React 静态资源均返回 200，问题源于 Browser history 将 `/doc.html` 当作前端路由匹配。
+- 将 React router 改为 hash router，并把 logo 路径改为 webjar 相对路径，适配 starter 静态资源部署。
+validation:
+- `mvn -pl knife4j-demo -am -DskipTests package` → BUILD SUCCESS
+- `curl http://localhost:8080/doc.html` → 200
+- `curl http://localhost:8080/v3/api-docs` → 200
+- `curl http://localhost:8080/webjars/knife4j-ui-react/assets/index.js` → 200，且打包产物包含 `createHashRouter`
+next:
+- 本地 demo 已使用修复后的 jar 在 8080 运行，可访问 `http://localhost:8080/doc.html`。
+blockers:
+- none
+
+## 2026-04-25 16:08 CST
+task: ad-hoc react api doc blank pane
+agent: codex
+branch: codex/ad-hoc-react-doc-html-router
+status: done
+summary:
+- 排查接口菜单点击后文档主体空白，确认原因是 App 只维护 Tab 标题和路由跳转，没有在 Tab 内容区渲染 React Router `Outlet`。
+- 在当前激活 Tab 中渲染 `Outlet`，并让接口菜单点击默认进入 `/:group/:tag/:operationId/doc` 文档页。
+- 为 hash router 增加 index 首页路由，避免首次打开 `/doc.html` 时内容区为空。
+validation:
+- `npm run build` → 成功
+- `mvn -pl knife4j-demo -am -DskipTests package` → BUILD SUCCESS
+- `curl http://localhost:8080/doc.html` → 200
+- `curl http://localhost:8080/v3/api-docs` → 200
+- `curl http://localhost:8080/webjars/knife4j-ui-react/assets/index.js` → 200，且打包产物包含文档页内容与 hash router
+next:
+- 本地 demo 已使用补充修复后的 jar 在 8080 运行，可刷新 `http://localhost:8080/doc.html` 后点击接口查看文档页。
+blockers:
+- none
+
+## 2026-04-25 16:12 CST
+task: ad-hoc react sidebar polish
+agent: codex
+branch: codex/ad-hoc-react-doc-html-router
+status: done
+summary:
+- 将左侧顶部 logo 区改为产品名 `Knife4j Next`，折叠态显示 `K4N`。
+- 为侧边栏搜索框增加专用暗色样式，覆盖 Ant Design 默认白底、placeholder 和清除按钮颜色。
+validation:
+- `npm run build` → 成功
+- `mvn -pl knife4j-demo -am -DskipTests package` → BUILD SUCCESS
+- `curl http://localhost:8080/doc.html` → 200
+- `curl http://localhost:8080/webjars/knife4j-ui-react/assets/index.js` → 200，且打包产物包含 `Knife4j Next`
+- `curl http://localhost:8080/webjars/knife4j-ui-react/assets/index.css` → 200，且打包产物包含 `knife4j-sidebar-search`
+next:
+- 本地 demo 已使用最新 jar 在 8080 运行，可刷新 `http://localhost:8080/doc.html` 查看侧边栏调整。
+blockers:
+- none
+
+## 2026-04-25 16:17 CST
+task: ad-hoc react api tabs and debug
+agent: codex
+branch: codex/ad-hoc-react-doc-html-router
+status: done
+summary:
+- 修复接口 Tab 切换看起来无效的问题：文档页从 mock operation 改为按当前路由参数读取真实 OpenAPI operation。
+- 新增 `useCurrentOperation` 共享 hook，用于文档页和调试页定位当前接口。
+- 增加接口页内 `文档 / 调试` 切换，并将调试页接入真实 method、path、path/query/header/body 参数。
+- 调试页支持同源发送请求、展示响应状态、耗时、响应体和响应 headers。
+validation:
+- `npm run build` → 成功
+- `mvn -pl knife4j-demo -am -DskipTests package` → BUILD SUCCESS
+- `curl http://localhost:8080/doc.html` → 200
+- `curl http://localhost:8080/v3/api-docs` → 200
+- `curl http://localhost:8080/webjars/knife4j-ui-react/assets/index.js` → 200，且打包产物包含文档/调试页文案
+next:
+- 本地 demo 已使用最新 jar 在 8080 运行，可刷新后验证接口 Tab 切换和调试功能。
+blockers:
+- none
+notes:
+- 构建过程改写了 `package-lock.json` 和两个 Java 文件的格式；维护者确认如属正常格式化则采纳，本次保留这些构建链输出。
+
+## 2026-04-25 16:20 CST
+task: ad-hoc react brand logo
+agent: codex
+branch: codex/ad-hoc-react-doc-html-router
+status: done
+summary:
+- 在左侧品牌区 `Knife4j Next` 文案左边加回 `knife4j-next-mark.svg` logo。
+- 折叠侧边栏时仅保留 logo，避免窄栏显示拥挤。
+validation:
+- `npm run build` → 成功
+- `mvn -pl knife4j-demo -am -DskipTests package` → BUILD SUCCESS
+- `curl http://localhost:8080/doc.html` → 200
+- `curl http://localhost:8080/webjars/knife4j-ui-react/assets/index.js` → 200，且打包产物包含 logo 路径和 `Knife4j Next`
+next:
+- 本地 demo 已使用最新 jar 在 8080 运行，可刷新查看品牌区 logo。
+blockers:
+- none
+
+## 2026-04-25 16:42 CST
+task: ad-hoc vue2 local demo
+agent: codex
+branch: codex/ad-hoc-react-doc-html-router
+status: done
+summary:
+- 确认先前访问 `http://127.0.0.1:8081/doc.html` 看到的不是 Vue2 Knife4j，而是 Vue2 devServer 的 `/` 代理把 `/doc.html` 转发给了后端 React 静态资源。
+- 使用 Node 17 + Yarn 构建 `knife4j-vue/dist`，并启动临时 Express 静态代理服务：`/doc.html` 和 `/webjars` 来自 Vue2 dist，其余 API 代理到 `http://127.0.0.1:17812`。
+validation:
+- `yarn run build` in `knife4j-vue` → 成功（仅 webpack size warning）
+- `curl http://127.0.0.1:8081/doc.html` → 200，返回 Vue2 dist `webjars/js/app.*.js`
+- `curl http://127.0.0.1:8081/v3/api-docs` → 200 `application/json`
+next:
+- 当前真正的 Vue2 对比页面为 `http://127.0.0.1:8081/doc.html`，后端 demo 代理目标为 `http://127.0.0.1:17812`。
+blockers:
+- none
+
+## 2026-04-25 16:52 CST
+task: ad-hoc react/vue2 capability parity planning
+agent: codex
+branch: codex/ad-hoc-react-doc-html-router
+status: done
+summary:
+- 根据维护者要求，将 React 前端下一阶段目标调整为优先复原 Knife4j Vue2 版能力，而不是先追求视觉重设计。
+- 在 `.agent/TASKS.md` 新增 TASK-026 至 TASK-031，按调试参数表单、requestBody、请求构造、响应面板、schema 示例生成、鉴权/全局参数接入拆分。
+validation:
+- 纯任务队列与进度文档更新，未运行代码构建。
+next:
+- 建议优先执行 TASK-026：React 调试页按 OpenAPI 参数定义渲染填参表单。
+blockers:
+- none

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -407,3 +407,102 @@ done_when:
 notes:
 - 对标原版 knife4j 的 zh-CN / en-US 切换
 - blocked 原因：等 TASK-023 集成后在真实环境验证
+
+### TASK-026
+status: ready
+area: ui-react
+title: React 调试页按 OpenAPI 参数定义渲染填参表单
+branch: codex/TASK-026-react-debug-params
+depends_on: TASK-013,TASK-017
+validation: cd knife4j-front/knife4j-ui-react && npm run build
+done_when:
+- ApiDebug 根据当前 operation 展示 path、query、header、cookie 参数的待填写表单项
+- 每个参数展示名称、位置、类型、required、description、default、example、enum 信息
+- enum 参数使用可选项输入，boolean 参数使用布尔选择，array/object 参数有 JSON 输入兜底
+- 表单初始值优先使用 example，其次 default，再按类型生成空值
+- 点击发送时合并用户填写的 path/query/header/cookie 参数，不再只依赖简化输入
+notes:
+- 第一优先级，对标 Vue2 `knife4j-vue/src/views/api/Debug.vue` 的参数填写能力
+- 交互可以更现代，但同一份 OpenAPI 下 Vue2 能展示的参数项 React 也必须展示
+- 建议抽出 `operationDebugModel` 或同等工具，避免把解析逻辑堆在 ApiDebug 组件里
+
+### TASK-027
+status: blocked
+area: ui-react
+title: React 调试页补全 requestBody 多内容类型表单
+branch: codex/TASK-027-react-debug-request-body
+depends_on: TASK-026
+validation: cd knife4j-front/knife4j-ui-react && npm run build
+done_when:
+- application/json 根据 schema 生成可编辑 JSON 示例
+- application/x-www-form-urlencoded 根据 schema properties 展示字段表单
+- multipart/form-data 支持普通字段和 file/binary 文件字段
+- raw/text/xml 等未知内容类型提供可编辑文本输入兜底
+- 发送请求时按所选 content-type 正确构造 body 和 Content-Type
+notes:
+- 对标 Vue2 `initBodyParameter`、`debugSendFormRequest`、`debugSendRawRequest` 等调试链路
+- 依赖 TASK-026 的参数模型，避免 requestBody 和普通参数各自实现一套解析
+
+### TASK-028
+status: blocked
+area: ui-react
+title: React 调试发送前校验与请求预览
+branch: codex/TASK-028-react-debug-request-builder
+depends_on: TASK-027
+validation: cd knife4j-front/knife4j-ui-react && npm run build
+done_when:
+- 发送前校验 required 的 path/query/header/cookie/body 字段，缺失时定位到对应输入项
+- 调试页展示最终请求 URL、method、headers、query、body 预览
+- 支持复制等价 curl 命令
+- path 参数替换、query 拼接、header 合并、body 序列化由统一 requestBuilder 负责
+notes:
+- 对标 Vue2 `Knife4jDebugger.js` 和 Debug.vue 的请求组装职责
+- 需要保留同源 Spring Boot starter 场景优先，不在本任务扩展跨域代理能力
+
+### TASK-029
+status: blocked
+area: ui-react
+title: React 调试响应面板对齐 Vue2 能力
+branch: codex/TASK-029-react-debug-response-panel
+depends_on: TASK-028
+validation: cd knife4j-front/knife4j-ui-react && npm run build
+done_when:
+- 响应区展示 status、耗时、headers、body、错误信息
+- JSON 响应自动格式化并支持复制原始内容
+- 非 JSON 响应用文本兜底，二进制响应给出下载或不可预览提示
+- 保留最近一次请求和响应，切换文档/调试 Tab 不丢失当前填写内容
+notes:
+- 对标 Vue2 `knife4j-vue/src/views/api/DebugResponse.vue`
+- 本任务只做单接口内状态保持，跨接口历史记录可后续拆分
+
+### TASK-030
+status: blocked
+area: ui-react
+title: React schema 示例生成对齐 Vue2 递归展开
+branch: codex/TASK-030-react-schema-example-builder
+depends_on: TASK-027
+validation: cd knife4j-front/knife4j-ui-react && npm run build
+done_when:
+- 根据 schema 递归生成 JSON 示例，支持 $ref、object、array、enum、example、default
+- 循环引用不会造成死循环，重复引用类型以安全占位值截断
+- requestBody JSON 示例、ApiDoc 示例和 Models 示例复用同一生成逻辑
+- 对深层嵌套有显式 maxDepth 保护，并在代码中集中配置
+notes:
+- 对标 Vue2 `Knife4jAsync.js` 的 `findRefDefinition` 与 utils 示例值逻辑
+- Vue2 不是固定深度展开，而是递归展开并通过引用链数组防循环；React 版建议增加 maxDepth 保险
+
+### TASK-031
+status: blocked
+area: ui-react
+title: React 调试接入鉴权与全局参数
+branch: codex/TASK-031-react-debug-auth-global-param
+depends_on: TASK-028,TASK-018,TASK-019
+validation: cd knife4j-front/knife4j-ui-react && npm run build
+done_when:
+- ApiDebug 发送请求时自动合并 Authorize 中配置的认证信息
+- ApiDebug 发送请求时自动合并 GlobalParam 中配置的 header/query 参数
+- 接口级参数与全局参数冲突时有明确优先级，并在 UI 中可见
+- 用户可以在发送前预览最终合并后的 headers/query
+notes:
+- 对标 Vue2 全局参数、Authorize 与 Debug.vue 的联动能力
+- 依赖请求预览和 requestBuilder 稳定后再接入，避免参数来源混乱

--- a/knife4j-front/knife4j-ui-react/package-lock.json
+++ b/knife4j-front/knife4j-ui-react/package-lock.json
@@ -1034,6 +1034,7 @@
       "resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-6.2.0.tgz",
       "integrity": "sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.2.0",
         "@typescript-eslint/types": "6.2.0",
@@ -1172,6 +1173,7 @@
       "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1437,7 +1439,8 @@
     "node_modules/dayjs": {
       "version": "1.11.9",
       "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.9.tgz",
-      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
+      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1542,6 +1545,7 @@
       "resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.45.0.tgz",
       "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -2922,6 +2926,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmmirror.com/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2933,6 +2938,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -3249,6 +3255,7 @@
       "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3271,6 +3278,7 @@
       "resolved": "https://registry.npmmirror.com/vite/-/vite-4.4.7.tgz",
       "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.26",

--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -6,7 +6,7 @@ import {
 } from '@ant-design/icons';
 import { Layout, Button, Select, ConfigProvider, Tabs, theme } from 'antd';
 import { Resizable } from 'react-resizable';
-import { useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { GroupProvider, useGroup } from './context/GroupContext';
 import { AuthProvider } from './context/AuthContext';
 import SidebarSearchMenu from './compoents/SidebarSearchMenu';
@@ -16,6 +16,8 @@ const { Header, Sider, Content, Footer } = Layout;
 type TargetKey = React.MouseEvent | React.KeyboardEvent | string;
 
 const defaultPanes = [{ label: '主页', children: '', key: '/group/home' }];
+
+const routeKeyToMenuKey = (key: string) => key.endsWith('/doc') ? key.slice(0, -4) : key;
 
 const footerStyle: React.CSSProperties = {
   textAlign: 'center',
@@ -49,20 +51,20 @@ const AppInner: React.FC = () => {
   };
 
   const menuClick = (menu: { key: string; item: { props: { title: string } } }) => {
-    const newActiveKey = menu.key;
+    const newActiveKey = `${menu.key}/doc`;
     const tabExists = items.some((pane) => pane.key === newActiveKey);
     if (!tabExists) {
       const title = menu.item.props.title;
       setItems([...items, { label: title, children: '', key: newActiveKey }]);
     }
-    setSelectedKey(newActiveKey);
+    setSelectedKey(menu.key);
     setActiveKey(newActiveKey);
-    navigate(menu.key);
+    navigate(newActiveKey);
   };
 
   const onChange = (key: string) => {
     setActiveKey(key);
-    setSelectedKey(key);
+    setSelectedKey(routeKeyToMenuKey(key));
     navigate(key);
   };
 
@@ -82,6 +84,10 @@ const AppInner: React.FC = () => {
   };
 
   const groupOptions = groups.map((g) => ({ value: g.value, label: g.label }));
+  const tabItems = items.map((item) => ({
+    ...item,
+    children: item.key === activeKey ? <Outlet /> : item.children,
+  }));
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
@@ -102,16 +108,24 @@ const AppInner: React.FC = () => {
           width={siderWidth}
           style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
         >
-          {/* Logo */}
+          {/* Brand */}
           <div
             style={{
               display: 'flex',
               justifyContent: 'center',
               alignItems: 'center',
-              padding: '8px 0',
+              gap: 10,
+              minHeight: 56,
+              padding: collapsed ? '12px 0' : '12px 16px',
+              color: '#fff',
+              fontSize: collapsed ? 14 : 20,
+              fontWeight: 700,
+              letterSpacing: collapsed ? 0 : 0.2,
+              whiteSpace: 'nowrap',
             }}
           >
-            <img src="/knife4j-next-mark.svg" style={{ width: 32, height: 32 }} />
+            <img src="webjars/knife4j-ui-react/knife4j-next-mark.svg" style={{ width: 28, height: 28 }} />
+            {!collapsed && <span>Knife4j Next</span>}
           </div>
 
           {/* Group switcher */}
@@ -177,7 +191,7 @@ const AppInner: React.FC = () => {
               activeKey={activeKey}
               type="editable-card"
               onEdit={onEdit}
-              items={items}
+              items={tabItems}
               style={{ flex: 1, margin: '2px 2px' }}
             />
           </div>

--- a/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
@@ -89,16 +89,12 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
     <>
       <div style={{ padding: '8px 8px 4px' }}>
         <Input
+          className="knife4j-sidebar-search"
           placeholder="搜索接口名/路径..."
           prefix={<SearchOutlined style={{ color: 'rgba(255,255,255,0.45)' }} />}
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
           allowClear
-          style={{
-            backgroundColor: 'rgba(255,255,255,0.08)',
-            borderColor: 'rgba(255,255,255,0.15)',
-            color: '#fff',
-          }}
         />
       </div>
       <Menu

--- a/knife4j-front/knife4j-ui-react/src/index.css
+++ b/knife4j-front/knife4j-ui-react/src/index.css
@@ -8,6 +8,37 @@ body {
 
 }
 
+.knife4j-sidebar-search.ant-input-affix-wrapper {
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: none;
+}
+
+.knife4j-sidebar-search.ant-input-affix-wrapper:hover,
+.knife4j-sidebar-search.ant-input-affix-wrapper-focused {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: none;
+}
+
+.knife4j-sidebar-search .ant-input {
+  color: rgba(255, 255, 255, 0.88);
+  background: transparent;
+}
+
+.knife4j-sidebar-search .ant-input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.knife4j-sidebar-search .ant-input-clear-icon {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.knife4j-sidebar-search .ant-input-clear-icon:hover {
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .knife4j-logo-collapsed {
   display: inline-block;
   vertical-align: middle;

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button, Input, Select, Tabs, Table, Typography, Space,
-  Tag, Spin, Alert, Divider
+  Alert, Button, Divider, Input, Select, Space, Spin, Table, Tabs, Tag, Typography,
 } from 'antd';
 import { SendOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import type { ParameterObject, SchemaObject } from '../../types/swagger';
+import { OperationModeTabs, useCurrentOperation } from './useCurrentOperation';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
@@ -24,65 +26,129 @@ interface DebugResponse {
   body: string;
 }
 
-// Mock operation metadata — in production this would come from GroupContext / knife4j-core
-const MOCK_OPERATION = {
-  method: 'POST',
-  path: '/api/user/login',
-  summary: '用户登录',
-  queryParams: [] as ParamRow[],
-  headerParams: [
-    { key: '1', name: 'Content-Type', value: 'application/json', description: '请求类型', required: true },
-  ] as ParamRow[],
-  bodyExample: JSON.stringify({ username: 'admin', password: '123456' }, null, 2),
-};
-
 const METHOD_COLORS: Record<string, string> = {
-  GET: 'green', POST: 'blue', PUT: 'orange', DELETE: 'red',
-  PATCH: 'purple', HEAD: 'cyan', OPTIONS: 'default',
+  GET: 'green', POST: 'blue', PUT: 'orange', DELETE: 'red', PATCH: 'purple', HEAD: 'cyan', OPTIONS: 'default',
 };
 
-const paramColumns = [
-  { title: '参数名', dataIndex: 'name', key: 'name', width: 160 },
-  {
-    title: '值',
-    dataIndex: 'value',
-    key: 'value',
-    render: (_: string, record: ParamRow) => (
-      <Input
-        size="small"
-        defaultValue={record.value}
-        onChange={(e) => { record.value = e.target.value; }}
-        placeholder={record.description}
-      />
-    ),
-  },
-  { title: '说明', dataIndex: 'description', key: 'description', width: 200 },
-  {
-    title: '必填',
-    dataIndex: 'required',
-    key: 'required',
-    width: 60,
-    render: (v: boolean) => v ? <Tag color="red">是</Tag> : <Tag>否</Tag>,
-  },
-];
+function currentOrigin() {
+  return typeof window === 'undefined' ? 'http://localhost:8080' : window.location.origin;
+}
+
+function schemaExample(schema?: SchemaObject): unknown {
+  if (!schema) return undefined;
+  if (schema.$ref) return {};
+  if (schema.type === 'array') return [schemaExample(schema.items) ?? {}];
+  if (schema.type === 'integer' || schema.type === 'number') return 0;
+  if (schema.type === 'boolean') return true;
+  if (schema.type === 'string') return schema.enum?.[0] ?? '';
+  if (schema.properties) {
+    return Object.fromEntries(Object.entries(schema.properties).map(([name, prop]) => [name, schemaExample(prop)]));
+  }
+  return {};
+}
+
+function requestBodyExample(schema?: SchemaObject) {
+  if (!schema) return '';
+  return JSON.stringify(schemaExample(schema), null, 2);
+}
+
+function firstRequestSchema(content?: Record<string, { schema?: SchemaObject }>): SchemaObject | undefined {
+  if (!content) return undefined;
+  return content['application/json']?.schema ?? Object.values(content)[0]?.schema;
+}
+
+function parameterRows(parameters: ParameterObject[] | undefined, location: ParameterObject['in']): ParamRow[] {
+  return (parameters ?? [])
+    .filter((parameter) => parameter.in === location)
+    .map((parameter) => ({
+      key: `${parameter.in}-${parameter.name}`,
+      name: parameter.name,
+      value: '',
+      description: parameter.description,
+      required: Boolean(parameter.required),
+    }));
+}
+
+function replacePathParams(path: string, params: ParamRow[]) {
+  return params.reduce((url, param) => {
+    if (!param.name) return url;
+    return url.replace(`{${param.name}}`, encodeURIComponent(param.value));
+  }, path);
+}
+
+const statusColor = (status: number) => status < 300 ? 'green' : status < 400 ? 'orange' : 'red';
 
 export default function ApiDebug() {
-  const [baseUrl, setBaseUrl] = useState('http://localhost:8080');
-  const [method, setMethod] = useState(MOCK_OPERATION.method);
-  const [path, setPath] = useState(MOCK_OPERATION.path);
-  const [queryParams, setQueryParams] = useState<ParamRow[]>(MOCK_OPERATION.queryParams);
-  const [headerParams, setHeaderParams] = useState<ParamRow[]>(MOCK_OPERATION.headerParams);
-  const [body, setBody] = useState(MOCK_OPERATION.bodyExample);
+  const { loading: docLoading, swaggerDoc, operation } = useCurrentOperation();
+  const [baseUrl, setBaseUrl] = useState(currentOrigin());
+  const [method, setMethod] = useState('GET');
+  const [path, setPath] = useState('/');
+  const [pathParams, setPathParams] = useState<ParamRow[]>([]);
+  const [queryParams, setQueryParams] = useState<ParamRow[]>([]);
+  const [headerParams, setHeaderParams] = useState<ParamRow[]>([]);
+  const [body, setBody] = useState('');
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<DebugResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!operation) return;
+    const op = operation.operation;
+    const requestSchema = firstRequestSchema(op.requestBody?.content);
+    const hasJsonBody = Boolean(requestSchema);
+    setMethod(operation.method.toUpperCase());
+    setPath(operation.path);
+    setPathParams(parameterRows(op.parameters, 'path'));
+    setQueryParams(parameterRows(op.parameters, 'query'));
+    setHeaderParams([
+      ...parameterRows(op.parameters, 'header'),
+      ...(hasJsonBody ? [{ key: 'content-type', name: 'Content-Type', value: 'application/json', description: '请求体类型', required: true }] : []),
+    ]);
+    setBody(requestBodyExample(requestSchema));
+    setResponse(null);
+    setError(null);
+  }, [operation]);
+
+  const paramColumns = useMemo<ColumnsType<ParamRow>>(() => [
+    { title: '参数名', dataIndex: 'name', key: 'name', width: 180, render: (value) => <Text code>{value}</Text> },
+    {
+      title: '值',
+      dataIndex: 'value',
+      key: 'value',
+      render: (_value: string, record: ParamRow, index: number) => (
+        <Input
+          size="small"
+          value={record.value}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            const update = (rows: ParamRow[]) => rows.map((row, rowIndex) => rowIndex === index ? { ...row, value: nextValue } : row);
+            if (record.key.startsWith('path-')) setPathParams(update);
+            else if (record.key.startsWith('query-')) setQueryParams(update);
+            else setHeaderParams(update);
+          }}
+          placeholder={record.required ? '必填' : record.description}
+        />
+      ),
+    },
+    { title: '说明', dataIndex: 'description', key: 'description', width: 240 },
+    { title: '必填', dataIndex: 'required', key: 'required', width: 70, render: (value) => value ? <Tag color="red">是</Tag> : <Tag>否</Tag> },
+  ], []);
+
+  if (docLoading) {
+    return <Spin style={{ display: 'block', margin: '80px auto' }} />;
+  }
+
+  if (!swaggerDoc || !operation) {
+    return <Alert type="warning" showIcon message="未找到调试接口" description="当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。" />;
+  }
+
   const buildUrl = () => {
-    const qs = queryParams
-      .filter(p => p.name && p.value)
-      .map(p => `${encodeURIComponent(p.name)}=${encodeURIComponent(p.value)}`)
+    const urlPath = replacePathParams(path, pathParams);
+    const queryString = queryParams
+      .filter((param) => param.name && param.value)
+      .map((param) => `${encodeURIComponent(param.name)}=${encodeURIComponent(param.value)}`)
       .join('&');
-    return `${baseUrl}${path}${qs ? '?' + qs : ''}`;
+    return `${baseUrl}${urlPath}${queryString ? `?${queryString}` : ''}`;
   };
 
   const handleSend = async () => {
@@ -92,114 +158,73 @@ export default function ApiDebug() {
     const start = Date.now();
     try {
       const headers: Record<string, string> = {};
-      headerParams.filter(p => p.name).forEach(p => { headers[p.name] = p.value; });
-
+      headerParams.filter((param) => param.name && param.value).forEach((param) => { headers[param.name] = param.value; });
       const init: RequestInit = { method, headers };
       if (!['GET', 'HEAD'].includes(method) && body.trim()) {
         init.body = body;
       }
-
       const res = await fetch(buildUrl(), init);
-      const duration = Date.now() - start;
-      const resHeaders: Record<string, string> = {};
-      res.headers.forEach((v, k) => { resHeaders[k] = v; });
+      const responseHeaders: Record<string, string> = {};
+      res.headers.forEach((value, key) => { responseHeaders[key] = value; });
       const text = await res.text();
-      setResponse({ status: res.status, statusText: res.statusText, duration, headers: resHeaders, body: text });
-    } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : String(e));
+      setResponse({ status: res.status, statusText: res.statusText, duration: Date.now() - start, headers: responseHeaders, body: text });
+    } catch (reason: unknown) {
+      setError(reason instanceof Error ? reason.message : String(reason));
     } finally {
       setLoading(false);
     }
   };
 
-  const addQueryParam = () =>
-    setQueryParams(prev => [...prev, { key: String(Date.now()), name: '', value: '', description: '' }]);
-
-  const addHeaderParam = () =>
-    setHeaderParams(prev => [...prev, { key: String(Date.now()), name: '', value: '', description: '' }]);
-
   const prettyBody = () => {
     if (!response) return '';
-    try { return JSON.stringify(JSON.parse(response.body), null, 2); } catch { return response.body; }
+    try {
+      return JSON.stringify(JSON.parse(response.body), null, 2);
+    } catch {
+      return response.body;
+    }
   };
 
-  const statusColor = (s: number) => s < 300 ? 'success' : s < 400 ? 'warning' : 'error';
-
   return (
-    <div id="knife4j-api-debug-page" style={{ padding: '16px 24px' }}>
+    <div id="knife4j-api-debug-page" style={{ padding: '24px', maxWidth: 1080 }}>
+      <OperationModeTabs activeKey="debug" />
+
       <Space align="center" style={{ marginBottom: 12 }}>
         <Tag color={METHOD_COLORS[method] ?? 'default'} style={{ fontSize: 14, padding: '2px 8px' }}>
           {method}
         </Tag>
-        <Title level={5} style={{ margin: 0 }}>{MOCK_OPERATION.summary}</Title>
+        <Title level={5} style={{ margin: 0 }}>{operation.operation.summary ?? operation.path}</Title>
       </Space>
 
-      {/* URL bar */}
       <Space.Compact style={{ width: '100%', marginBottom: 16 }}>
         <Select
           value={method}
           onChange={setMethod}
           style={{ width: 110 }}
-          options={['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].map(m => ({ value: m, label: m }))}
+          options={['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].map((item) => ({ value: item, label: item }))}
         />
-        <Input
-          value={baseUrl}
-          onChange={e => setBaseUrl(e.target.value)}
-          style={{ width: 220 }}
-          placeholder="http://localhost:8080"
-        />
-        <Input
-          value={path}
-          onChange={e => setPath(e.target.value)}
-          style={{ flex: 1 }}
-          placeholder="/api/path"
-        />
-        <Button
-          type="primary"
-          icon={<SendOutlined />}
-          onClick={handleSend}
-          loading={loading}
-        >
-          发送
-        </Button>
+        <Input value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} style={{ width: 240 }} />
+        <Input value={path} onChange={(event) => setPath(event.target.value)} style={{ flex: 1 }} />
+        <Button type="primary" icon={<SendOutlined />} onClick={handleSend} loading={loading}>发送</Button>
       </Space.Compact>
 
-      {/* Params tabs */}
       <Tabs
-        defaultActiveKey="query"
+        defaultActiveKey="path"
         size="small"
         items={[
           {
+            key: 'path',
+            label: `Path (${pathParams.length})`,
+            children: <Table size="small" dataSource={pathParams} columns={paramColumns} pagination={false} rowKey="key" />,
+          },
+          {
             key: 'query',
             label: `Query (${queryParams.length})`,
-            children: (
-              <>
-                <Table
-                  size="small"
-                  dataSource={queryParams}
-                  columns={paramColumns}
-                  pagination={false}
-                  rowKey="key"
-                />
-                <Button size="small" style={{ marginTop: 8 }} onClick={addQueryParam}>+ 添加参数</Button>
-              </>
-            ),
+            children: <Table size="small" dataSource={queryParams} columns={paramColumns} pagination={false} rowKey="key" />,
           },
           {
             key: 'header',
             label: `Header (${headerParams.length})`,
-            children: (
-              <>
-                <Table
-                  size="small"
-                  dataSource={headerParams}
-                  columns={paramColumns}
-                  pagination={false}
-                  rowKey="key"
-                />
-                <Button size="small" style={{ marginTop: 8 }} onClick={addHeaderParam}>+ 添加 Header</Button>
-              </>
-            ),
+            children: <Table size="small" dataSource={headerParams} columns={paramColumns} pagination={false} rowKey="key" />,
           },
           {
             key: 'body',
@@ -207,7 +232,7 @@ export default function ApiDebug() {
             children: (
               <TextArea
                 value={body}
-                onChange={e => setBody(e.target.value)}
+                onChange={(event) => setBody(event.target.value)}
                 rows={8}
                 style={{ fontFamily: 'monospace', fontSize: 13 }}
                 placeholder="JSON request body"
@@ -219,16 +244,13 @@ export default function ApiDebug() {
 
       <Divider style={{ margin: '16px 0' }} />
 
-      {/* Response */}
       {loading && <Spin tip="请求中..." style={{ display: 'block', margin: '24px auto' }} />}
       {error && <Alert type="error" message="请求失败" description={error} showIcon />}
       {response && (
         <div>
           <Space style={{ marginBottom: 8 }}>
             <Text strong>响应状态：</Text>
-            <Tag color={statusColor(response.status) === 'success' ? 'green' : statusColor(response.status) === 'warning' ? 'orange' : 'red'}>
-              {response.status} {response.statusText}
-            </Tag>
+            <Tag color={statusColor(response.status)}>{response.status} {response.statusText}</Tag>
             <Text type="secondary">耗时：{response.duration} ms</Text>
           </Space>
           <Tabs
@@ -238,10 +260,7 @@ export default function ApiDebug() {
                 key: 'body',
                 label: '响应体',
                 children: (
-                  <pre style={{
-                    background: '#f6f8fa', padding: 12, borderRadius: 4,
-                    fontSize: 13, maxHeight: 400, overflow: 'auto', margin: 0,
-                  }}>
+                  <pre style={{ background: '#f6f8fa', padding: 12, borderRadius: 4, fontSize: 13, maxHeight: 400, overflow: 'auto', margin: 0 }}>
                     {prettyBody()}
                   </pre>
                 ),
@@ -252,7 +271,7 @@ export default function ApiDebug() {
                 children: (
                   <Table
                     size="small"
-                    dataSource={Object.entries(response.headers).map(([k, v]) => ({ key: k, name: k, value: v }))}
+                    dataSource={Object.entries(response.headers).map(([key, value]) => ({ key, name: key, value }))}
                     columns={[
                       { title: 'Header', dataIndex: 'name', key: 'name', width: 240 },
                       { title: '值', dataIndex: 'value', key: 'value' },

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -1,10 +1,9 @@
-import { Badge, Table, Tag, Typography } from 'antd';
+import { Alert, Badge, Spin, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import type { SchemaObject, SwaggerDoc } from '../../types/swagger';
+import type { ParameterObject, ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
+import { OperationModeTabs, useCurrentOperation } from './useCurrentOperation';
 
 const { Title, Paragraph, Text } = Typography;
-
-// ---- mock 数据（对标 knife4j-core Knife4jPathItemObject 结构）----
 
 interface ParamRow {
   key: string;
@@ -30,55 +29,21 @@ interface BodyRow {
   description: string;
 }
 
-const MOCK_OPERATION = {
-  url: '/api/user',
-  methodType: 'POST',
-  summary: '创建用户',
-  description: '创建一个新用户，请求体包含用户基本信息。',
-  deprecated: false,
-  parameters: [
-    { key: '1', name: 'Authorization', in: 'header', type: 'string', required: true, description: 'Bearer token' },
-  ] as ParamRow[],
-  requestBody: {
-    required: true,
-    content: {
-      'application/json': {
-        schema: {
-          $ref: '#/components/schemas/CreateUserRequest',
-        },
-      },
-    },
-  },
-  responses: [
-    { key: '200', statusCode: '200', description: '成功', schema: 'UserVO' },
-    { key: '400', statusCode: '400', description: '参数错误', schema: '' },
-    { key: '401', statusCode: '401', description: '未授权', schema: '' },
-  ] as ResponseRow[],
-};
-
-const MOCK_SWAGGER_DOC: Pick<SwaggerDoc, 'components'> = {
-  components: {
-    schemas: {
-      CreateUserRequest: {
-        type: 'object',
-        required: ['username', 'email'],
-        properties: {
-          username: { type: 'string', description: '用户名，3-20 个字符' },
-          email: { type: 'string', format: 'email', description: '邮箱地址' },
-          role: { type: 'string', description: '角色，默认 user', enum: ['user', 'admin'] },
-          age: { type: 'integer', description: '年龄' },
-        },
-      },
-    },
-  },
-};
-
-// ---- $ref 解析 ----
-
 function resolveRef(ref: string, doc: Pick<SwaggerDoc, 'components' | 'definitions'>): SchemaObject | undefined {
   const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
   if (!match) return undefined;
-  return (doc.components?.schemas ?? (doc.definitions as Record<string, SchemaObject> | undefined) ?? {})[match[1]];
+  return (doc.components?.schemas ?? doc.definitions ?? {})[match[1]];
+}
+
+function schemaName(schema?: SchemaObject): string {
+  if (!schema) return '';
+  if (schema.$ref) return schema.$ref.split('/').pop() ?? '$ref';
+  if (schema.type === 'array') return `${schemaName(schema.items) || 'object'}[]`;
+  return [schema.type, schema.format].filter(Boolean).join(' / ') || 'object';
+}
+
+function parameterType(parameter: ParameterObject): string {
+  return schemaName(parameter.schema) || [parameter.type, parameter.format].filter(Boolean).join(' / ') || '-';
 }
 
 function schemaToBodyRows(
@@ -91,147 +56,159 @@ function schemaToBodyRows(
   return Object.entries(resolved.properties).map(([name, prop]) => ({
     key: name,
     name,
-    type: prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object'),
+    type: schemaName(prop),
     required: requiredSet.has(name),
     description: prop.description ?? '',
   }));
 }
 
-// ---- 请求参数表格列 ----
+function firstRequestSchema(requestBody: { content?: Record<string, { schema?: SchemaObject }> } | undefined): SchemaObject | undefined {
+  if (!requestBody?.content) return undefined;
+  return requestBody.content['application/json']?.schema ?? Object.values(requestBody.content)[0]?.schema;
+}
+
+function responseSchema(response: ResponseObject): string {
+  const schema = response.content?.['application/json']?.schema ?? response.schema ?? Object.values(response.content ?? {})[0]?.schema;
+  return schemaName(schema);
+}
 
 const paramColumns: ColumnsType<ParamRow> = [
   {
     title: '参数名',
     dataIndex: 'name',
-    width: 160,
-    render: (v) => <Text code>{v}</Text>,
+    width: 180,
+    render: (value) => <Text code>{value}</Text>,
   },
   {
     title: '位置',
     dataIndex: 'in',
     width: 90,
-    render: (v) => {
+    render: (value) => {
       const colorMap: Record<string, string> = {
-        path: 'blue', query: 'cyan', header: 'purple', cookie: 'orange',
+        path: 'blue', query: 'cyan', header: 'purple', cookie: 'orange', body: 'geekblue', formData: 'lime',
       };
-      return <Tag color={colorMap[v] ?? 'default'}>{v}</Tag>;
+      return <Tag color={colorMap[value] ?? 'default'}>{value}</Tag>;
     },
   },
-  { title: '类型', dataIndex: 'type', width: 100 },
+  { title: '类型', dataIndex: 'type', width: 130 },
   {
     title: '必填',
     dataIndex: 'required',
-    width: 70,
-    render: (v) => v ? <Badge status="error" text="是" /> : <Badge status="default" text="否" />,
+    width: 80,
+    render: (value) => value ? <Badge status="error" text="是" /> : <Badge status="default" text="否" />,
   },
   { title: '说明', dataIndex: 'description' },
 ];
-
-// ---- 请求体字段表格列 ----
 
 const bodyColumns: ColumnsType<BodyRow> = [
   {
     title: '字段名',
     dataIndex: 'name',
-    width: 160,
-    render: (v) => <Text code>{v}</Text>,
+    width: 180,
+    render: (value) => <Text code>{value}</Text>,
   },
-  { title: '类型', dataIndex: 'type', width: 100 },
+  { title: '类型', dataIndex: 'type', width: 130 },
   {
     title: '必填',
     dataIndex: 'required',
-    width: 70,
-    render: (v) => v ? <Badge status="error" text="是" /> : <Badge status="default" text="否" />,
+    width: 80,
+    render: (value) => value ? <Badge status="error" text="是" /> : <Badge status="default" text="否" />,
   },
   { title: '说明', dataIndex: 'description' },
 ];
-
-// ---- 响应结构表格列 ----
 
 const responseColumns: ColumnsType<ResponseRow> = [
   {
     title: '状态码',
     dataIndex: 'statusCode',
-    width: 90,
-    render: (v) => {
-      const color = v.startsWith('2') ? 'success' : v.startsWith('4') ? 'warning' : 'error';
-      return <Tag color={color}>{v}</Tag>;
+    width: 100,
+    render: (value) => {
+      const color = value.startsWith('2') ? 'success' : value.startsWith('4') ? 'warning' : 'error';
+      return <Tag color={color}>{value}</Tag>;
     },
   },
   { title: '说明', dataIndex: 'description' },
   {
     title: 'Schema',
     dataIndex: 'schema',
-    render: (v) => v ? <Text code>{v}</Text> : <Text type="secondary">—</Text>,
+    width: 180,
+    render: (value) => value ? <Text code>{value}</Text> : <Text type="secondary">—</Text>,
   },
 ];
 
-// ---- 方法颜色 ----
-
 const METHOD_COLOR: Record<string, string> = {
-  GET: 'green', POST: 'blue', PUT: 'orange', DELETE: 'red',
-  PATCH: 'cyan', HEAD: 'purple', OPTIONS: 'default',
+  GET: 'green', POST: 'blue', PUT: 'orange', DELETE: 'red', PATCH: 'cyan', HEAD: 'purple', OPTIONS: 'default',
 };
 
 export default function ApiDoc() {
-  const op = MOCK_OPERATION;
-  const doc = MOCK_SWAGGER_DOC;
+  const { loading, swaggerDoc, operation } = useCurrentOperation();
 
-  const bodyRows: BodyRow[] = (() => {
-    const rb = op.requestBody;
-    if (!rb) return [];
-    const jsonContent = rb.content?.['application/json'];
-    if (!jsonContent?.schema) return [];
-    return schemaToBodyRows(jsonContent.schema as SchemaObject, doc);
-  })();
+  if (loading) {
+    return <Spin style={{ display: 'block', margin: '80px auto' }} />;
+  }
+
+  if (!swaggerDoc || !operation) {
+    return <Alert type="warning" showIcon message="未找到接口文档" description="当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。" />;
+  }
+
+  const method = operation.method.toUpperCase();
+  const op = operation.operation;
+  const parameters: ParamRow[] = (op.parameters ?? []).map((parameter, index) => ({
+    key: `${parameter.in}-${parameter.name}-${index}`,
+    name: parameter.name,
+    in: parameter.in,
+    type: parameterType(parameter),
+    required: Boolean(parameter.required),
+    description: parameter.description ?? '',
+  }));
+  const bodySchema = firstRequestSchema(op.requestBody);
+  const bodyRows = bodySchema ? schemaToBodyRows(bodySchema, swaggerDoc) : [];
+  const responses: ResponseRow[] = Object.entries(op.responses ?? {}).map(([statusCode, response]) => ({
+    key: statusCode,
+    statusCode,
+    description: response.description ?? '',
+    schema: responseSchema(response),
+  }));
 
   return (
-    <div style={{ padding: '24px', maxWidth: 960 }}>
-      {/* 接口标题行 */}
+    <div style={{ padding: '24px', maxWidth: 1080 }}>
+      <OperationModeTabs activeKey="doc" />
+
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
-        <Tag color={METHOD_COLOR[op.methodType] ?? 'default'} style={{ fontSize: 14, padding: '2px 10px' }}>
-          {op.methodType}
+        <Tag color={METHOD_COLOR[method] ?? 'default'} style={{ fontSize: 14, padding: '2px 10px' }}>
+          {method}
         </Tag>
-        <Text code style={{ fontSize: 15 }}>{op.url}</Text>
+        <Text code style={{ fontSize: 15 }}>{operation.path}</Text>
         {op.deprecated && <Tag color="red">已废弃</Tag>}
       </div>
 
-      <Title level={4} style={{ marginTop: 0 }}>{op.summary}</Title>
+      <Title level={4} style={{ marginTop: 0 }}>{op.summary ?? operation.path}</Title>
       {op.description && <Paragraph type="secondary">{op.description}</Paragraph>}
 
-      {/* 请求参数 */}
-      {op.parameters.length > 0 && (
-        <>
-          <Title level={5} style={{ marginTop: 24 }}>请求参数</Title>
-          <Table<ParamRow>
-            columns={paramColumns}
-            dataSource={op.parameters}
-            pagination={false}
-            size="small"
-            bordered
-          />
-        </>
-      )}
+      <Title level={5} style={{ marginTop: 24 }}>请求参数</Title>
+      <Table<ParamRow>
+        columns={paramColumns}
+        dataSource={parameters}
+        pagination={false}
+        size="small"
+        bordered
+        locale={{ emptyText: '无请求参数' }}
+      />
 
-      {/* 请求体 */}
-      {bodyRows.length > 0 && (
-        <>
-          <Title level={5} style={{ marginTop: 24 }}>请求体（application/json）</Title>
-          <Table<BodyRow>
-            columns={bodyColumns}
-            dataSource={bodyRows}
-            pagination={false}
-            size="small"
-            bordered
-          />
-        </>
-      )}
+      <Title level={5} style={{ marginTop: 24 }}>请求体</Title>
+      <Table<BodyRow>
+        columns={bodyColumns}
+        dataSource={bodyRows}
+        pagination={false}
+        size="small"
+        bordered
+        locale={{ emptyText: bodySchema ? '当前请求体暂不支持字段展开' : '无请求体' }}
+      />
 
-      {/* 响应结构 */}
       <Title level={5} style={{ marginTop: 24 }}>响应结构</Title>
       <Table<ResponseRow>
         columns={responseColumns}
-        dataSource={op.responses}
+        dataSource={responses}
         pagination={false}
         size="small"
         bordered

--- a/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Tabs } from 'antd';
+import { useGroup } from '../../context/GroupContext';
+import type { MenuOperation, SwaggerDoc } from '../../types/swagger';
+
+interface CurrentOperation {
+  loading: boolean;
+  swaggerDoc: SwaggerDoc | null;
+  tag?: string;
+  operation?: MenuOperation;
+}
+
+export function useCurrentOperation(): CurrentOperation {
+  const { tag, operaterId } = useParams();
+  const { loading, swaggerDoc, menuTags } = useGroup();
+
+  const operation = useMemo(() => {
+    if (!tag || !operaterId) return undefined;
+    const routeTag = decodeURIComponent(tag);
+    const routeOperationId = decodeURIComponent(operaterId);
+    const menuTag = menuTags.find((item) => item.tag === routeTag);
+    return menuTag?.operations.find((item) => {
+      const fallbackId = item.operationId ?? item.path;
+      return fallbackId === routeOperationId || item.key === `${routeTag}/${routeOperationId}`;
+    });
+  }, [menuTags, operaterId, tag]);
+
+  return {
+    loading,
+    swaggerDoc,
+    tag: tag ? decodeURIComponent(tag) : undefined,
+    operation,
+  };
+}
+
+interface OperationModeTabsProps {
+  activeKey: 'doc' | 'debug';
+}
+
+export function OperationModeTabs({ activeKey }: OperationModeTabsProps) {
+  const navigate = useNavigate();
+  const { group, tag, operaterId } = useParams();
+
+  return (
+    <Tabs
+      activeKey={activeKey}
+      onChange={(key) => {
+        if (!group || !tag || !operaterId) return;
+        navigate(`/${encodeURIComponent(group)}/${encodeURIComponent(tag)}/${encodeURIComponent(operaterId)}/${key}`);
+      }}
+      items={[
+        { key: 'doc', label: '文档' },
+        { key: 'debug', label: '调试' },
+      ]}
+    />
+  );
+}

--- a/knife4j-front/knife4j-ui-react/src/routes/router.tsx
+++ b/knife4j-front/knife4j-ui-react/src/routes/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createHashRouter } from "react-router-dom";
 import App from '../App.tsx'
 
 import Home from "../pages/Home.tsx";
@@ -12,11 +12,15 @@ import ApiHome from "../pages/api/ApiHome.tsx";
 import ApiDoc from "../pages/api/ApiDoc.tsx";
 import ApiDebug from "../pages/api/ApiDebug.tsx";
 
-const router = createBrowserRouter([
+const router = createHashRouter([
     {
         path: "/",
         element: <App />,
         children: [
+            {
+                index: true,
+                element: <Home />
+            },
             {
                 path: ":group/home",
                 element: <Home />

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/RootRedirectController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/RootRedirectController.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package com.baizhukui.knife4j.demo;
 
 import org.springframework.stereotype.Controller;


### PR DESCRIPTION
## Summary
- Switch the React doc.html entry to hash routing so Spring Boot starter deployments no longer 404 on `/doc.html`.
- Render routed API content inside opened tabs and default sidebar API clicks to the document view.
- Add a shared current-operation hook so API doc/debug pages consume real OpenAPI operations.
- Add document/debug mode tabs and a first real debug flow with parameter inputs, same-origin request sending, and response display.
- Polish the sidebar brand/search area and add the Knife4j Next logo.
- Record the Vue2 comparison setup and split follow-up React/Vue2 capability parity tasks.

## Validation
- `cd knife4j-front/knife4j-ui-react && npm run build`
- `cd knife4j && mvn -pl knife4j-demo -am -DskipTests package`
- `curl http://localhost:8080/doc.html`
- `curl http://localhost:8080/v3/api-docs`
- `curl http://localhost:8080/webjars/knife4j-ui-react/assets/index.js`

## Notes
- `package-lock.json` gained npm-generated `peer: true` metadata during build/install.
- `RootRedirectController.java` picked up the project license header from the Java formatting/build chain.
- Follow-up parity work starts with `TASK-026` for Vue2-like debug parameter forms.
