### PR TITLE
docs: 全面重写 VitePress 文档站 - 新建 5 个指南页（gateway/聚合/WebFlux/Demo/FAQ）- 新建…

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -316,3 +316,22 @@ next:
 - 建议优先执行 TASK-026：React 调试页按 OpenAPI 参数定义渲染填参表单。
 blockers:
 - none
+
+## 2026-07-03 CST
+task: docs-site-overhaul
+agent: coordinator (direct)
+branch: codex/TASK-027-docs-site-overhaul
+status: review
+summary:
+- 全面重写 VitePress 文档站，对齐并超越上游 knife4j 文档深度
+- 新建 5 个指南页：gateway 聚合、Disk/Nacos/Eureka 聚合、WebFlux 接入、Demo 预览、FAQ
+- 新建 4 个参考页：version-ref、configuration、annotations
+- 重写 5 个现有页：introduction、getting-started、migration、compatibility、modules
+- 重写 release-notes 和 roadmap
+- 更新 .vitepress/config.ts 侧边栏和导航结构
+validation:
+- cd docs-site && npm ci && npm run build → build complete in 3.20s
+next:
+- 提交 PR，等待维护者审查
+blockers:
+- none

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -42,8 +42,8 @@ export default defineConfig({
     nav: [
       { text: '快速开始', link: '/guide/getting-started' },
       { text: '功能', link: '/guide/features' },
-      { text: '兼容矩阵', link: '/reference/compatibility' },
       { text: '迁移', link: '/guide/migration' },
+      { text: '配置参考', link: '/reference/configuration' },
       { text: 'GitHub', link: 'https://github.com/songxychn/knife4j-next' }
     ],
     sidebar: [
@@ -51,23 +51,41 @@ export default defineConfig({
         text: '开始使用',
         items: [
           { text: '产品介绍', link: '/guide/introduction' },
-          { text: '功能', link: '/guide/features' },
+          { text: '功能概览', link: '/guide/features' },
           { text: '快速开始', link: '/guide/getting-started' },
+          { text: '在线 Demo', link: '/guide/demo' },
           { text: '迁移指引', link: '/guide/migration' }
         ]
       },
       {
-        text: '参考',
+        text: '接入指南',
         items: [
-          { text: '兼容矩阵', link: '/reference/compatibility' },
-          { text: '模块说明', link: '/reference/modules' },
-          { text: '发布说明', link: '/release-notes/' }
+          { text: 'Spring Cloud Gateway 聚合', link: '/guide/gateway' },
+          { text: 'Disk / Nacos / Eureka 聚合', link: '/guide/aggregation' },
+          { text: 'Spring WebFlux 接入', link: '/guide/webflux' }
         ]
       },
       {
-        text: '规划',
+        text: '参考手册',
         items: [
-          { text: '下一步路线图', link: '/roadmap/' }
+          { text: '兼容矩阵', link: '/reference/compatibility' },
+          { text: '版本参考', link: '/reference/version-ref' },
+          { text: '模块说明', link: '/reference/modules' },
+          { text: '配置参考', link: '/reference/configuration' },
+          { text: '注解速查表', link: '/reference/annotations' }
+        ]
+      },
+      {
+        text: 'FAQ',
+        items: [
+          { text: '常见问题', link: '/guide/faq' }
+        ]
+      },
+      {
+        text: '项目',
+        items: [
+          { text: '发布说明', link: '/release-notes/' },
+          { text: '路线图', link: '/roadmap/' }
         ]
       }
     ],

--- a/docs-site/guide/aggregation.md
+++ b/docs-site/guide/aggregation.md
@@ -1,0 +1,269 @@
+---
+title: Aggregation 聚合
+---
+
+# Aggregation 聚合（knife4j-aggregation-*-starter）
+
+`knife4j-aggregation-spring-boot-starter`（Boot 2 / javax）和 `knife4j-aggregation-jakarta-spring-boot-starter`（Boot 3 / jakarta）提供**独立的聚合应用**方案：
+
+- 启动一个**专门用来聚合的 Servlet 应用**，读取若干下游服务的 OpenAPI 文档，合并成一套 `doc.html`。
+- 支持 **5 种数据源**：本地文件（Disk）、HTTP 直连（Cloud）、Nacos、Eureka、腾讯北极星（Polaris）。
+- 与 [Gateway starter](./gateway) 二选一：Gateway 跑在 WebFlux 技术栈内嵌；Aggregation 是独立 Servlet 应用。
+
+## 何时选 aggregation 而不是 gateway
+
+- 你的微服务**不经过** Spring Cloud Gateway（或 Gateway 用的是别的技术栈）。
+- 你希望聚合应用**完全独立部署**，不参与业务流量。
+- 你想**从本地静态文件**加载历史版本的 `swagger.json` 做对比。
+
+## 依赖
+
+Spring Boot 3（Jakarta）：
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-web</artifactId>
+</dependency>
+```
+
+Spring Boot 2（javax）换成 `knife4j-aggregation-spring-boot-starter`。
+
+聚合服务 `Application` 类：
+
+```java
+@SpringBootApplication
+public class AggregationApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AggregationApplication.class, args);
+    }
+}
+```
+
+启动后访问 `http://localhost:8080/doc.html`。
+
+## 公共配置骨架
+
+```yaml
+knife4j:
+  enable-aggregation: true  # 开启聚合总开关
+  basic-auth:               # 可选：保护聚合 UI 的 Basic 认证
+    enable: true
+    username: admin
+    password: ${KNIFE4J_AGGREGATION_PASSWORD:change-me}
+```
+
+然后根据数据源类型选择 **disk / cloud / nacos / eureka / polaris** 的一种（或多种混合）。
+
+## 模式 1：Disk（本地文件）
+
+从磁盘或 classpath 读取 OpenAPI JSON 文件，**不发请求**。
+
+```yaml
+knife4j:
+  enable-aggregation: true
+  disk:
+    enable: true
+    routes:
+      - name: 用户服务
+        location: classpath:swagger/user-service.json
+        swagger-version: "3.0"
+        debug-url: http://user-service:9001
+        service-path: /user-service
+        order: 1
+      - name: 订单服务
+        location: /data/swagger/order-service.json
+        swagger-version: "2.0"
+        debug-url: http://order-service:9002
+        order: 2
+```
+
+字段含义：
+
+| 字段 | 说明 |
+| --- | --- |
+| `name` | UI 中该分组的显示名称 |
+| `location` | 本地文件路径或 classpath 路径 |
+| `swagger-version` | `"2.0"` 或 `"3.0"` |
+| `debug-url` | 在 UI 发起调试时请求真实落到的地址 |
+| `service-path` | 有 Gateway 前置时追加的 basePath（避免 UI 展示路径与实际不一致） |
+| `order` | 排序，越小越靠前 |
+
+::: info `host` 字段自 v4.0.0 废弃
+`host` 已被 `debug-url` 替代。历史配置仍然可用（但以 `debug-url` 为准）。
+:::
+
+## 模式 2：Cloud（HTTP 直连）
+
+聚合服务作为 HTTP 客户端，定时从下游拉 `/v2/api-docs` 或 `/v3/api-docs`：
+
+```yaml
+knife4j:
+  enable-aggregation: true
+  cloud:
+    enable: true
+    routes:
+      - name: 用户服务
+        uri: http://user-service:9001
+        location: /v3/api-docs
+        swagger-version: "3.0"
+        service-name: user-service
+        order: 1
+      - name: 订单服务
+        uri: http://order-service:9002
+        location: /v2/api-docs
+        swagger-version: "2.0"
+        order: 2
+        route-auth:        # 下游 doc.html 被 Basic 保护时
+          enable: true
+          username: admin
+          password: secret
+```
+
+这是最常用的模式，适合 K8s 集群内部网络。
+
+## 模式 3：Nacos
+
+```yaml
+knife4j:
+  enable-aggregation: true
+  nacos:
+    enable: true
+    service-url: http://nacos:8848/nacos
+    # 若 Nacos 本身开启鉴权（参考 v2.0.9+）
+    service-auth:
+      enable: true
+      username: nacos
+      password: ${NACOS_PASSWORD}
+    token-expire: 18000
+    # 访问下游服务时使用的公共 Basic（仅用于 swagger 接口）
+    route-auth:
+      enable: false
+    routes:
+      - name: 用户服务
+        service-name: user-service
+        namespace: public
+        group-name: DEFAULT_GROUP
+        location: /v3/api-docs
+        swagger-version: "3.0"
+        service-path: /user-service
+        order: 1
+```
+
+聚合服务在启动时从 Nacos 拿实例列表，定时从实例拉 API 文档。注意：
+
+- `service-auth` 只影响 Nacos OpenAPI 的鉴权。
+- 默认 `token-expire = 18000` 秒，到期前会自动刷新（阈值 100s）。
+
+## 模式 4：Eureka
+
+```yaml
+knife4j:
+  enable-aggregation: true
+  eureka:
+    enable: true
+    service-url: http://eureka:8761/eureka
+    # 若 Eureka Server 开启了 Basic
+    service-auth:
+      enable: false
+    routes:
+      - name: 用户服务
+        service-name: USER-SERVICE
+        location: /v3/api-docs
+        swagger-version: "3.0"
+        order: 1
+```
+
+Eureka 客户端以 `serviceName`（默认大写）匹配实例。
+
+## 模式 5：Polaris（腾讯北极星）
+
+```yaml
+knife4j:
+  enable-aggregation: true
+  polaris:
+    enable: true
+    server-addr: grpc://polaris-server:8091
+    namespace: default
+    routes:
+      - name: 用户服务
+        service-name: user-service
+        location: /v3/api-docs
+        swagger-version: "3.0"
+        order: 1
+```
+
+Polaris 使用 gRPC 协议，聚合服务作为 Polaris SDK 客户端。
+
+## HTTP 连接参数调优
+
+```yaml
+knife4j:
+  connection-setting:
+    socket-timeout: 60000       # 毫秒
+    connect-timeout: 10000      # 毫秒
+    connection-request-timeout: 10000
+    max-total: 200              # 连接池总数
+    default-max-per-route: 20   # 每个目标地址最多连接数
+```
+
+这些参数影响 cloud / nacos / eureka / polaris 四种模式（disk 不走 HTTP）。
+
+## 保护聚合 UI
+
+```yaml
+knife4j:
+  basic-auth:
+    enable: true
+    username: admin
+    password: ${KNIFE4J_AGGREGATION_PASSWORD:change-me}
+```
+
+聚合应用应该跑在**内部网络**或外挂 Nginx 层做额外防护。`basic-auth` 只是一道基础屏障。
+
+## 验证
+
+```bash
+# 启动聚合应用
+mvn spring-boot:run -f aggregation-app/pom.xml
+
+# 访问聚合入口
+curl -I http://localhost:8080/doc.html
+
+# 查看聚合的分组列表（开发调试）
+curl http://localhost:8080/swagger-resources
+```
+
+## 排错清单
+
+| 现象 | 可能原因 |
+| --- | --- |
+| UI 显示 "加载资源失败" | 下游 `/v3/api-docs` 不通、聚合跨域、Basic 认证失败 |
+| 分组列表为空 | `knife4j.enable-aggregation=true` 忘加；或 `*.enable=false` |
+| `route-auth` 不生效 | `route-auth.enable=true` 是必须的，否则配置被忽略 |
+| Nacos 模式拿不到实例 | `service-url` 是否带 `/nacos` 后缀；namespace 对不对；token 是否过期（重启服务） |
+| 聚合后调试请求都打到聚合服务本身 | 配置 `service-path`（Gateway 场景）或确保 `debug-url` 指向下游 |
+
+## 和 Gateway starter 如何二选一
+
+| 对比项 | Gateway starter | Aggregation starter |
+| --- | --- | --- |
+| 运行形态 | 嵌入 Spring Cloud Gateway 进程 | 独立 Spring Boot 应用 |
+| 技术栈 | WebFlux | Servlet（spring-boot-starter-web） |
+| 数据源 | 服务发现 / 手动路由 | Disk / Cloud / Nacos / Eureka / Polaris |
+| 典型场景 | 已有 Gateway，顺带聚合 | 无 Gateway 或想独立部署聚合 |
+| 是否支持本地 JSON | ❌ | ✅（Disk 模式） |
+| 是否参与生产业务流量 | 是（Gateway 同进程） | 否 |
+
+## 相关
+
+- [Gateway 聚合](./gateway)：另一种形态。
+- [配置参考 / knife4j aggregation](../reference/configuration#aggregation)：全部 YAML 选项。
+- [模块说明](../reference/modules)：`knife4j-aggregation-*-starter` 在仓库里的位置。
+

--- a/docs-site/guide/demo.md
+++ b/docs-site/guide/demo.md
@@ -1,0 +1,117 @@
+---
+title: Demo 预览
+---
+
+# Demo 预览（knife4j-demo）
+
+`knife4j-demo` 是仓库内置的最小可运行工程，用来：
+
+1. 作为**官方站点在线预览**的后端。
+2. 让你在本地一条命令看到 `knife4j-next` 跑起来长什么样。
+3. 提供一个现成的 `@Schema`、分页、CRUD 的参考工程。
+
+## 工程位置
+
+- 模块路径：`knife4j/knife4j-demo`
+- 主类：`com.baizhukui.knife4j.demo.DemoApplication`
+- Controller：`com.baizhukui.knife4j.demo.UserController`
+- DTO：`com.baizhukui.knife4j.demo.dto.*`
+
+## 技术栈
+
+| 组件 | 版本 | 说明 |
+| --- | --- | --- |
+| Spring Boot | `3.4.5` | demo `pom.xml` 显式声明 |
+| knife4j starter | `knife4j-openapi3-jakarta-spring-boot-starter`（本仓库当前版本） | `4.6.0.3` |
+| JDK | 17 | Dockerfile base image `eclipse-temurin:17-jre-alpine` |
+| springdoc-openapi-jakarta | `2.8.9` | 由 starter 管理 |
+
+## 快速运行（三种方式）
+
+### 方式 A：IDE 里跑
+
+1. 打开仓库根目录，让 IDE 识别 Maven 多模块。
+2. 运行 `com.baizhukui.knife4j.demo.DemoApplication`。
+3. 浏览器打开 `http://localhost:8080/doc.html`。
+
+### 方式 B：命令行 Maven
+
+```bash
+cd knife4j
+./mvnw -pl knife4j-demo -am spring-boot:run
+```
+
+或构建可执行 jar 后直接运行：
+
+```bash
+./mvnw -pl knife4j-demo -am package -DskipTests
+java -jar knife4j-demo/target/knife4j-demo-*.jar
+```
+
+### 方式 C：Docker Compose
+
+仓库自带 `knife4j/knife4j-demo/docker-compose.yml`，使用 GitHub Container Registry 上的镜像：
+
+```yaml
+services:
+  knife4j-demo:
+    image: ghcr.io/songxychn/knife4j-next/knife4j-demo:latest
+    container_name: knife4j-demo
+    restart: unless-stopped
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+```
+
+启动：
+
+```bash
+cd knife4j/knife4j-demo
+docker compose up -d
+# 默认映射容器内 8080，可按需在 compose 中加 ports
+```
+
+该镜像由 `.github/workflows/deploy.yml` 随 `master` 每次推送自动构建并推到 `ghcr.io`，结合 `watchtower` 可以做到官方站点的自动升级。
+
+## 访问入口
+
+启动后（容器默认不暴露端口，本地开发建议用方式 A/B）：
+
+| 入口 | 说明 |
+| --- | --- |
+| `http://localhost:8080/` | 重定向到 `/doc.html`（由 `RootRedirectController` 提供） |
+| `http://localhost:8080/doc.html` | Knife4j UI（新 React 前端） |
+| `http://localhost:8080/v3/api-docs` | 原始 OpenAPI JSON |
+| `http://localhost:8080/swagger-ui.html` | springdoc 默认 Swagger UI（可对比） |
+
+## Demo 里展示了什么
+
+`UserController` 演示了 OpenAPI3 注解下最常见的用法，全部用 `io.swagger.v3.oas.annotations.*`：
+
+- `@Tag` 分组
+- `@Operation` + `@Parameter` + `@RequestBody` 描述接口与参数
+- `@Schema` 描述 DTO 字段
+- 分页、CRUD、路径参数、请求体参数组合
+
+建议作为你自己工程接入 knife4j 的**基线模板**。
+
+## 在线预览
+
+官方站点预留的在线预览地址：
+
+- `https://demo.knife4jnext.com/doc.html`（如对应域名已上线）
+- 版本跟随 `master`，每次 `master` 合并后由 `watchtower` 自动刷新
+
+如果访问失败，优先在本地跑一遍，以避免把预览环境问题当成功能问题。
+
+## 拿来改的最小清单
+
+如果你想拷贝这个 demo 做自己的工程：
+
+1. 把 `knife4j/knife4j-demo` 复制到独立仓库。
+2. 改 `pom.xml` 的 `groupId`/`artifactId`/`name`。
+3. 替换 package `com.baizhukui.knife4j.demo` 为你的命名空间。
+4. 按需调整 `application.yml` 的 `springdoc.group-configs.packages-to-scan`。
+5. 保留 `knife4j.enable: true` 以启用 knife4j 增强。
+
+更详细的接入说明见 [快速开始](./getting-started)。
+

--- a/docs-site/guide/faq.md
+++ b/docs-site/guide/faq.md
@@ -1,0 +1,370 @@
+---
+title: 常见问题
+---
+
+# 常见问题（FAQ）
+
+## 关于本 fork
+
+### 和 upstream knife4j 是什么关系
+
+`knife4j-next` 是 [`xiaoymin/knife4j`](https://github.com/xiaoymin/knife4j) 的社区维护 fork。功能语义完全兼容，只改了 Maven `groupId`（`com.github.xiaoymin` → `com.baizhukui`）。详见 [产品介绍](./introduction)。
+
+### 如何从 `com.github.xiaoymin` 切到 `com.baizhukui`
+
+改 Maven 依赖 `groupId`，业务代码不动。详见 [迁移指引](./migration)。
+
+### 可以回滚到 upstream 吗
+
+可以。`com.github.xiaoymin:knife4j-*` 在 Maven Central 仍在，业务代码从未修改，只需在 `pom.xml` 里把坐标改回去。
+
+### upstream 文档还有效吗
+
+**大多数情况仍然有效**。upstream 文档 <https://doc.xiaominfo.com/> 上关于 `@ApiOperationSupport`、`knife4j.*` 配置、UI 行为的内容本 fork 完全兼容。两个例外：
+
+1. 版本发布节奏：upstream 最新是 `4.6.0`，fork 是 `4.6.0.3`；fork 额外带 3 个 patch 的兼容/安全修复。
+2. 新 React 前端覆盖范围：upstream Vue2 前端上有的 UI 功能（Postman 导出、afterScript、自定义 Footer、版本小蓝点等），本 fork 的新 React 前端尚未全部覆盖。详见下文 [React 配置不生效](#react-setting-not-effective)。
+
+### 本 fork 相比 upstream 多了哪些修复
+
+| 版本 | 修复内容 | 对应 upstream issue |
+| --- | --- | --- |
+| `4.6.0.1` | `/v2/api-docs;xxx` 分号绕过 Basic 认证漏洞 | [#886](https://github.com/xiaoymin/knife4j/issues/886) |
+| `4.6.0.2` | Gateway context-path 导致 host 缺少斜杠 | [#954](https://github.com/xiaoymin/knife4j/issues/954) |
+| `4.6.0.3` | Spring Boot 3.4/3.5 兼容（springdoc 版本升级） | [#874](https://github.com/xiaoymin/knife4j/issues/874) [#882](https://github.com/xiaoymin/knife4j/issues/882) [#913](https://github.com/xiaoymin/knife4j/issues/913) |
+| `4.6.0.3` | 新 React 前端集成 | — |
+
+## 访问与路径
+
+### SpringBoot 访问 `doc.html` 404 {#doc-html-404}
+
+按顺序排查：
+
+1. **starter 是否真的在 classpath**：`mvn dependency:tree | grep knife4j`。
+2. **`knife4j.enable=true` 是否加了**（openapi2 starter 需要，openapi3 starter 可选）。
+3. **是否有 `server.servlet.context-path`**？应该访问 `http://host:port/<context-path>/doc.html`。
+4. **是否有全局 `WebMvcConfigurer` 把 `/webjars/**` 排除了静态资源处理**？如果项目自定义了 `WebMvcConfigurer`，需要手动添加：
+
+   ```java
+   @Override
+   public void addResourceHandlers(ResourceHandlerRegistry registry) {
+       registry.addResourceHandler("doc.html")
+               .addResourceLocations("classpath:/META-INF/resources/");
+       registry.addResourceHandler("/webjars/**")
+               .addResourceLocations("classpath:/META-INF/resources/webjars/");
+   }
+   ```
+
+5. **是否同时引入了冲突的 Swagger UI**（`springfox-boot-starter`、`springdoc-openapi-ui` 非 Jakarta 版）？
+6. **Spring Security / Shiro 是否拦截了 `/doc.html`、`/webjars/**`、`/v3/api-docs/**`**？需要放行这些路径。
+
+### WebFlux 环境下 `doc.html` 404
+
+WebFlux 没有 Servlet，不能混入 `spring-boot-starter-web`。确保：
+
+1. 使用 `knife4j-openapi3-webflux-jakarta-spring-boot-starter`（而非 WebMvc 版）。
+2. 不要引入 `spring-boot-starter-web`，只保留 `spring-boot-starter-webflux`。
+3. 如果用了 Spring Cloud Gateway，不需要 webflux starter，改用 `knife4j-gateway-spring-boot-starter`。详见 [WebFlux 接入](./webflux) 和 [Gateway 聚合](./gateway)。
+
+### Spring MVC（非 Boot）工程看不到接口文档
+
+通用的非 Boot Spring MVC 工程需要手动配置静态资源：
+
+```xml
+<mvc:resources mapping="/doc.html" location="classpath:/META-INF/resources/"/>
+<mvc:resources mapping="/webjars/**" location="classpath:/META-INF/resources/webjars/"/>
+<mvc:resources mapping="/swagger-ui/**" location="classpath:/META-INF/resources/webjars/swagger-ui/"/>
+```
+
+以及 `<mvc:default-servlet-handler/>` 和 `<mvc:annotation-driven/>`。
+
+### Nginx 反向代理后路径不对
+
+启用 `server.forward-headers-strategy: framework` 让 Spring 感知 `X-Forwarded-*` 头：
+
+```yaml
+server:
+  forward-headers-strategy: framework
+```
+
+并在 Nginx 透传相关头：
+
+```nginx
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+```
+
+### `/doc.html` 需要带前缀
+
+浏览器访问时仍然可以只写 `/doc.html`，但如果你想让前端 API 请求自动走前缀，请用 `server.servlet.context-path`。
+
+## 生产环境 & 安全
+
+### 生产环境怎么禁用 `doc.html`
+
+```yaml
+knife4j:
+  production: true
+```
+
+这会让 `ProductionSecurityFilter` 对 `/doc.html`、`/v2/api-docs`、`/v3/api-docs`、`/swagger-resources`、`/swagger-ui` 等入口返回 403。
+
+> 仅在 WebMvc（Servlet）starter 中生效。WebFlux starter 没有该过滤器，建议在网关层或 Spring Security 配置中限制访问。
+
+### 只想给部分用户看文档
+
+启用 Basic 认证：
+
+```yaml
+knife4j:
+  basic:
+    enable: true
+    username: admin
+    password: ${DOC_PASSWORD}
+```
+
+### 有安全修复吗
+
+`4.6.0.1` 修复了 `/v2/api-docs;xxx` 利用分号绕过 `knife4j.basic` 认证的问题（[#886](https://github.com/xiaoymin/knife4j/issues/886)）。**生产环境建议至少升到 `4.6.0.1`**，更稳妥是 `4.6.0.3`。
+
+### CSP（Content-Security-Policy）限制导致 UI 白屏
+
+React 前端使用的是**非 inline** 脚本，通常 CSP `script-src 'self'` 即可。如果配置了 `default-src 'none'`，需要追加：
+
+```
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data:;
+font-src 'self' data:;
+connect-src 'self';
+```
+
+`'unsafe-inline'` 对 style 暂时需要（前端组件库用到 style 插入）；后续新前端会移除该依赖。
+
+## 配置不生效
+
+### 为什么我的 `knife4j.setting.*` 配置不生效 {#react-setting-not-effective}
+
+如果你用的是 `knife4j-openapi3-spring-boot-starter` 或 `knife4j-openapi3-jakarta-spring-boot-starter`（也就是新 React 前端），**以下 UI 配置暂不生效**：
+
+- `knife4j.setting.enable-debug=false`
+- `knife4j.setting.enable-search=false`
+- `knife4j.setting.enable-open-api=false`
+- `knife4j.setting.enable-version=true`
+- `knife4j.setting.enable-footer=false` / `enable-footer-custom`
+- `knife4j.setting.enable-home-custom` / `home-custom-path`
+- `knife4j.setting.swagger-model-name`
+- `knife4j.setting.enable-after-script`
+- `knife4j.setting.enable-reload-cache-parameter`
+- `knife4j.setting.enable-host` / `enable-host-text`
+
+原因：React 新前端当前**不读取**后端注入到 OpenAPI extension 的 `x-knife4j.setting` 字段。后端 `ProductionSecurityFilter`、`knife4j.basic`、`knife4j.documents` 等服务端侧能力不受影响。
+
+过渡方案：
+
+- 如果你重度依赖这些 UI 能力，暂时使用 `knife4j-openapi2-spring-boot-starter`（Vue2 UI），或 upstream `com.github.xiaoymin` 的同名依赖。
+- 或者在 [路线图](../roadmap/#react-ui-coverage) 跟进覆盖进度。
+
+### `knife4j.enable=true` 了但 UI 上看不到接口
+
+通常是 springdoc 的 `packages-to-scan` 没配好，springdoc 不知道扫哪些 Controller：
+
+```yaml
+springdoc:
+  group-configs:
+    - group: default
+      paths-to-match: /**
+      packages-to-scan: com.your.project
+```
+
+### `No OpenAPI resource found for group: swagger-config` {#no-openapi-resource-found}
+
+OpenAPI3 starter 下，前端会请求 `/v3/api-docs/swagger-config`。如果 404，通常是：
+
+1. **未引入 `springdoc-openapi-*-ui` 依赖**——应由 starter 自动带入。如果你用的是本 fork `4.6.0.3`，starter 已包含该依赖，无需手动添加。如果你用的是 upstream `4.0.0`，需要手动加 `springdoc-openapi-ui`（已在 `4.1.0` 修复）。
+2. **网关层把 `/v3/api-docs/**` 拦截了**。
+3. **应用启动失败**，接口还未注册。
+
+排查命令：
+
+```bash
+curl -I http://localhost:8080/v3/api-docs
+curl -I http://localhost:8080/v3/api-docs/swagger-config
+```
+
+### `4.1.0` 之后接口响应显示 Base64 编码
+
+如果你自定义了 `WebMvcConfigurer#configureMessageConverters`（比如加入 FastJson），springdoc 的 OpenAPI 接口可能返回 Base64 编码内容。解决方法是在自定义 converter 列表末尾追加 `ByteArrayHttpMessageConverter`：
+
+```java
+@Configuration
+public class CommonWebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(fastJsonHttpMessageConverter());
+        // 必须追加，否则 springdoc-openapi 接口会响应 Base64 编码
+        // 参考 https://github.com/springdoc/springdoc-openapi/issues/2143
+        converters.add(new ByteArrayHttpMessageConverter());
+    }
+}
+```
+
+使用最新版本（`4.6.0.3`）且未自定义 MessageConverter 时不会遇到此问题。
+
+### `@ParameterObject` 展开的参数在 UI 上是扁平列表
+
+这是 springdoc 默认行为。`@ParameterObject` 会把对象内每个字段展开成独立 query 参数。这是**设计如此**，不是 bug。如果你希望作为整体 JSON 传入，用 `@RequestBody`。
+
+### Spring Boot 3.4 / 3.5 启动报错
+
+如果你用的是 upstream `4.5.0` 或更早版本，在 Boot 3.4+ 上会遇到 `NoSuchMethodError` 或 `ClassNotFoundException`。本 fork `4.6.0.3` 已将 springdoc-openapi 升级到 `2.8.9`，解决了此问题。
+
+修复方法：升级到 `com.baizhukui:knife4j-openapi3-jakarta-spring-boot-starter:4.6.0.3`。
+
+## 全局响应封装导致文档异常
+
+### Knife4j 文档请求异常弹窗
+
+如果你在项目中对所有 Controller 返回值做了统一封装（比如 `Result<T>` 包装），可能导致 `/v3/api-docs` 或 `/swagger-resources` 的响应也被包装，使得前端解析失败。
+
+**症状**：打开 `doc.html` 弹出"Knife4j文档请求异常"。
+
+**排查**：
+
+1. 用浏览器 F12 → Network 查看 `/v3/api-docs/swagger-config` 和 `/v3/api-docs` 的响应。
+2. 如果响应体被 `{"code": 0, "data": {...}}` 之类的外壳包裹，说明全局封装拦截了文档接口。
+
+**解决**：在全局封装逻辑中排除文档相关路径：
+
+```java
+@Component
+public class GlobalResponseWrapper implements ResponseBodyAdvice<Object> {
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            ServerHttpRequest request, ServerHttpResponse response) {
+        String path = request.getURI().getPath();
+        // 排除 OpenAPI 文档相关接口
+        if (path.startsWith("/v3/api-docs") || path.startsWith("/v2/api-docs")
+                || path.startsWith("/swagger-resources") || path.startsWith("/swagger-ui")) {
+            return body;
+        }
+        // 正常封装
+        return Result.ok(body);
+    }
+}
+```
+
+### `/v3/api-docs` 返回非法 JSON
+
+另一种常见情况：List 类型字段的 `@ApiModelProperty(example = "{'id':'xxx'}")` 生成了非法 JSON。springdoc 在解析时可能把 example 原样写入，导致前端 `JSON.parse()` 失败。
+
+**解决**：移除集合属性上的 `example`，让框架自动生成。或确保 example 是合法 JSON。
+
+## 注解 / 字段说明
+
+### `@DynamicParameters` 怎么不生效了
+
+`@DynamicParameters` 和 `@DynamicResponseParameters` 是 Springfox 专属特性。在：
+
+- `knife4j-openapi2-spring-boot-starter`：**仍然生效**。
+- `knife4j-openapi3-spring-boot-starter` / `knife4j-openapi3-jakarta-spring-boot-starter`：**已在 upstream v4.0 弃用**，注解保留但不处理。
+
+迁到 OpenAPI3 后，请改用实体类：
+
+```java
+public class UserCreateRequest {
+    @Schema(description = "用户名", example = "alice")
+    private String name;
+
+    @Schema(description = "年龄", example = "18")
+    private Integer age;
+}
+```
+
+### `@ApiOperationSupport(ignoreParameters = ...)` 不生效
+
+同上，`ignoreParameters` / `includeParameters` 是 Springfox Plugin 特性，只在 openapi2 starter 生效。在 openapi3 系列中只有 `author` 和 `order` 两个属性被处理。
+
+### Swagger 字段属性说明不显示
+
+OpenAPI3 下使用 `@Schema(description = "...")` 注解字段。OpenAPI2 下使用 `@ApiModelProperty(value = "...")`。注意**不要混用**。
+
+### 文件上传没有文件选择控件
+
+Controller 方法参数要么是 `MultipartFile`（webmvc）要么是 `FilePart`（webflux）。在 OpenAPI3 下加 `@RequestPart` 注解：
+
+```java
+@PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+public void upload(@RequestPart("file") MultipartFile file) { ... }
+```
+
+### `@Api` 和 `@ApiModel` 能不能用
+
+- OpenAPI2 starter（Springfox）：`@Api`、`@ApiModel`、`@ApiModelProperty`、`@ApiOperation` 等正常使用。
+- OpenAPI3 starter（springdoc）：这些注解**不建议使用**。springdoc 可以识别部分 Swagger 1.x 注解但行为不可预测，请统一使用 `@Tag`、`@Schema`、`@Operation`。
+
+## 异常
+
+### `java.lang.NumberFormatException: For input string: ""`
+
+通常因为 `@ApiModelProperty(example = "")` 或 `@ApiImplicitParam(example = "")` 给了空字符串但字段是数值类型。把 `example` 改成合法数字或移除。
+
+### `NoSuchMethodError` 相关 Springfox
+
+多为 `springfox-swagger2` 不同版本混用。本 fork 使用 `springfox 2.10.5`，确保不要手动引入其他版本。
+
+如果是 Boot 3.4+ 的 `NoSuchMethodError`，参见上文 [Spring Boot 3.4 / 3.5 启动报错](#spring-boot-34-35)。
+
+### Spring Boot 3.4 / 3.5 启动报错 {#spring-boot-34-35}
+
+upstream `4.5.0` 及更早版本在 Boot 3.4+ 上会遇到 `NoSuchMethodError` 或 `ClassNotFoundException`。本 fork `4.6.0.3` 已将 springdoc-openapi 升级到 `2.8.9`，解决了此问题。
+
+**修复**：升级到 `com.baizhukui:knife4j-openapi3-jakarta-spring-boot-starter:4.6.0.3`。
+
+### `Servlet` 相关的 ClassNotFoundException（WebFlux 环境）
+
+不要在 WebFlux 项目中引入 `spring-boot-starter-web` 或 WebMvc 版 starter。WebFlux 项目使用 `knife4j-openapi3-webflux-*-spring-boot-starter`。
+
+## Gateway & 聚合
+
+### Gateway 聚合后看不到子服务接口
+
+1. 确认子服务的 `/v3/api-docs` 在 Gateway 内网可达。
+2. Gateway starter 使用 DISCOVER 策略时，确认 `spring.cloud.discovery.reactive.enabled=true`。
+3. 使用 MANUAL 策略时，确认 `knife4j.gateway.routes` 里的 `service-name` 和 `url` 配置正确。
+4. 详见 [Gateway 聚合](./gateway)。
+
+### 聚合模式（Disk / Cloud / Nacos / Eureka / Polaris）怎么选
+
+- **Disk**：开发/测试环境，Swagger JSON 文件在本地 classpath。
+- **Cloud**：通过 Spring Cloud Discovery 发现服务。
+- **Nacos**：从 Nacos 注册中心拉取服务列表。
+- **Eureka**：从 Eureka 注册中心拉取服务列表。
+- **Polaris**：从北极星注册中心拉取服务列表。
+
+详见 [独立聚合](./aggregation)。
+
+## 其他
+
+### 历史旧版 FAQ 在哪
+
+upstream `doc.xiaominfo.com` 仍在提供完整的历史 FAQ，如 Springfox 2.9.2 的相关异常、离线文档 Markdown 格式错乱等。fork 完全兼容，相关问题可以直接参考：
+
+- [upstream FAQ 索引](https://doc.xiaominfo.com/docs/faq)
+- [upstream Springfox 2.9.2 NoSuchMethodError](https://doc.xiaominfo.com/docs/faq/sp-nmerror)
+- [upstream 文件上传问题](https://doc.xiaominfo.com/docs/faq/upload-error)
+- [upstream Knife4j文档请求异常](https://doc.xiaominfo.com/docs/faq/knife4j-exception)
+
+### 还是没解决？
+
+- 查 [GitHub Issues](https://github.com/songxychn/knife4j-next/issues)
+- 提 issue 时请带上：knife4j 版本、Spring Boot 版本、是否用 jakarta、关键配置片段、最小复现。
+

--- a/docs-site/guide/gateway.md
+++ b/docs-site/guide/gateway.md
@@ -1,0 +1,210 @@
+---
+title: Gateway 聚合
+---
+
+# Gateway 聚合（knife4j-gateway-spring-boot-starter）
+
+`knife4j-gateway-spring-boot-starter` 让 Spring Cloud Gateway 充当聚合入口：一次访问 `https://gateway/doc.html`，下面挂着所有下游微服务的 OpenAPI 分组。
+
+它解决三件事：
+
+1. 下游服务不用各自暴露 `doc.html`，开发期也能走统一域名访问。
+2. Gateway 统一加 Basic 认证，保护文档。
+3. 服务新增 / 下线不用改前端，通过服务发现自动刷新。
+
+## 适用场景
+
+- 项目使用 Spring Cloud Gateway（WebFlux 技术栈）。
+- 下游服务已经用任一 knife4j starter 暴露 `/v2/api-docs` 或 `/v3/api-docs`。
+- 需要在 Gateway 层面合并、排序、打分组。
+
+::: info 和 knife4j-aggregation-*-starter 的区别
+`knife4j-gateway-*-starter` 只跑在 Gateway 进程里（WebFlux）；`knife4j-aggregation-*-starter` 可以独立部署成聚合服务（Servlet）。二者不要在同一 Gateway 里同时启用。[Aggregation](./aggregation) 里有详细对比。
+:::
+
+## 最小依赖
+
+Gateway 主工程 `pom.xml`：
+
+```xml
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-gateway</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-gateway-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+::: warning 不要把 knife4j 的 openapi starter 加到 Gateway
+`knife4j-gateway-starter` 不是 UI 生成器，而是路由+聚合。Gateway 本身**不生成** OpenAPI 文档，只**汇聚**下游的。
+:::
+
+## 两种策略
+
+Starter 通过 `knife4j.gateway.strategy` 切换：
+
+| 策略 | 值 | 场景 |
+| --- | --- | --- |
+| 服务发现 | `DISCOVER` | 下游服务都注册到 Nacos/Eureka/Consul，自动聚合全部 |
+| 手动路由 | `MANUAL`（默认） | 没接服务发现，或只想聚合一部分下游 |
+
+## 策略 A：服务发现（DISCOVER）
+
+```yaml
+server:
+  port: 8080
+
+spring:
+  application:
+    name: gateway-service
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true      # Gateway 自动从注册中心生成路由
+          lower-case-service-id: true
+
+knife4j:
+  gateway:
+    enabled: true
+    strategy: DISCOVER
+    tags-sorter: alpha        # tag 排序，可选 alpha / order
+    operations-sorter: alpha  # 接口排序，可选 alpha / method / order
+    discover:
+      enabled: true
+      version: OpenAPI3       # 或 Swagger2
+      excluded-services:      # 排除掉这些服务名（支持正则，v4.3.0+）
+        - gateway-service
+        - .*-config
+      oas3:
+        url: /v3/api-docs
+      swagger2:
+        url: /v2/api-docs
+      service-config:         # 针对个别服务打覆盖
+        user-service:
+          group-name: 用户中心
+          order: 1
+          group-names:        # 该服务在 springdoc.group-configs 里定义了多个 group
+            - users
+            - roles
+```
+
+运行后：
+
+1. 打开 `http://<gateway>/doc.html`。
+2. 左上角分组下拉会出现 `user-service (users)` / `user-service (roles)` 等下游服务的分组。
+
+### 关于 `excludedServices`
+
+- 区分大小写由 `Set<String>` 和下游服务名决定。一般下游注册时用小写。
+- `4.3.0+` 支持**正则表达式**，`".*-config"` 会排除所有 config 结尾的服务。
+
+### `service-config` 的用法
+
+当服务注册名（例如 `user-service`）不适合直接当 UI 上的 tab 名时，可以通过 `service-config.<serviceId>` 覆盖：
+
+- `group-name`：UI 下拉里显示的名称。
+- `order`：排序权重，越小越靠前。
+- `group-names`：如果下游用 springdoc 的 `group-configs` 拆了多个 group，这里列出要聚合哪些 group。缺省只聚合 `default`。
+- `context-path`：下游挂在非根路径（比如 `/api`），在此填写让聚合 UI 调用下游时路径正确。
+
+## 策略 B：手动路由（MANUAL）
+
+没有服务发现，或只想聚合一部分下游：
+
+```yaml
+server:
+  port: 8080
+
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: user-service
+          uri: http://user-service:9001
+          predicates:
+            - Path=/user-service/**
+          filters:
+            - StripPrefix=1
+
+knife4j:
+  gateway:
+    enabled: true
+    strategy: MANUAL
+    routes:
+      - name: 用户中心
+        service-name: user-service
+        url: /user-service/v3/api-docs
+        context-path: /user-service
+        order: 1
+      - name: 订单中心
+        service-name: order-service
+        url: /order-service/v3/api-docs
+        context-path: /order-service
+        order: 2
+```
+
+关键点：
+
+- `url` 是 **聚合 Gateway** 去取下游文档的路径（Gateway 自身发一次请求）。
+- `context-path` 是下游真实 context-path，**前端 UI 调试接口时会在请求 URL 前拼上这段**，避免落到 Gateway 根路径找不到。
+- `order` 越小越靠前。
+
+## 保护 Gateway 聚合入口
+
+```yaml
+knife4j:
+  gateway:
+    enabled: true
+    basic:
+      enable: true
+      username: admin
+      password: ${KNIFE4J_GATEWAY_PASSWORD:change-me}
+```
+
+此 Basic 只保护 Gateway 本身的 `/doc.html` + 聚合接口，**不会**把认证传到下游。
+
+## OpenAPI3 聚合中 context-path 丢失的问题
+
+历史 issue：下游应用设置了 `server.servlet.context-path=/api` 时，OpenAPI3 规范里不像 Swagger2 带 `basePath`，聚合到 Gateway 后调试请求会漏路径。
+
+- 修复版本：`4.6.0.2`（[#954](https://github.com/xiaoymin/knife4j/issues/954)）
+- 推荐手动声明：在 `service-config.<serviceId>.context-path`（DISCOVER）或 `routes[].context-path`（MANUAL）显式配置，最稳妥。
+
+## 验证
+
+```bash
+# 1. 启动下游 user-service，验证 /v3/api-docs 返回 JSON
+curl http://user-service:9001/v3/api-docs | head
+
+# 2. 启动 gateway
+# 3. 确认 gateway 能拉到下游文档（DISCOVER 模式路径就是 /v3/api-docs）
+curl http://gateway:8080/v3/api-docs
+
+# 4. 浏览器打开 gateway doc.html
+open http://gateway:8080/doc.html
+
+# 5. 手动触发聚合接口（Knife4j 用来发现服务的自定义接口）
+curl http://gateway:8080/v3/api-docs/swagger-config
+```
+
+## 排错清单
+
+| 现象 | 建议 |
+| --- | --- |
+| `doc.html` 打不开 | 确认 `knife4j.gateway.enabled: true`，以及 spring-cloud-starter-gateway 和 knife4j-gateway-starter 版本兼容 |
+| UI 列出了服务但点进去 404 | 多半是 `context-path` 漏填；或 Gateway route 的 `StripPrefix` 与 `context-path` 不匹配 |
+| 聚合路径命中 Gateway 路由规则 | 确保 `knife4j.gateway.discover.oas3.url` 指向的路径能被 Gateway 透传到下游 |
+| 依然只看到一个服务 | 检查服务发现是否实际注册成功（`/actuator/gateway/routes`）；确认 `excluded-services` 没把目标服务排除掉 |
+| 某些配置不生效 | knife4j gateway starter 跑在 WebFlux 栈，不要混用 spring-boot-starter-web（会冲突） |
+
+## 相关
+
+- [Aggregation starter](./aggregation)：如果你需要 **独立部署** 一个聚合服务，而不是跑在 Gateway 里。
+- [配置参考 / knife4j.gateway](../reference/configuration#gateway)：全部 YAML 选项。
+- [发布说明](../release-notes/)：gateway 相关的 changelog。
+

--- a/docs-site/guide/getting-started.md
+++ b/docs-site/guide/getting-started.md
@@ -1,20 +1,28 @@
+---
+title: 快速开始
+---
+
 # 快速开始
 
-通过 starter 接入 Knife4j Next 后，你可以在 Spring Boot 应用中直接获得增强版 OpenAPI 文档页面，并通过 `doc.html` 完成接口浏览和在线调试。
+本指南给出三条接入路径对应的最小可运行工程。每条路径都经过 `master` 的 `knife4j-smoke-tests` 模块回归验证。
 
-## 1. 选择依赖
+::: tip 先决定走哪条路径
+- **新项目、Spring Boot 3.x、不想踩 javax/jakarta 雷**：用 **OpenAPI3 Jakarta**，UI 是新 React 版本。
+- **还在 Spring Boot 2.7.x**：可以继续用 OpenAPI2（Springfox）或 OpenAPI3（springdoc-openapi 非 Jakarta），UI 对应上游 Vue2 版本。
+- **已经在 upstream knife4j**：先看 [迁移指引](./migration)，只改 `groupId` 即可，不必换路径。
 
-### Spring Boot 2.x
+如果不确定哪个版本合适，先看 [版本参考表](../reference/version-ref)。
+:::
 
-```xml
-<dependency>
-    <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>4.6.0.3</version>
-</dependency>
-```
+## 路径一：Spring Boot 3.x + OpenAPI3 Jakarta（推荐）
 
-### Spring Boot 3.x
+### 环境要求
+
+- JDK 17+
+- Spring Boot `3.4.0` ~ `3.5.x`（smoke-tests 覆盖 `3.4.0` 与 `3.5.0`）
+- springdoc-openapi-jakarta `2.8.9`（starter 已管理，无需显式声明）
+
+### 依赖
 
 ```xml
 <dependency>
@@ -24,41 +32,204 @@
 </dependency>
 ```
 
-## 2. 保持默认入口
+### 最小 `application.yml`
 
-应用启动后，继续通过下面的地址访问文档：
+```yaml
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
+  group-configs:
+    - group: default
+      paths-to-match: /**
+      packages-to-scan: com.example.demo
 
-```text
-http://ip:port/doc.html
+knife4j:
+  enable: true
+  setting:
+    language: zh_cn
 ```
 
-`doc.html` 是 Knife4j 默认的文档入口，适合在开发、测试和联调环境中快速访问接口文档。
+### 示例 Controller
 
-## 3. 验证接入效果
+```java
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
 
-1. 启动 Spring Boot 应用。
-2. 访问 `http://ip:port/doc.html`。
-3. 检查接口分组、请求参数和响应模型是否正常展示。
-4. 如果项目使用鉴权、网关或上下文路径，再继续验证对应场景。
+@RestController
+@RequestMapping("/api/users")
+@Tag(name = "用户管理", description = "用户相关接口")
+public class UserController {
 
-## 4. 本地开发
+    @Operation(summary = "按 id 查询用户")
+    @GetMapping("/{id}")
+    public UserDto get(@PathVariable Long id) {
+        return new UserDto(id, "alice");
+    }
 
-如果你要本地运行这个 VitePress 文档站：
-
-```bash
-cd docs-site
-npm install
-npm run dev
+    @Operation(summary = "新增用户")
+    @PostMapping
+    public UserDto create(@RequestBody UserDto body) {
+        return body;
+    }
+}
 ```
 
-默认会启动在：
+### 验证
 
-```text
-http://127.0.0.1:5173/
+1. `mvn spring-boot:run` 或运行 `knife4j-demo` 模块。
+2. 浏览器打开 `http://localhost:8080/doc.html`，应看到 React 版界面。
+3. `http://localhost:8080/v3/api-docs` 返回原始 OpenAPI JSON。
+
+::: warning 新前端配置覆盖范围
+React 新前端**不读取** `knife4j.setting.enable-debug`、`enable-search`、`enable-open-api`、`enable-version`、`enable-footer-custom`、`home-custom-path`、`swagger-model-name`、`enable-after-script` 等 UI 开关。
+这些配置对 OpenAPI3 系列 starter + 新前端**暂不生效**。详见 [FAQ / 为什么我的 knife4j.setting 配置不生效](./faq#react-setting-not-effective) 与 [路线图 / 新前端覆盖范围](../roadmap/#react-ui-coverage)。
+:::
+
+---
+
+## 路径二：Spring Boot 2.x + OpenAPI3（springdoc-openapi）
+
+### 环境要求
+
+- JDK 8 / 11 / 17
+- Spring Boot `2.4.0` ~ `2.7.x`（建议 `2.7.18`）
+- springdoc-openapi `1.8.0`（starter 已管理）
+
+### 依赖
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
 ```
 
-## 5. 下一步
+### 最小 `application.yml`
 
-- 查看 [兼容矩阵](/reference/compatibility)，确认当前项目使用的 Spring Boot 版本。
-- 查看 [迁移指引](/guide/migration)，了解从已有 Knife4j 项目切换时需要注意的依赖变化。
-- 查看 [模块说明](/reference/modules)，了解 starter、UI webjar 和前端模块的关系。
+```yaml
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+
+knife4j:
+  enable: true
+  setting:
+    language: zh_cn
+```
+
+Controller 写法与 Jakarta 版一致，annotation 使用 `io.swagger.v3.oas.annotations`。
+
+UI 同样是新 React 版本，注意覆盖范围提示。
+
+---
+
+## 路径三：Spring Boot 2.x + OpenAPI2（Springfox，Vue2 UI）
+
+::: info 何时选这条
+- 项目深度依赖 Springfox 专属注解（`@ApiOperationSupport(ignoreParameters/includeParameters)`、`@DynamicParameters`、`@DynamicResponseParameters`）。
+- 需要 upstream knife4j 文档上提到的完整 UI 能力（自定义 Footer/Home、OAuth2 调试、Postman 导出、版本小蓝点、afterScript）。
+- 这些特性在本 fork 的新 React 前端中尚未覆盖，但在 Vue2 UI 中完整保留。
+:::
+
+### 依赖
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+### 最小 `application.yml`
+
+```yaml
+knife4j:
+  enable: true
+  openapi:
+    title: Knife4j 示例
+    description: "`我是测试`"
+    email: you@example.com
+    concat: maintainer
+    version: v1.0
+    license: Apache 2.0
+    group:
+      default:
+        group-name: 默认分组
+        api-rule: package
+        api-rule-resources:
+          - com.example.demo
+```
+
+### 示例 Controller（Swagger 2 annotations）
+
+```java
+import io.swagger.annotations.*;
+import org.springframework.web.bind.annotation.*;
+
+@Api(tags = "用户管理")
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    @ApiOperation("按 id 查询用户")
+    @GetMapping("/{id}")
+    public UserDto get(@ApiParam("用户 id") @PathVariable Long id) {
+        return new UserDto(id, "alice");
+    }
+}
+```
+
+### 可选：启用 Docket 扩展体系
+
+```java
+@Configuration
+@EnableSwagger2WebMvc
+public class SwaggerConfig {
+
+    private final OpenApiExtensionResolver openApiExtensionResolver;
+
+    @Autowired
+    public SwaggerConfig(OpenApiExtensionResolver openApiExtensionResolver) {
+        this.openApiExtensionResolver = openApiExtensionResolver;
+    }
+
+    @Bean
+    public Docket defaultApi() {
+        String group = "默认分组";
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName(group)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.example.demo"))
+                .paths(PathSelectors.any())
+                .build()
+                .extensions(openApiExtensionResolver.buildExtensions(group));
+    }
+}
+```
+
+---
+
+## 跑不起来？
+
+1. `doc.html` 返回 404：确认 starter 在 classpath 里，且 `knife4j.enable=true`。若 context-path 非根，访问 `http://localhost:8080/<context-path>/doc.html`。
+2. 看到 Swagger 原生 UI 而不是 Knife4j 界面：通常是引入了 `springfox-boot-starter` 或 `springdoc-openapi-ui` 的**非 jakarta** 版本与 jakarta starter 冲突。
+3. `No OpenAPI resource found for group: swagger-config`：参考 [FAQ](./faq#no-openapi-resource-found)。
+4. 生产环境想隐藏 doc.html：设置 `knife4j.production=true`，并视需要启用 `knife4j.basic`。
+
+更多问题见 [FAQ](./faq)。
+
+## 下一步
+
+- 想看**完整可运行样例**：[Demo 预览](./demo)。
+- 做**网关聚合**：[Gateway 接入](./gateway)。
+- 做**多服务聚合**：[Aggregation](./aggregation)。
+- 查**所有配置项**：[配置参考](../reference/configuration)。

--- a/docs-site/guide/introduction.md
+++ b/docs-site/guide/introduction.md
@@ -4,20 +4,83 @@ title: 产品介绍
 
 # 产品介绍
 
-Knife4j Next 是面向 Spring 生态的 OpenAPI 文档增强与接口调试工具，延续 `doc.html` 使用习惯，同时把维护重心放在更稳定的兼容性和更清晰的项目叙事上。
+`knife4j-next` 是 [`xiaoymin/knife4j`](https://github.com/xiaoymin/knife4j) 的社区维护 fork，延续 `doc.html` 的接入习惯与 starter 模块结构，在 upstream 发布节奏放缓时接续安全修复、兼容性修复和发布流程。
 
-## 核心能力
+## 与 upstream 的关系
 
-- 保留熟悉的接口浏览与调试体验，方便现有项目平滑接入。
-- 支持离线文档、Markdown / HTML 导出、自定义首页、访问控制等团队交付能力。
-- 面向 Spring Boot 2.x 与 3.x 维护兼容矩阵，降低升级和回归风险。
+| 维度 | upstream `knife4j` | `knife4j-next`（本项目） |
+| --- | --- | --- |
+| Maven `groupId` | `com.github.xiaoymin` | `com.baizhukui` |
+| artifactId | 保留 | 完全一致，可直接替换 |
+| Java 包名 | `com.github.xiaoymin.knife4j.*` | 同上（未重命名，降低迁移成本） |
+| `knife4j.*` 配置键 | 保留 | 完全兼容 |
+| 访问入口（doc.html / v2 / v3 api-docs） | 保留 | 完全一致 |
+| 仓库 | `xiaoymin/knife4j` | [`songxychn/knife4j-next`](https://github.com/songxychn/knife4j-next) |
+| 发布渠道 | Maven Central | Maven Central |
+| 当前版本 | `4.6.0` | `4.6.0.3` |
+| 文档站 | [doc.xiaominfo.com](https://doc.xiaominfo.com/) | 本站（`knife4jnext.com`） |
 
-## 当前定位
+**迁移的最小单位是改 `groupId`，业务代码、配置键、访问路径都不必动。** 详见 [迁移指引](./migration)。
 
-这个项目不是一次性重写，而是在兼容现有用户的前提下，逐步推进更现代的前端与更可重复的维护流程。
+## 这份 fork 想解决什么
 
-## 接下来可以看什么
+1. **兼容性修复**。upstream 对 Spring Boot 3.4 / 3.5 的适配步伐变慢，fork 已经升级 `springdoc-openapi-jakarta` 到 `2.8.9`，把 3.4.0 / 3.5.0 两个版本纳入 smoke-tests 模块定期回归。
+2. **安全修复**。`4.6.0.2` 修复了 `/v2/api-docs;xxx` 分号绕过 Basic 认证的漏洞（[#886](https://github.com/xiaoymin/knife4j/issues/886)），`4.6.0.2` 还修复了 gateway `context-path` 下聚合 host 少斜杠的问题（[#954](https://github.com/xiaoymin/knife4j/issues/954)）。
+3. **可重复发布流程**。`.github/workflows/release.yml` 通过 Central Publishing Plugin 直接推送 Maven Central，不依赖人工临场操作。
+4. **可试用的 Demo**。`knife4j-demo` 模块提供完整的 Spring Boot 3.4 示例工程 + Dockerfile + docker-compose.yml。
 
-- [快速开始](/guide/getting-started)
-- [兼容矩阵](/reference/compatibility)
-- [迁移指引](/guide/migration)
+## 哪些是 **已经** 做了的
+
+下表仅列 **`master` 已合并** 的工作，不是路线图承诺。
+
+| 方向 | 已合并 | 对应资料 |
+| --- | --- | --- |
+| Boot 2.7.18 starter + UI webjar | ✅ | [快速开始](./getting-started) |
+| Boot 3.4.0 / 3.5.0 兼容 | ✅ | smoke-tests 模块 `boot3-jakarta-app`、`boot35-jakarta-app` |
+| /doc.html 分号绕过修复 | ✅ `#886` | [发布说明](../release-notes/) |
+| Gateway context-path 修复 | ✅ `#954` | [Gateway 接入](./gateway) |
+| React + Vite 新前端 webjar | ✅ | 在 `knife4j-openapi3-ui` 生效；`knife4j-openapi2-ui` 继续用 Vue2 |
+| 设置面板（Authorize / GlobalParam / OfflineDoc） | ✅ | 新前端右上角入口 |
+| `knife4j-demo` Docker Compose | ✅ | [Demo 预览](./demo) |
+| `com.baizhukui` 坐标发布 | ✅ | Maven Central |
+
+## 哪些是 **没有** 做或 **部分实现**，需要你知道
+
+upstream 文档里列出的 29 个增强特性在本 fork 的实际实现状态，前端和后端存在差异：
+
+| 情况 | 数量 | 示例 | 建议 |
+| --- | --- | --- | --- |
+| 全部模块已实现 | 4 项 | `knife4j.enable`、`knife4j.production`、`knife4j.basic`、JSR303 透传 | 安心使用 |
+| openapi2-starter 完整，openapi3 系列**部分丢弃** | 6 项 | `@DynamicParameters`、`@DynamicResponseParameters`、`@ApiOperationSupport(ignoreParameters/includeParameters)` 等 Springfox 专属能力 | 迁到 openapi3 时改用实体类替代 |
+| 后端实现，新 React 前端未读取 | 13 项 | `knife4j.setting.enable-debug=false`、`enable-search`、`enable-open-api`、`enable-version`、`enable-footer-custom`、`home-custom-path`、`swagger-model-name`、`enable-after-script` 等 | 依赖这些 UI 开关的用户暂时使用 openapi2 + Vue2 UI |
+| 全模块未实现 | 2 项 | 导出 Postman、Markdown 离线导出（新前端仅 HTML/Word） | 等待后续迭代 |
+
+完整对应关系见 [路线图 / 新前端覆盖范围](../roadmap/#react-ui-coverage)。
+
+## 两个前端、两个 UI webjar
+
+这一点最容易混淆，**先说清**：
+
+| UI webjar | 打包的前端 | 对应 starter |
+| --- | --- | --- |
+| `knife4j-openapi2-ui` | 上游 Vue2 产物（功能完整） | `knife4j-openapi2-spring-boot-starter`、`knife4j-aggregation-spring-boot-starter` |
+| `knife4j-openapi3-ui` | 从 `4.6.0.3` 起是新 React 产物 | `knife4j-openapi3-spring-boot-starter`、`knife4j-openapi3-jakarta-spring-boot-starter`、`knife4j-aggregation-jakarta-spring-boot-starter` |
+
+所以：
+
+- 用 **Springfox + OpenAPI2** 走 `openapi2-starter`，UI 仍是**熟悉的 Vue2 版本**，所有 upstream 功能都有。
+- 用 **springdoc-openapi + OpenAPI3** 走 `openapi3-starter` 或 `openapi3-jakarta-starter`，UI 是 **新 React 版本**（覆盖见上表），不熟悉行为请同时参考 [FAQ](./faq)。
+
+## 维护节奏
+
+- 小版本（patch：`4.6.0.1`→`4.6.0.2`→`4.6.0.3`）：安全修复、兼容性修复、前端体验改动。
+- 中版本（minor）：通常伴随至少一次维护者 review，不做产品级重设计。
+- 自治 agent 工作 在 `.agent/` 下留痕，每个任务对应 `TASK-###`，PR 与分支一一对应。
+
+## 下一步推荐路径
+
+- 想立刻试用：[快速开始](./getting-started) + [Demo 预览](./demo)
+- 已经在用 upstream：[迁移指引](./migration)
+- 准备做网关聚合：[Gateway](./gateway)
+- 想看完整配置项：[配置参考](../reference/configuration)
+- 踩到坑了：[FAQ](./faq)

--- a/docs-site/guide/migration.md
+++ b/docs-site/guide/migration.md
@@ -1,56 +1,177 @@
-# 迁移指引
+---
+title: 从 upstream 迁移
+---
 
-如果你已经在使用 upstream 的 `knife4j`，迁移到 `knife4j-next` 时，建议先把目标设成“平稳切换”，而不是“顺手升级所有东西”。
+# 从 upstream 迁移到 knife4j-next
 
-## 最先需要知道的变化
+本文针对已经在用 `com.github.xiaoymin:knife4j-*` 的项目，说明**切到 `com.baizhukui:knife4j-*` 的最小改动**。
 
-### Maven 坐标变了
+## 核心结论
 
-最重要的变化是 `groupId`：
+迁移的最小原子操作只有一件事：**改 Maven 依赖坐标的 `groupId`**。
 
-| 旧坐标 | 新坐标 |
+- Java 包名保留 `com.github.xiaoymin.knife4j.*`，**不变**。
+- 所有 `knife4j.*` YAML 配置键，**不变**。
+- `/doc.html`、`/v2/api-docs`、`/v3/api-docs` 访问路径，**不变**。
+- 全部既有注解（`@ApiOperationSupport`、`@ApiSupport`、`@DynamicParameters` ... ），**不变**。
+
+## 依赖替换（before / after）
+
+### Spring Boot 3.x Jakarta
+
+Before：
+
+```xml
+<dependency>
+    <groupId>com.github.xiaoymin</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>4.6.0</version>
+</dependency>
+```
+
+After：
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+### Spring Boot 2.x + springdoc-openapi
+
+Before：
+
+```xml
+<dependency>
+    <groupId>com.github.xiaoymin</groupId>
+    <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
+    <version>4.6.0</version>
+</dependency>
+```
+
+After：
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+### Spring Boot 2.x + Springfox（OpenAPI2）
+
+Before：
+
+```xml
+<dependency>
+    <groupId>com.github.xiaoymin</groupId>
+    <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
+    <version>4.6.0</version>
+</dependency>
+```
+
+After：
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+### 网关 / 聚合 / WebFlux 对应坐标
+
+| upstream | knife4j-next |
 | --- | --- |
-| `com.github.xiaoymin` | `com.baizhukui` |
+| `com.github.xiaoymin:knife4j-gateway-spring-boot-starter` | `com.baizhukui:knife4j-gateway-spring-boot-starter` |
+| `com.github.xiaoymin:knife4j-aggregation-spring-boot-starter` | `com.baizhukui:knife4j-aggregation-spring-boot-starter` |
+| `com.github.xiaoymin:knife4j-aggregation-jakarta-spring-boot-starter` | `com.baizhukui:knife4j-aggregation-jakarta-spring-boot-starter` |
+| `com.github.xiaoymin:knife4j-openapi3-webflux-spring-boot-starter` | `com.baizhukui:knife4j-openapi3-webflux-spring-boot-starter`（见 [WebFlux](./webflux)） |
+| `com.github.xiaoymin:knife4j-openapi3-webflux-jakarta-spring-boot-starter` | `com.baizhukui:knife4j-openapi3-webflux-jakarta-spring-boot-starter`（见 [WebFlux](./webflux)） |
 
-这意味着你的第一步通常不是改代码，而是先改依赖来源。
+## 业务代码不用动
 
-## 推荐迁移顺序
+下面这些在 upstream 文档中会出现的代码，**迁到 knife4j-next 后完全不用改**：
 
-1. 先替换 Maven 坐标，保留你现有的业务配置和访问路径。
-2. 启动应用，确认 `doc.html` 能正常打开。
-3. 验证最关键的接口分组、鉴权、网关聚合和静态资源加载。
-4. 如果你还依赖旧官网文档里的某些历史功能，暂时可以把它们作为参考资料，而不是迁移阻塞点。
+```java
+// 注解 import 不变
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import com.github.xiaoymin.knife4j.annotations.ApiSupport;
+import com.github.xiaoymin.knife4j.annotations.DynamicParameters;
+```
 
-## 哪些东西尽量先别动
+```yaml
+# 配置键不变
+knife4j:
+  enable: true
+  production: false
+  setting:
+    language: zh_cn
+  basic:
+    enable: true
+    username: admin
+    password: secret
+```
 
-- 先不要同时切换到新的前端实现。
-- 先不要把历史缓存、网关规则和上下文路径一并重构。
-- 先不要假设旧文档站里的每个链接都已经迁到新站。
+::: warning 部分注解只在 openapi2-starter 可用
+`@DynamicParameters`、`@DynamicResponseParameters`、`@ApiOperationSupport(ignoreParameters/includeParameters)` 等 **Springfox 专属** 的 Plugin 体系只在 `knife4j-openapi2-spring-boot-starter` 生效。
+迁到 `openapi3` 系列 starter 时这些注解会被编译器接受但 **运行时不处理**。这是 upstream v4.0 起官方弃用的决策，非本 fork 变更。详见 [注解速查](../reference/annotations)。
+:::
 
-## 这次新文档站的角色
+## 迁移步骤
 
-这个 VitePress 版本不会假装自己已经把旧站所有内容都迁完。它更像是新的“主入口”：
+1. **更新 Maven 依赖坐标**：全部 `com.github.xiaoymin` → `com.baizhukui`。
+2. **确认版本**：升到 `4.6.0.3`（包含 `/v2/api-docs;` 分号绕过修复、gateway context-path 修复、springdoc 2.8.9 兼容等）。
+3. **刷新依赖**：`mvn -U clean verify` 或 `mvn dependency:tree | grep knife4j` 检查无残留旧坐标。
+4. **启动验证**：访问 `/doc.html`，确认能看到接口列表。
+5. **如切到 OpenAPI3 系列 starter**：额外检查是否用了 Springfox 专属注解（`@DynamicParameters` 等），必要时替换为 DTO 实体类方式（参考 [注解速查](../reference/annotations)）。
 
-- 先回答“现在怎么接入”
-- 再回答“和 upstream 的差异是什么”
-- 最后再逐步承接“所有历史细节”
+## 验证命令
 
-## 迁移检查清单
+```bash
+# 确认依赖里全部是 com.baizhukui
+mvn dependency:tree -Dincludes=com.baizhukui:knife4j-*,com.github.xiaoymin:knife4j-*
 
-- [ ] 已切换到 `com.baizhukui`
-- [ ] 已确认当前使用的是 Boot 2.x 还是 3.x
-- [ ] 已验证 `doc.html` 入口
-- [ ] 已验证常用分组和调试能力
-- [ ] 已验证网关或聚合场景
-- [ ] 已记录仍需依赖旧文档的历史功能点
+# 启动并抓一下 doc.html
+mvn spring-boot:run &
+curl -I http://localhost:8080/doc.html
+curl http://localhost:8080/v3/api-docs | head
 
-## 关于旧文档站
+# 生产环境保护是否生效
+curl -I http://localhost:8080/doc.html   # 403 即正确
+```
 
-你后面给域名之后，新站会进一步补：
+## 迁移后验收清单
 
-- 正式的迁移 FAQ
-- 旧链接跳转策略
-- 版本差异页
-- 兼容性公告页
+- [ ] `mvn dependency:tree` 输出里没有 `com.github.xiaoymin:knife4j-*` 残留
+- [ ] 应用成功启动，`/doc.html` 可访问
+- [ ] `/v3/api-docs`（或 `/v2/api-docs`）返回正确的 OpenAPI JSON
+- [ ] 业务代码**没有**改动，只有 `pom.xml` 的 groupId 改了
+- [ ] 如果启用了 `knife4j.production` 或 `knife4j.basic`，生产发布前再做一次黑盒验证
+- [ ] 如果依赖新 React 前端的 UI 行为，已阅读 [新前端覆盖范围](../roadmap/#react-ui-coverage)，确认 `enable-debug`、`enable-search`、`enable-version` 等配置是否还是你预期的效果
 
-在此之前，旧站更像“历史资料库”，新站才是你面向社区的新入口。
+## 回滚策略
+
+`com.github.xiaoymin:knife4j-*` 仍然在 Maven Central，随时可以回退：
+
+```xml
+<!-- 回滚 -->
+<dependency>
+    <groupId>com.github.xiaoymin</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>4.6.0</version>
+</dependency>
+```
+
+由于业务代码未改，回滚成本等于依赖替换成本。
+
+## 常见迁移问题
+
+- **找不到 `com.baizhukui` 坐标**：刷新 Maven 中央仓库镜像；企业私服需要手动同步（Central 已发布）。
+- **doc.html 404**：见 [FAQ / SpringBoot 访问 doc.html 404](./faq#doc-html-404)。
+- **`enable-version` / `enable-debug` 等开关对新前端无效**：见 [FAQ / 为什么我的 knife4j.setting 配置不生效](./faq#react-setting-not-effective)。
+- **Gateway context-path 下聚合出错**：升级到 `4.6.0.2` 或以上即修复（[#954](https://github.com/xiaoymin/knife4j/issues/954)）。

--- a/docs-site/guide/webflux.md
+++ b/docs-site/guide/webflux.md
@@ -1,0 +1,142 @@
+---
+title: WebFlux 接入
+---
+
+# WebFlux 接入（knife4j-openapi3-webflux-*-starter）
+
+本 fork 提供两个 WebFlux 专用 starter：
+
+| 模块 | 说明 | 依赖 |
+| --- | --- | --- |
+| `knife4j-openapi3-webflux-spring-boot-starter` | 非 Jakarta（适合 Spring Boot 2.x WebFlux） | `springdoc-openapi-webflux-ui` `1.8.0` |
+| `knife4j-openapi3-webflux-jakarta-spring-boot-starter` | Jakarta（Spring Boot 3.x WebFlux） | `springdoc-openapi-starter-webflux-ui` `2.8.9` |
+
+两者的作用都是：
+
+1. 引入 springdoc 的 **WebFlux 版** swagger-ui 自动配置（而不是 webmvc 版）。
+2. 把本仓库的 `knife4j-openapi3-ui` webjar（React 新前端）挂上去，以取代 springdoc 默认 Swagger UI。
+
+## 和普通 WebMvc 版本的区别
+
+```diff
+- <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
++ <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
+```
+
+- WebMvc 版依赖 `springdoc-openapi-starter-webmvc-ui`。
+- WebFlux 版依赖 `springdoc-openapi-starter-webflux-ui`。
+- 两者**不能同时引入**，否则自动配置会冲突。
+
+除此之外两个 starter 本身**不包含任何额外 Java 代码**（没有自定义 `OperationCustomizer`、`OpenApiCustomizer`、过滤器等）。所以：
+
+::: warning WebFlux 下的 knife4j 增强能力
+`knife4j-openapi3-webflux-*-starter` 仅完成**依赖编排**，不提供 `knife4j-openapi3-jakarta-spring-boot-starter` 那套基于 `Knife4jOpenApiCustomizer` / `Knife4jOperationCustomizer` 的能力：
+- `@ApiOperationSupport(author/order)` 的 vendor extension 不会写入 `/v3/api-docs`
+- `knife4j.documents`、`knife4j.production`、`knife4j.basic` 相关 Servlet 过滤器**不存在**
+- i18n、自定义主页、自定义 Footer 等 `knife4j.setting.*` 的服务端注入缺失
+
+如果需要以上能力，建议继续使用 WebMvc 技术栈，或等待 `knife4j-openapi3-webflux-*-starter` 后续补齐（已列入 [路线图](../roadmap/)）。
+:::
+
+## Boot 3.x（Jakarta）最小例
+
+### 依赖
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-webflux</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+### `application.yml`
+
+```yaml
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs
+```
+
+### 示例 Controller（Reactive）
+
+```java
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/users")
+@Tag(name = "用户管理")
+public class UserController {
+
+    @Operation(summary = "按 id 查询用户")
+    @GetMapping("/{id}")
+    public Mono<UserDto> get(@PathVariable Long id) {
+        return Mono.just(new UserDto(id, "alice"));
+    }
+}
+```
+
+访问 `http://localhost:8080/doc.html` 即可。
+
+## Boot 2.x（非 Jakarta）最小例
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-webflux</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-webflux-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+## Spring Cloud Gateway 是 WebFlux 但**不**用这个 starter
+
+Spring Cloud Gateway 基于 WebFlux，但它本身不生成 OpenAPI 文档——它**转发**请求。所以 Gateway 场景不用 `knife4j-openapi3-webflux-*-starter`，而用 `knife4j-gateway-spring-boot-starter`。
+
+- 需要 **做 API 聚合** → [Gateway 聚合](./gateway)
+- 需要 **生成** 自己的 API 文档 → 本页
+
+## 替代方案
+
+如果 `knife4j-openapi3-webflux-*-starter` 提供的能力不足（比如你想要 `@ApiOperationSupport` 的完整语义），可以：
+
+1. **继续用 WebMvc**：把项目从 WebFlux 切回 Servlet，很多情况下这是最省事的选择。
+2. **直接用 springdoc-openapi WebFlux starter** + 手写 knife4j 的 vendor extension，相当于自己实现一部分 `Knife4jOpenApiCustomizer` 的能力。
+
+大部分团队用 WebFlux 的场景是 **网关 / 反应式微服务**，业务文档能力在 WebMvc 上就够用了。
+
+## 验证
+
+```bash
+mvn spring-boot:run
+curl -I http://localhost:8080/doc.html
+curl http://localhost:8080/v3/api-docs | head
+curl http://localhost:8080/v3/api-docs/swagger-config
+```
+
+返回 JSON 即正确。
+
+## 排错
+
+| 现象 | 建议 |
+| --- | --- |
+| 404 `/doc.html` | 是否错误地同时引入了 `knife4j-openapi3-jakarta-spring-boot-starter`（WebMvc 版）；WebFlux 环境下的静态资源路径需要 WebFlux 专用配置 |
+| UI 是默认 Swagger UI 而不是 knife4j | 清 Maven 缓存；确认 `knife4j-openapi3-ui` 被 starter 传递依赖进来 |
+| `Servlet` 相关的 ClassNotFoundException | 不要混入 `spring-boot-starter-web` |
+

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: Knife4j Next
-  text: 更现代的 Knife4j
-  tagline: 为 Spring 生态提供开箱即用的 API 文档增强体验，覆盖文档浏览、接口调试、微服务聚合、鉴权配置、离线导出与团队协作。
+  text: 为 Spring 生态保驾护航的 OpenAPI 文档增强
+  tagline: 延续熟悉的 doc.html 接入方式，持续修复 Spring Boot 2.7 / 3.x 的兼容性。这是 Knife4j 的社区维护 fork。
   image:
     src: /knife4j-next-mark.svg
     alt: Knife4j Next
@@ -13,66 +13,108 @@ hero:
       text: 快速开始
       link: /guide/getting-started
     - theme: alt
-      text: 了解功能
-      link: /#%E6%A0%B8%E5%BF%83%E5%8A%9F%E8%83%BD
+      text: 从 upstream 迁移
+      link: /guide/migration
+    - theme: alt
+      text: GitHub
+      link: https://github.com/songxychn/knife4j-next
 
 features:
-  - title: 文档更清晰
-    details: 在 Swagger / OpenAPI 的基础上增强接口分组、参数展示、模型结构和搜索体验，让后端接口对团队更可读。
-  - title: 调试更顺手
-    details: 直接在 doc.html 中完成接口请求、参数缓存、全局参数、OAuth2 / Basic Auth 等常见调试流程。
-  - title: 聚合更简单
-    details: 面向 Spring Cloud Gateway 与服务聚合场景，将多个服务的 OpenAPI 文档统一到一个入口展示。
-  - title: 交付更完整
-    details: 支持离线文档、Markdown / HTML 导出、自定义首页、访问控制和生产环境禁用等团队交付能力。
+  - title: 保持 doc.html 使用习惯
+    details: Maven groupId 切到 com.baizhukui 即可替换原依赖，/doc.html、/v2/api-docs、/v3/api-docs 入口保持不变。
+    link: /guide/migration
+    linkText: 迁移指引
+  - title: Spring Boot 2.7、3.4、3.5 都跑过
+    details: 4 个 smoke 模块（Boot 2.7.18、Boot 3.4.0、Boot 3.5.0）随每次构建回归，springdoc-openapi-jakarta 已对齐 2.8.9。
+    link: /reference/compatibility
+    linkText: 兼容矩阵
+  - title: 配置项按前缀整理
+    details: knife4j.setting / knife4j.basic / knife4j.gateway / knife4j.cloud / knife4j.nacos ... 全部 YAML 选项、默认值、所属模块有据可查。
+    link: /reference/configuration
+    linkText: 配置参考
+  - title: Gateway 与多服务聚合
+    details: knife4j-gateway-spring-boot-starter 支持 DISCOVER / MANUAL 两种策略；aggregation starter 另外提供 disk / cloud / nacos / eureka / polaris 五种聚合模式。
+    link: /guide/gateway
+    linkText: 网关接入
 ---
 
-## 核心功能
+## 这是 Knife4j 的 fork，不是重写
 
-<div class="status-grid">
-  <div class="status-card">
-    <span class="label">Browse</span>
-    <strong>API 文档浏览</strong>
-    <p>接口分组、模型结构、参数说明和全文搜索集中展示。</p>
-  </div>
-  <div class="status-card">
-    <span class="label">Debug</span>
-    <strong>在线接口调试</strong>
-    <p>直接在页面内发起请求，支持常用鉴权和全局参数。</p>
-  </div>
-  <div class="status-card">
-    <span class="label">Gateway</span>
-    <strong>微服务文档聚合</strong>
-    <p>为网关和多服务项目提供统一的 API 文档入口。</p>
-  </div>
-  <div class="status-card">
-    <span class="label">Export</span>
-    <strong>离线文档导出</strong>
-    <p>将接口说明导出为团队交付更方便的离线文档。</p>
-  </div>
-</div>
+`knife4j-next` 是 [`xiaoymin/knife4j`](https://github.com/xiaoymin/knife4j) 的社区维护分支。
 
-## 适合哪些场景
+- 保留 `com.github.xiaoymin.knife4j.*` Java 包名，不做重命名。
+- 保留 `doc.html` / `v2/api-docs` / `v3/api-docs` 访问入口。
+- 保留 `@ApiOperationSupport`、`@ApiSupport`、`knife4j.*` 等全部既有注解与配置键。
+- 只改 `groupId`：`com.github.xiaoymin` → `com.baizhukui`，其余业务代码不用动。
 
-<div class="signal-board">
-  <p>如果你的团队已经在使用 Swagger、OpenAPI、Springfox 或 springdoc-openapi，但默认 UI 不够好用，Knife4j Next 可以作为更完整的文档增强层。</p>
-  <p>它保留熟悉的 <code>/doc.html</code> 访问入口，同时提供更适合团队协作、联调和微服务聚合的功能。</p>
-</div>
+## 60 秒上手
 
-## 主要能力
+Spring Boot 3.x（Jakarta）：
 
-- **接口分组与搜索**：让大型项目中的接口更容易查找、定位和理解。
-- **请求参数增强**：支持全局参数、动态参数、参数缓存和请求过滤。
-- **鉴权调试**：覆盖 Basic Auth、OAuth2 等常见接口调试场景。
-- **模型展示增强**：更友好地展示请求体、响应体和嵌套模型结构。
-- **网关聚合**：适合 Spring Cloud Gateway、多服务、多分组的文档统一展示。
-- **离线交付**：支持将接口文档导出为离线格式，方便评审、归档和交付。
-- **访问控制**：支持生产环境禁用、基础访问控制和文档入口保护。
-
-## 接入方式
-
-Spring Boot 2.x 和 Spring Boot 3.x 项目都可以通过 starter 快速接入。先从 [快速开始](/guide/getting-started) 选择适合你的依赖版本，然后启动应用访问：
-
-```text
-http://ip:port/doc.html
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
 ```
+
+最小配置：
+
+```yaml
+knife4j:
+  enable: true
+  setting:
+    language: zh_cn
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+```
+
+启动应用后访问 `http://localhost:8080/doc.html`。完整流程见 [快速开始](/guide/getting-started)。
+
+## 本次版本亮点（4.6.0.3）
+
+- 🧩 React + Vite 构建的新前端已集成到 `knife4j-openapi3-ui` webjar（旧 Vue2 产物仍由 `knife4j-openapi2-ui` 使用）。
+- 🛡️ 修复 `/v2/api-docs;xxx` 分号绕过 Basic 认证（[#886](https://github.com/xiaoymin/knife4j/issues/886)）。
+- 🌉 修复 gateway `context-path` 下聚合 host 缺斜杠（[#954](https://github.com/xiaoymin/knife4j/issues/954)）。
+- 🧱 升级 springdoc-openapi-jakarta 至 `2.8.9`，兼容 Boot 3.4.x / 3.5.x。
+- 🐳 `knife4j-demo` 模块提供 Docker Compose 在线预览。
+
+完整更新列表见 [发布说明](/release-notes/)。
+
+::: warning 关于新前端覆盖范围
+新 React 前端当前**仅覆盖部分** upstream 增强特性。如果你依赖的是 `knife4j.setting.enable-debug=false`、`enable-footer-custom`、`home-custom-path`、`swagger-model-name`、`enable-after-script`、`enable-version`、Postman 导出或 OAuth2 调试的完整授权流程，请在切换到新前端前先查阅 [新前端覆盖范围](/roadmap/#react-ui-coverage)。`knife4j-openapi2-ui` 仍是 Vue2 旧前端，所有 upstream 特性继续可用。
+:::
+
+## 文档导航
+
+**上手**
+
+- [产品介绍](/guide/introduction)：这个 fork 的定位、与 upstream 的对照表
+- [快速开始](/guide/getting-started)：Spring Boot 2.x / 3.x 完整接入
+- [迁移指引](/guide/migration)：从 `com.github.xiaoymin` 切到 `com.baizhukui`
+- [Demo 预览](/guide/demo)：`knife4j-demo` 模块、本地跑 / Docker Compose
+- [常见问题](/guide/faq)：doc.html 404、生产环境禁用、Nginx 反向代理、React 配置不生效
+
+**组件**
+
+- [Gateway 聚合](/guide/gateway)：Spring Cloud Gateway + knife4j-gateway-starter
+- [Aggregation 聚合](/guide/aggregation)：disk / cloud / nacos / eureka / polaris
+- [WebFlux 方案](/guide/webflux)：当前 fork 中的 webflux 实际情况与替代路径
+
+**参考**
+
+- [兼容矩阵](/reference/compatibility)：Java、Spring、Boot、springdoc 基线
+- [版本参考表](/reference/version-ref)：Boot 版本如何选 knife4j 版本
+- [模块说明](/reference/modules)：14 个 Maven 模块的职责与选择决策
+- [配置参考](/reference/configuration)：全部 `knife4j.*` YAML 选项
+- [注解速查](/reference/annotations)：Springfox 专有 vs 通用注解
+
+**其他**
+
+- [路线图](/roadmap/)：当前任务队列 + React UI 覆盖缺口清单
+- [发布说明](/release-notes/)：版本更新记录

--- a/docs-site/reference/annotations.md
+++ b/docs-site/reference/annotations.md
@@ -1,0 +1,401 @@
+---
+title: 注解速查表
+---
+
+# 注解速查表
+
+本页列出 Knife4j 生态中所有相关注解，按来源分组，并标注 **通用** vs **Springfox 专有** vs **Knife4j 专有**。
+
+> 迁移建议：如果你正在使用 OpenAPI 3 + springdoc，应优先使用 **通用** 栏的注解。Springfox 专有注解仅在 `knife4j-openapi2-spring-boot-starter` 场景下有效。
+
+---
+
+## 快速对照：Swagger 2 → OpenAPI 3 迁移映射
+
+| Swagger 2（Springfox 专有） | OpenAPI 3（通用） | 说明 |
+| --- | --- | --- |
+| `@Api` | `@Tag` | 控制器分组 |
+| `@ApiOperation` | `@Operation` | 接口说明 |
+| `@ApiParam` | `@Parameter` | 参数说明 |
+| `@ApiModel` | `@Schema` | 模型类说明 |
+| `@ApiModelProperty` | `@Schema`（字段级） | 模型字段说明 |
+| `@ApiImplicitParam` | `@Parameter` | 隐式参数 |
+| `@ApiImplicitParams` | 多个 `@Parameter` | 多个隐式参数 |
+| `@ApiResponse` / `@ApiResponses` | `@ApiResponse` / `@ApiResponses` | 响应说明（注意包名不同） |
+| `@Authorization` / `@AuthorizationScope` | `@SecurityScheme` + `@SecurityRequirement` | 安全定义 |
+| `springfox.documentation.annotations.ApiIgnore` | `@Hidden` 或 `@Operation(hidden = true)` | 忽略接口 |
+
+---
+
+## 一、OpenAPI 3 通用注解
+
+> **包名**：`io.swagger.v3.oas.annotations.*`
+> **依赖**：`io.swagger.core.v3:swagger-annotations`（springdoc 自动引入）
+> **适用**：所有 OpenAPI 3 starter
+
+### 1.1 接口与操作
+
+| 注解 | 目标 | 常用属性 | 说明 |
+| --- | --- | --- | --- |
+| `@Tag` | 类 | `name`, `description` | 控制器分组，等价于 Swagger 2 的 `@Api` |
+| `@Tags` | 类 | `value`（多个 `@Tag`） | 多分组声明 |
+| `@Operation` | 方法 | `summary`, `description`, `deprecated`, `hidden`, `security`, `tags`, `operationId` | 接口说明，等价于 `@ApiOperation` |
+| `@Hidden` | 类/方法/字段 | — | 标记整个接口或字段不在文档中展示 |
+
+### 1.2 参数
+
+| 注解 | 目标 | 常用属性 | 说明 |
+| --- | --- | --- | --- |
+| `@Parameter` | 方法参数 / 字段 | `name`, `description`, `required`, `example`, `deprecated`, `hidden`, `schema` | 参数说明，等价于 `@ApiParam` / `@ApiImplicitParam` |
+| `@Parameters` | 方法 | `value`（多个 `@Parameter`） | 多参数声明 |
+
+### 1.3 数据模型
+
+| 注解 | 目标 | 常用属性 | 说明 |
+| --- | --- | --- | --- |
+| `@Schema` | 类 / 字段 / 方法参数 | `description`, `title`, `example`, `requiredMode`, `defaultValue`, `deprecated`, `hidden`, `nullable`, `allowableValues`, `implementation` | 统一的模型与字段说明，等价于 `@ApiModel` + `@ApiModelProperty` |
+| `@ArraySchema` | 字段 | `schema`, `minItems`, `maxItems`, `uniqueItems` | 数组类型字段 |
+
+### 1.4 响应
+
+| 注解 | 目标 | 常用属性 | 说明 |
+| --- | --- | --- | --- |
+| `@ApiResponse` | 方法 | `responseCode`, `description`, `content`, `headers` | 单个响应说明 |
+| `@ApiResponses` | 方法 | `value`（多个 `@ApiResponse`） | 多响应说明 |
+
+### 1.5 安全
+
+| 注解 | 目标 | 常用属性 | 说明 |
+| --- | --- | --- | --- |
+| `@SecurityScheme` | 类 | `name`, `type`, `scheme`, `bearerFormat`, `in`, `paramName` | 安全方案定义 |
+| `@SecuritySchemes` | 类 | `value`（多个 `@SecurityScheme`） | 多安全方案 |
+
+### 1.6 其他
+
+| 注解 | 目标 | 常用属性 | 说明 |
+| --- | --- | --- | --- |
+| `@Server` | 类/方法 | `url`, `description` | 服务端点 |
+| `@Servers` | 类/方法 | `value`（多个 `@Server`） | 多服务端点 |
+| `@ExternalDocumentation` | 类/方法 | `url`, `description` | 外部文档链接 |
+| `@Info` | 类（配合 `@OpenAPIDefinition`） | `title`, `version`, `description`, `termsOfService`, `contact`, `license` | API 基本信息 |
+| `@Extension` / `@Extensions` | 多处 | `name`, `properties` | OpenAPI 扩展字段（`x-*`） |
+| `@ExtensionProperty` | — | `name`, `value` | 扩展属性键值对 |
+
+---
+
+## 二、Swagger 2 / Springfox 专有注解
+
+> **包名**：`io.swagger.annotations.*`
+> **依赖**：`io.swagger:swagger-annotations`（Springfox 自动引入）
+> **适用**：仅 `knife4j-openapi2-spring-boot-starter`
+> **状态**：⛔ 如果你使用 OpenAPI 3 starter，这些注解**不生效**
+
+| 注解 | 目标 | 常用属性 | OpenAPI 3 替代 |
+| --- | --- | --- | --- |
+| `@Api` | 类 | `value`, `tags`, `description`, `produces`, `consumes` | `@Tag` |
+| `@ApiOperation` | 方法 | `value`, `notes`, `tags`, `produces`, `consumes`, `httpMethod` | `@Operation` |
+| `@ApiParam` | 方法参数 | `value`, `required`, `defaultValue`, `allowableValues`, `hidden` | `@Parameter` |
+| `@ApiModel` | 类 | `value`, `description` | `@Schema`（类级） |
+| `@ApiModelProperty` | 字段 | `value`, `required`, `example`, `dataType`, `hidden`, `allowableValues` | `@Schema`（字段级） |
+| `@ApiImplicitParam` | 方法 | `name`, `value`, `dataType`, `paramType`, `required`, `defaultValue` | `@Parameter` |
+| `@ApiImplicitParams` | 方法 | `value`（多个 `@ApiImplicitParam`） | 多个 `@Parameter` |
+| `@ApiResponse` | 方法 | `code`, `message`, `response` | `@ApiResponse`（注意包名不同） |
+| `@ApiResponses` | 方法 | `value`（多个 `@ApiResponse`） | `@ApiResponses`（注意包名不同） |
+| `@Authorization` | — | `value`, `scopes` | `@SecurityScheme` |
+| `@AuthorizationScope` | — | `scope`, `description` | `@OAuthScope`（编程式） |
+| `@Extension` | 多处 | `name`, `properties` | `@Extension`（v3） |
+| `@ExtensionProperty` | — | `name`, `value` | `@ExtensionProperty`（v3） |
+| `@Example` | — | `value` | `@ExampleObject`（v3） |
+| `@ExampleProperty` | — | `value`, `mediaType` | `@ExampleObject`（v3） |
+
+### Springfox 框架注解
+
+| 注解 | 包名 | 说明 |
+| --- | --- | --- |
+| `@EnableSwagger2WebMvc` | `springfox.documentation.swagger2.annotations` | 启用 Springfox Swagger 2（仅 openapi2 starter） |
+| `@ApiIgnore` | `springfox.documentation.annotations` | 忽略接口，OpenAPI 3 中用 `@Hidden` 替代 |
+
+---
+
+## 三、Knife4j 专有增强注解
+
+> **包名**：`com.github.xiaoymin.knife4j.annotations.*`
+> **依赖**：`knife4j-core`（所有 starter 自动引入）
+> **前提**：需配合 `knife4j.enable=true` 使用（openapi2 starter 必须开启；openapi3 starter 建议开启）
+
+### 3.1 `@ApiSupport` — 控制器增强
+
+> **替代已废弃的 `@ApiSort`**（since 2.0.3）
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `order` | `int` | `Integer.MAX_VALUE` | Tag 排序值，数值越小越靠前 |
+| `author` | `String` | `""` | 开发者（单值） |
+| `authors` | `String[]` | `{}` | 开发者（多值，与 `author` 合并展示；since 4.2.0） |
+
+**目标**：`ElementType.TYPE`（放在 Controller 类上）
+
+```java
+@Tag(name = "用户管理")
+@ApiSupport(order = 1, author = "张三")
+@RestController
+public class UserController { ... }
+```
+
+> ⚠️ **React UI 注意**：`order` 排序在 React 前端暂不生效，`author`/`authors` 展示暂未实现。Vue2 前端完整支持。
+
+### 3.2 `@ApiOperationSupport` — 接口增强
+
+> **替代已废弃的 `@ApiOperationSort`**（since 1.9.4）
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `order` | `int` | `0` | 操作排序值，同 Tag 下数值越小越靠前 |
+| `author` | `String` | `""` | 开发者（单值） |
+| `authors` | `String[]` | `{}` | 开发者（多值，与 `author` 合并展示；since 4.2.0） |
+| `params` | `DynamicParameters` | `@DynamicParameters` | 动态请求参数（⚠️ 自 4.0 起放弃维护） |
+| `responses` | `DynamicResponseParameters` | `@DynamicResponseParameters` | 动态响应参数（⚠️ 自 4.0 起放弃维护） |
+| `ignoreParameters` | `String[]` | `{}` | 忽略参数名（⚠️ 自 4.0 起放弃维护） |
+| `includeParameters` | `String[]` | `{}` | 包含参数名（⚠️ 自 4.0 起放弃维护） |
+
+**目标**：`ElementType.METHOD`, `ElementType.ANNOTATION_TYPE`
+
+```java
+@Operation(summary = "创建用户")
+@ApiOperationSupport(order = 1, author = "张三")
+@PostMapping
+public UserVO create(@RequestBody UserCreateRequest req) { ... }
+```
+
+**`ignoreParameters` 使用方式**：
+
+```java
+// 忽略实体类中的 id 字段
+@ApiOperationSupport(ignoreParameters = {"id"})
+
+// 忽略嵌套属性
+@ApiOperationSupport(ignoreParameters = {"req.id", "req.inner.name"})
+
+// 仅包含指定字段（与 ignoreParameters 对立）
+@ApiOperationSupport(includeParameters = {"name", "email"})
+```
+
+> ⚠️ **React UI 注意**：`order` 排序在 React 前端暂不生效，`author`/`authors` 展示暂未实现。`ignoreParameters`/`includeParameters` 依赖后端 OpenAPI customizer 修改 schema，React 前端可以消费其结果。
+
+### 3.3 `@DynamicParameter` / `@DynamicParameters` / `@DynamicResponseParameters` — 动态模型
+
+> ⛔ **自 4.0 起放弃维护**，建议改用实体类 + `@Schema` 注解。保留定义仅用于向后兼容。
+
+#### `@DynamicParameter`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `name` | `String` | `""` | 属性名称 |
+| `value` | `String` | `""` | 属性说明 |
+| `required` | `boolean` | `false` | 是否必传 |
+| `dataTypeClass` | `Class<?>` | `Void.class` | 属性类型 |
+| `example` | `String` | `""` | 示例值 |
+
+#### `@DynamicParameters`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `name` | `String` | `""` | 动态 Model 名称 |
+| `properties` | `DynamicParameter[]` | `@DynamicParameter` | 属性集合 |
+
+#### `@DynamicResponseParameters`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `name` | `String` | `""` | 动态响应 Model 名称 |
+| `properties` | `DynamicParameter[]` | `@DynamicParameter` | 属性集合 |
+
+**替代方案**（推荐）：
+
+```java
+// ❌ 旧写法（已放弃维护）
+@ApiOperationSupport(
+    params = @DynamicParameters(name = "CreateUserReq", properties = {
+        @DynamicParameter(name = "name", value = "用户名", required = true),
+        @DynamicParameter(name = "email", value = "邮箱")
+    })
+)
+
+// ✅ 新写法（推荐）
+@Schema(description = "创建用户请求")
+public class UserCreateRequest {
+    @Schema(description = "用户名", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String name;
+
+    @Schema(description = "邮箱")
+    private String email;
+}
+```
+
+### 3.4 `@Ignore` — 忽略接口或参数
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `value` | `String` | `""` | 忽略原因说明 |
+
+**目标**：`ElementType.METHOD`, `ElementType.TYPE`, `ElementType.PARAMETER`
+
+```java
+@Ignore("内部接口，不对外暴露")
+@GetMapping("/internal")
+public String internal() { ... }
+```
+
+> 💡 OpenAPI 3 标准方案是 `@Hidden`，Knife4j 的 `@Ignore` 是其增强版（可附带原因说明）。两者功能重叠，推荐优先使用 `@Hidden`。
+
+### 3.5 `@EnableKnife4j` — 启用增强
+
+> **包名**：`com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j`
+> **目标**：`ElementType.TYPE`（放在 Spring Boot 启动类或配置类上）
+
+```java
+@EnableKnife4j
+@SpringBootApplication
+public class MyApplication { ... }
+```
+
+**等价配置**：在 `application.yml` 中设置 `knife4j.enable: true`，Spring Boot 自动配置会生效。`@EnableKnife4j` 主要用于显式声明或 openapi2 场景。
+
+> ⚠️ 在 OpenAPI 3 + Spring Boot 3.x 场景下，`@EnableKnife4j` **不是必须的**——`knife4j.enable=true` 足矣。
+
+---
+
+## 四、springdoc 专用注解
+
+> **包名**：`org.springdoc.core.annotations.*`
+> **依赖**：`springdoc-openapi`（starter 自动引入）
+
+| 注解 | 目标 | 说明 |
+| --- | --- | --- |
+| `@ParameterObject` | 方法参数 | 将一个 POJO 参数展开为多个 query 参数（而非整体作为一个 request body） |
+
+```java
+@GetMapping("/search")
+public PageResult<UserVO> search(@ParameterObject PageQuery query) { ... }
+// 等价于在 URL 上展开 query.pageNum、query.pageSize、query.keyword
+```
+
+---
+
+## 五、已废弃注解
+
+| 注解 | 废弃版本 | 替代方案 |
+| --- | --- | --- |
+| `@ApiSort` | 2.0.3 | `@ApiSupport(order = N)` |
+| `@ApiOperationSort` | 1.9.4 | `@ApiOperationSupport(order = N)` |
+| `@ApiIgnore`（Springfox） | — | `@Hidden`（OpenAPI 3） |
+| `@EnableSwagger2WebMvc` | — | Springfox 本身已停止维护，迁移至 springdoc |
+
+---
+
+## 六、按场景速查
+
+### 场景 1：OpenAPI 3 + Spring Boot 3.x（Jakarta）
+
+**推荐注解组合**：
+
+```java
+@Tag(name = "用户管理")                     // 控制器分组
+@ApiSupport(order = 1, author = "张三")     // Knife4j 增强：排序 + 作者
+@RestController
+public class UserController {
+
+    @Operation(summary = "创建用户")         // 接口说明
+    @ApiOperationSupport(order = 1)         // Knife4j 增强：排序
+    @PostMapping
+    public UserVO create(
+        @RequestBody                        // 请求体
+        @Schema(description = "创建用户请求")
+        UserCreateRequest req
+    ) { ... }
+
+    @Operation(summary = "查询用户")         // 接口说明
+    @GetMapping("/{id}")
+    public UserVO get(
+        @Parameter(description = "用户ID", example = "1")  // 路径参数
+        @PathVariable Long id
+    ) { ... }
+}
+```
+
+### 场景 2：OpenAPI 3 + Spring Boot 2.x
+
+注解用法与场景 1 完全相同，区别仅在于 Maven 依赖使用 `knife4j-openapi3-spring-boot-starter`（javax）而非 `knife4j-openapi3-jakarta-spring-boot-starter`（jakarta）。
+
+### 场景 3：Swagger 2 / Springfox（旧项目）
+
+**使用注解**：
+
+```java
+@Api(tags = "用户管理")                     // Swagger 2 分组
+@ApiSort(1)                                // 已废弃，建议迁移
+@RestController
+public class UserController {
+
+    @ApiOperation(value = "创建用户")        // Swagger 2 接口说明
+    @PostMapping
+    public UserVO create(@RequestBody UserCreateRequest req) { ... }
+}
+```
+
+> 迁移路径参见 [迁移指南](/guide/migration)。
+
+---
+
+## 七、React UI 功能覆盖现状
+
+Knife4j 专有注解的后端增强逻辑通过 `Knife4jOpenApiCustomizer` / `Knife4jOperationCustomizer` 修改 OpenAPI spec，React 前端理论上可以消费修改后的 spec。但以下增强在 **React 前端 UI 层面**暂未实现：
+
+| 增强功能 | 后端是否生效 | Vue2 UI | React UI | 说明 |
+| --- | --- | --- | --- | --- |
+| `@ApiSupport.order` Tag 排序 | ✅ 写入 spec | ✅ | ❌ | React 侧边栏暂不按 order 排序 |
+| `@ApiSupport.author/authors` | ✅ 写入 spec | ✅ | ❌ | React 暂不展示开发者信息 |
+| `@ApiOperationSupport.order` 操作排序 | ✅ 写入 spec | ✅ | ❌ | React 操作列表暂不按 order 排序 |
+| `@ApiOperationSupport.author/authors` | ✅ 写入 spec | ✅ | ❌ | React 暂不展示开发者信息 |
+| `ignoreParameters` / `includeParameters` | ✅ 修改 schema | ✅ | ⚠️ | 后端已修改 schema，React 能读到结果 |
+| `@DynamicParameter` 系列 | ⚠️ 仅 openapi2 | ✅ | ❌ | 4.0 起放弃维护 |
+| `@Ignore` | ✅ 过滤接口 | ✅ | ⚠️ | 后端过滤后 React 不展示被忽略接口 |
+
+---
+
+## 八、常见问题
+
+### `@ApiSupport` 和 `@Tag` 的关系是什么？
+
+`@Tag` 是 OpenAPI 3 标准注解，定义分组名称和描述。`@ApiSupport` 是 Knife4j 增强注解，提供排序和开发者信息——两者互补，不冲突：
+
+```java
+@Tag(name = "用户管理", description = "用户 CRUD 接口")  // 标准属性
+@ApiSupport(order = 1, author = "张三")                   // Knife4j 增强
+```
+
+### `@Schema` 的 `requiredMode` vs `required`？
+
+- `required = true`：Swagger 2 遗留写法，仍可用但已废弃。
+- `requiredMode = Schema.RequiredMode.REQUIRED`：OpenAPI 3 推荐写法（since swagger-annotations 2.2）。
+
+```java
+// ✅ 推荐
+@Schema(description = "用户名", requiredMode = Schema.RequiredMode.REQUIRED)
+private String name;
+
+// ⚠️ 遗留写法（仍可用）
+@Schema(description = "用户名", required = true)
+private String name;
+```
+
+### 为什么 `@ApiSupport.order` 不生效？
+
+1. 确认 `knife4j.enable=true` 已配置。
+2. 确认使用的是 WebMvc Starter（非 WebFlux，WebFlux 不支持后端增强）。
+3. React 前端暂不支持按 `order` 排序，切换到 Vue2 前端验证。
+
+### `@Ignore` vs `@Hidden` 用哪个？
+
+功能重叠，推荐优先使用 OpenAPI 3 标准的 `@Hidden`。`@Ignore` 的额外好处是可附带忽略原因说明，但当前无 UI 消费此信息。
+

--- a/docs-site/reference/compatibility.md
+++ b/docs-site/reference/compatibility.md
@@ -1,49 +1,99 @@
+---
+title: 兼容矩阵
+---
+
 # 兼容矩阵
 
-这份矩阵先描述的是**当前工程依赖基线**，主要依据 `knife4j/pom.xml` 整理，不等于每一种组合都已经完成全量回归测试。
+本页回答两个现实问题：
 
-## 当前基线
+1. **我现在能不能迁过来？**
+2. **迁过来之后我最该先验证什么？**
 
-| 维度 | 当前基线 |
+## 依赖基线
+
+| 维度 | 版本 |
 | --- | --- |
-| 项目版本 | `4.6.0.3` |
-| Java 基线 | `1.8` |
-| Spring Framework 5.x | `5.3.31` |
-| Spring Boot 2.x | `2.7.18` |
-| Spring Framework 6.x | `6.2.0` |
-| Spring Boot 3.x | `3.4.x / 3.5.x` |
-| Springfox | `2.10.5` |
-| springdoc-openapi | `1.8.0` |
-| springdoc-openapi Jakarta | `2.8.9` |
+| knife4j-next | `4.6.0.3` |
+| Java 最低版本 | `1.8`（openapi2 / openapi3 非 Jakarta）；`17`（Jakarta） |
+| Springfox | `2.10.5`（openapi2 starter） |
+| springdoc-openapi | `1.8.0`（Boot 2.x）；`2.8.9`（Boot 3.x Jakarta） |
+| 前端 UI | React（openapi3 starter）；Vue2（openapi2 starter） |
 
-## 当前站点建议怎么表达兼容性
+## Starter 兼容矩阵
 
-### 作为文档承诺
+以下矩阵基于 `knife4j-smoke-tests` 模块的自动化验证结果。✅ = smoke test 已通过；⚠️ = 依赖层面可用但无自动测试；❌ = 不兼容。
 
-- `Spring Boot 2.7.x`：优先维护
-- `Spring Boot 3.4.x`：优先维护
-- `doc.html`：继续作为默认访问入口
-- `Gateway / Aggregation`：作为重点回归场景
+### WebMvc（Servlet）
 
-### 不要过度承诺
+| Starter | Boot 2.7 | Boot 3.4 | Boot 3.5 | UI | 验证状态 |
+| --- | --- | --- | --- | --- | --- |
+| `knife4j-openapi2-spring-boot-starter` | ✅ | ❌ | ❌ | Vue2 | [boot2-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot2-app) |
+| `knife4j-openapi3-spring-boot-starter` | ✅ | ❌ | ❌ | React | [boot3-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-app) |
+| `knife4j-openapi3-jakarta-spring-boot-starter` | ❌ | ✅ | ✅ | React | [boot3-jakarta-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-jakarta-app) / [boot35-jakarta-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot35-jakarta-app) |
 
-- 不要在首页直接写“全面兼容所有 3.x / 4.x”
-- 不要把尚未跑通的组合写成已支持
-- 不要把实验性前端路线混进兼容性承诺
+- openapi2 starter 依赖 Springfox，**不能在 Boot 3.x 上使用**。
+- openapi3（非 Jakarta）starter 依赖 `springdoc-openapi 1.8.0`，**仅适用于 Boot 2.x**。
+- openapi3 Jakarta starter 依赖 `springdoc-openapi 2.8.9`，**仅适用于 Boot 3.x**。
 
-## 后续应该补的验证矩阵
+### WebFlux
 
-| 方向 | 建议动作 |
-| --- | --- |
-| Boot 2.7 | 跑 starter 冒烟示例 |
-| Boot 3.4 / 3.5 | 跑 Jakarta starter 与静态资源访问 |
-| WebFlux | 验证 `openapi3-webflux` 两条线 |
-| Gateway | 覆盖路由聚合、上下文路径、鉴权 |
-| 文档访问 | 验证 `doc.html`、`v2/api-docs`、`v3/api-docs` |
+| Starter | Boot 2.7 | Boot 3.4+ | UI | 验证状态 |
+| --- | --- | --- | --- | --- |
+| `knife4j-openapi3-webflux-spring-boot-starter` | ⚠️ | ❌ | React | 无 smoke test |
+| `knife4j-openapi3-webflux-jakarta-spring-boot-starter` | ❌ | ⚠️ | React | 无 smoke test |
 
-## 这个页面的定位
+- WebFlux starter 是**纯依赖编排**，不含后端增强能力（`@ApiOperationSupport`、`knife4j.setting.*` 等）。
+- 详见 [WebFlux 接入](../guide/webflux)。
 
-这个页面不是在“炫技”，而是在帮助用户回答两个现实问题：
+### Gateway & 聚合
 
-1. 我现在能不能迁过来？
-2. 迁过来之后我最该先验证什么？
+| Starter | Boot 2.7 | Boot 3.4+ | 说明 | 验证状态 |
+| --- | --- | --- | --- | --- |
+| `knife4j-gateway-spring-boot-starter` | ❌ | ✅ | Spring Cloud Gateway 聚合 | ⚠️ 手动验证 |
+| `knife4j-aggregation-spring-boot-starter` | ✅ | ❌ | 独立聚合（Boot 2.x） | ⚠️ 手动验证 |
+| `knife4j-aggregation-jakarta-spring-boot-starter` | ❌ | ✅ | 独立聚合（Boot 3.x） | ⚠️ 手动验证 |
+
+- Gateway starter 仅用于 Spring Cloud Gateway（WebFlux），**不适用于普通 WebMvc 项目**。
+- 聚合 starter 用于**非网关**的微服务聚合场景。
+- 详见 [Gateway 聚合](../guide/gateway) 和 [独立聚合](../guide/aggregation)。
+
+## Smoke Tests 验证内容
+
+每个 smoke-test 子模块验证以下端点返回 200 且内容正确：
+
+| 端点 | openapi2 验证 | openapi3 验证 |
+| --- | --- | --- |
+| `GET /doc.html` | ✅ 包含 `webjars/js/` | ✅ 包含 `webjars/knife4j-ui-react/` |
+| `GET /v2/api-docs` | ✅ 包含 `"swagger":"2.0"` | — |
+| `GET /v3/api-docs` | — | ✅ 包含 `"openapi"` |
+
+运行全部 smoke test：
+
+```bash
+./scripts/test-java.sh
+```
+
+## 选型决策树
+
+```
+你的 Spring Boot 版本是？
+├── 2.x
+│   ├── 需要继续用 Swagger 2 / Springfox？
+│   │   └── knife4j-openapi2-spring-boot-starter（Vue2 UI）
+│   └── 用 OpenAPI 3 / springdoc？
+│       ├── WebMvc → knife4j-openapi3-spring-boot-starter（React UI）
+│       └── WebFlux → knife4j-openapi3-webflux-spring-boot-starter（React UI）
+└── 3.x
+    ├── WebMvc → knife4j-openapi3-jakarta-spring-boot-starter（React UI）
+    ├── WebFlux → knife4j-openapi3-webflux-jakarta-spring-boot-starter（React UI）
+    └── Spring Cloud Gateway？
+        └── knife4j-gateway-spring-boot-starter
+```
+
+## 不要做的事
+
+- ❌ 不要在 Boot 3.x 上使用 openapi2 starter（Springfox 不兼容 Jakarta）。
+- ❌ 不要同时引入 WebMvc 和 WebFlux 版 starter。
+- ❌ 不要在 Boot 2.x 上使用 Jakarta 版 starter。
+- ❌ 不要在 Boot 3.x 上使用非 Jakarta 版 starter（springdoc 1.x 不兼容）。
+- ❌ 不要把 Gateway starter 和 WebMvc/WebFlux starter 混用。

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -1,0 +1,362 @@
+---
+title: 配置参考
+---
+
+# 配置参考
+
+本页列出所有 `knife4j.*` YAML 配置属性，按使用场景分组。
+
+> 属性源自 `@ConfigurationProperties` 类定义。部分 UI 配置在 React 前端暂不生效，已用 ⚠️ 标注。
+
+## WebMvc Starter 通用配置
+
+适用于 `knife4j-openapi2-spring-boot-starter`、`knife4j-openapi3-spring-boot-starter`、`knife4j-openapi3-jakarta-spring-boot-starter`。
+
+### `knife4j.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.enable` | `boolean` | `false` | 启用 knife4j 增强模式（openapi2 必须设为 `true`；openapi3 可选） |
+| `knife4j.cors` | `boolean` | `false` | 启用默认跨域支持 |
+| `knife4j.production` | `boolean` | `false` | 生产环境：设为 `true` 后 `/doc.html`、`/v2/api-docs`、`/v3/api-docs` 等返回 403 |
+| `knife4j.openapi` | Object | — | OpenAPI 基本信息（仅 openapi2 starter，见下文） |
+| `knife4j.basic` | Object | — | HTTP Basic 认证配置，见下文 |
+| `knife4j.setting` | Object | — | UI 个性化配置，见下文 |
+| `knife4j.documents` | List | — | 自定义 Markdown 文档分组，见下文 |
+| `knife4j.insight` | Object | — | Knife4jInsight 配置，见下文 |
+
+### `knife4j.basic.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.basic.enable` | `boolean` | `false` | 启用 Basic 认证 |
+| `knife4j.basic.username` | `String` | — | 用户名 |
+| `knife4j.basic.password` | `String` | — | 密码 |
+| `knife4j.basic.include` | `List<String>` | — | 需要认证的 URL（正则表达式，since 4.1.0） |
+
+### `knife4j.setting.*`
+
+| 属性 | 类型 | 默认值 | 说明 | React UI |
+| --- | --- | --- | --- | --- |
+| `knife4j.setting.language` | `ZH_CN` / `EN` | `ZH_CN` | 界面语言 | ⚠️ 暂不生效 |
+| `knife4j.setting.enableSwaggerModels` | `boolean` | `true` | 显示 Swagger Models 功能 | ⚠️ |
+| `knife4j.setting.swaggerModelName` | `String` | `"Swagger Models"` | Swagger Models 名称 | ⚠️ |
+| `knife4j.setting.enableDocumentManage` | `boolean` | `true` | 显示文档管理功能 | ⚠️ |
+| `knife4j.setting.enableReloadCacheParameter` | `boolean` | `false` | 显示调试后刷新变量按钮 | ⚠️ |
+| `knife4j.setting.enableAfterScript` | `boolean` | `true` | 显示 afterScript 功能 | ⚠️ |
+| `knife4j.setting.enableVersion` | `boolean` | `false` | 启用接口版本控制 | ⚠️ |
+| `knife4j.setting.enableRequestCache` | `boolean` | `true` | 启用请求参数缓存 | ⚠️ |
+| `knife4j.setting.enableFilterMultipartApis` | `boolean` | `false` | 过滤 RequestMapping 多方法显示 | ⚠️ |
+| `knife4j.setting.enableFilterMultipartApiMethodType` | `String` | `"POST"` | 过滤方法类型 | ⚠️ |
+| `knife4j.setting.enableHost` | `boolean` | `false` | 启用 Host | ⚠️ |
+| `knife4j.setting.enableHostText` | `String` | `""` | Host 地址 | ⚠️ |
+| `knife4j.setting.enableDynamicParameter` | `boolean` | `false` | 启用动态请求参数 | ⚠️ |
+| `knife4j.setting.enableDebug` | `boolean` | `true` | 启用调试功能 | ⚠️ |
+| `knife4j.setting.enableFooter` | `boolean` | `true` | 显示底部 Footer | ⚠️ |
+| `knife4j.setting.enableFooterCustom` | `boolean` | `false` | 自定义 Footer | ⚠️ |
+| `knife4j.setting.footerCustomContent` | `String` | — | 自定义 Footer 内容（支持 Markdown） | ⚠️ |
+| `knife4j.setting.enableSearch` | `boolean` | `true` | 显示搜索框 | ⚠️ |
+| `knife4j.setting.enableOpenApi` | `boolean` | `true` | 显示 OpenAPI 原始结构 Tab | ⚠️ |
+| `knife4j.setting.enableHomeCustom` | `boolean` | `false` | 启用首页自定义 | ⚠️ |
+| `knife4j.setting.homeCustomLocation` | `String` | — | 首页自定义 Markdown 文件路径 | ⚠️ |
+| `knife4j.setting.enableGroup` | `boolean` | `true` | 显示分组下拉框 | ⚠️ |
+| `knife4j.setting.enableResponseCode` | `boolean` | `true` | 显示响应状态码栏 | ⚠️ |
+| `knife4j.setting.customCode` | `Integer` | `200` | 生产环境屏蔽时的自定义 HTTP 状态码 | ✅ |
+
+> 标 ⚠️ 的配置在 React 新前端中暂不生效（后端会写入 OpenAPI extension，但前端不读取）。详见 [FAQ](../guide/faq#react-setting-not-effective)。
+
+### `knife4j.documents`（列表）
+
+```yaml
+knife4j:
+  documents:
+    - group: 2.X版本
+      name: 测试文档
+      locations: classpath:markdown/*
+```
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `group` | `String` | 所属分组 |
+| `name` | `String` | 文档名称 |
+| `locations` | `String` | Markdown 文件路径（classpath 前缀） |
+
+### `knife4j.insight.*`（since 4.4.0）
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.insight.enable` | `boolean` | `false` | 启用 Knife4jInsight 自动上传 |
+| `knife4j.insight.server` | `String` | — | Insight 数据源地址（如 `http://console.knife4j.net`） |
+| `knife4j.insight.secret` | `String` | — | 上传凭证密钥 |
+| `knife4j.insight.namespace` | `String` | — | 上传命名空间（默认从应用名生成） |
+| `knife4j.insight.serviceName` | `String` | — | 上传服务名（默认取 `spring.application.name`） |
+
+### `knife4j.openapi.*`（仅 openapi2 starter）
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.openapi.title` | `String` | — | 文档标题 |
+| `knife4j.openapi.description` | `String` | — | 描述 |
+| `knife4j.openapi.version` | `String` | — | 版本号 |
+| `knife4j.openapi.email` | `String` | — | 联系邮箱 |
+| `knife4j.openapi.url` | `String` | — | 主页 URL |
+| `knife4j.openapi.concat` | `String` | — | 联系人 |
+| `knife4j.openapi.termsOfServiceUrl` | `String` | — | 服务条款 URL |
+| `knife4j.openapi.license` | `String` | — | 许可证 |
+| `knife4j.openapi.licenseUrl` | `String` | — | 许可证 URL |
+| `knife4j.openapi.group` | `Map` | — | 分组配置（key 为分组名） |
+
+`knife4j.openapi.group.<name>.*`
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `groupName` | `String` | 分组名称 |
+| `apiRule` | `PACKAGE` / `ANNOTATION` | API 扫描策略 |
+| `apiRuleResources` | `List<String>` | 策略对应资源（包名或注解类名） |
+| `pathRule` | `ANT` / `REGEX` | 路径匹配策略 |
+| `pathRuleResources` | `List<String>` | 路径资源 |
+
+---
+
+## Gateway Starter 配置
+
+适用于 `knife4j-gateway-spring-boot-starter`。
+
+### `knife4j.gateway.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.gateway.enabled` | `boolean` | `false` | 启用 Gateway 聚合 |
+| `knife4j.gateway.strategy` | `MANUAL` / `DISCOVER` | `MANUAL` | 聚合策略 |
+| `knife4j.gateway.tagsSorter` | `alpha` / `order` | `alpha` | Tag 排序规则 |
+| `knife4j.gateway.operationsSorter` | `alpha` / `order` | `alpha` | Operation 排序规则 |
+| `knife4j.gateway.basic` | Object | — | Basic 认证（同 `knife4j.basic`） |
+| `knife4j.gateway.discover` | Object | — | 服务发现配置 |
+| `knife4j.gateway.routes` | List | — | 手动路由配置 |
+
+### `knife4j.gateway.discover.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `enabled` | `Boolean` | `FALSE` | 启用服务发现 |
+| `excludedServices` | `Set<String>` | — | 排除的服务名（支持正则，since 4.3.0） |
+| `version` | `OpenAPI3` / `Swagger2` | `OpenAPI3` | 规范版本 |
+
+### `knife4j.gateway.routes[]`
+
+```yaml
+knife4j:
+  gateway:
+    enabled: true
+    routes:
+      - name: 用户服务
+        serviceName: user-service
+        url: /v3/api-docs
+        contextPath: /
+        order: 1
+```
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `name` | `String` | — | 分组名称（UI 显示） |
+| `serviceName` | `String` | — | 服务名 |
+| `url` | `String` | `"/v2/api-docs?group=default"` | OpenAPI 数据源路径 |
+| `contextPath` | `String` | `"/"` | 上下文路径（since 4.1.0） |
+| `order` | `Integer` | `0` | 排序（升序） |
+
+---
+
+## 聚合 Starter 配置
+
+适用于 `knife4j-aggregation-spring-boot-starter` 和 `knife4j-aggregation-jakarta-spring-boot-starter`。
+
+### `knife4j.enableAggregation`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.enableAggregation` | `boolean` | `false` | 启用聚合模式 |
+
+### `knife4j.disk.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.disk.enable` | `boolean` | `false` | 启用 Disk 模式 |
+| `knife4j.disk.routes` | List | — | Disk 路由列表 |
+
+`knife4j.disk.routes[]`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `name` | `String` | — | 服务名（UI 分组显示） |
+| `location` | `String` | — | OpenAPI 文件路径（classpath 或 URL） |
+| `debugUrl` | `String` | — | 调试目标 URL |
+| `swaggerVersion` | `String` | `"2.0"` | 规范版本（`2.0` 或 `3.0`） |
+| `servicePath` | `String` | — | 微服务路径（网关 basePath） |
+| `order` | `Integer` | `1` | 排序 |
+
+### `knife4j.cloud.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.cloud.enable` | `boolean` | `false` | 启用 Cloud 模式 |
+| `knife4j.cloud.routes` | List | — | Cloud 路由列表 |
+| `knife4j.cloud.routeAuth` | Object | — | 通用路由认证 |
+
+`knife4j.cloud.routes[]`
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `name` | `String` | 服务名 |
+| `uri` | `String` | OpenAPI 实例 URI（如 `http://192.168.0.1:8999`） |
+| `location` | `String` | OpenAPI 文件路径 |
+| `debugUrl` | `String` | 调试目标 URL |
+| `swaggerVersion` | `String` | 规范版本 |
+| `servicePath` | `String` | 微服务路径 |
+| `routeAuth` | Object | 路由级认证（覆盖通用配置） |
+| `order` | `Integer` | 排序 |
+
+### `knife4j.nacos.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.nacos.enable` | `boolean` | `false` | 启用 Nacos 模式 |
+| `knife4j.nacos.serviceUrl` | `String` | — | Nacos 地址（如 `http://192.168.0.1:8848/nacos`） |
+| `knife4j.nacos.secret` | `String` | — | 接口访问密钥 |
+| `knife4j.nacos.serviceAuth` | Object | — | Nacos 注册中心认证 |
+| `knife4j.nacos.routeAuth` | Object | — | 通用路由认证 |
+| `knife4j.nacos.routes` | List | — | Nacos 路由列表 |
+
+`knife4j.nacos.routes[]`
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `serviceName` | `String` | 服务名（必填） |
+| `groupName` | `String` | Nacos 分组 |
+| `namespaceId` | `String` | 命名空间 ID |
+| `clusters` | `String` | 集群名（逗号分隔） |
+| *(继承 `CommonRoute`)* `name`, `location`, `debugUrl`, `swaggerVersion`, `servicePath`, `order`, `routeAuth` | | 同 Cloud 路由 |
+
+### `knife4j.eureka.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.eureka.enable` | `boolean` | `false` | 启用 Eureka 模式 |
+| `knife4j.eureka.serviceUrl` | `String` | — | Eureka 地址（如 `http://localhost:10000/eureka/`） |
+| `knife4j.eureka.serviceAuth` | Object | — | Eureka 注册中心认证 |
+| `knife4j.eureka.routeAuth` | Object | — | 通用路由认证 |
+| `knife4j.eureka.routes` | List | — | Eureka 路由列表 |
+
+`knife4j.eureka.routes[]`
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `serviceName` | `String` | 服务名（必填） |
+| *(继承 `CommonRoute`)* `name`, `location`, `debugUrl`, `swaggerVersion`, `servicePath`, `order`, `routeAuth` | | 同 Cloud 路由 |
+
+### `knife4j.polaris.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.polaris.enable` | `boolean` | `false` | 启用 Polaris 模式 |
+| `knife4j.polaris.serviceUrl` | `String` | — | Polaris 地址 |
+| `knife4j.polaris.serviceAuth` | Object | — | Polaris 注册中心认证 |
+| `knife4j.polaris.jwtCookie` | `String` | — | 接口访问 JWT Cookie |
+| `knife4j.polaris.routeAuth` | Object | — | 通用路由认证 |
+| `knife4j.polaris.routes` | List | — | Polaris 路由列表 |
+
+`knife4j.polaris.routes[]`
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `service` | `String` | 服务名（必填） |
+| `namespace` | `String` | 命名空间 ID |
+| *(继承 `CommonRoute`)* `name`, `location`, `debugUrl`, `swaggerVersion`, `servicePath`, `order`, `routeAuth` | | 同 Cloud 路由 |
+
+### `knife4j.openapiv3.*`（聚合 Jakarta 版）
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.openapiv3.url` | `String` | `"/v3/api-docs"` | OpenAPI 数据源 URL |
+| `knife4j.openapiv3.oauth2RedirectUrl` | `String` | `""` | OAuth2 重定向 URL |
+| `knife4j.openapiv3.validatorUrl` | `String` | `""` | Validator URL |
+| `knife4j.openapiv3.tagsSorter` | `alpha` / `order` | `alpha` | Tag 排序规则（since 4.5.0） |
+| `knife4j.openapiv3.operationsSorter` | `alpha` / `order` | `alpha` | Operation 排序规则（since 4.5.0） |
+
+### `knife4j.basic-auth.*`（聚合版）
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.basic-auth.enable` | `boolean` | `false` | 启用认证 |
+| `knife4j.basic-auth.username` | `String` | — | 用户名 |
+| `knife4j.basic-auth.password` | `String` | — | 密码 |
+
+### `knife4j.connection-setting.*`
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `knife4j.connection-setting.socketTimeout` | `int` | `10000` | Socket 超时（ms） |
+| `knife4j.connection-setting.connectTimeout` | `int` | `10000` | 连接超时（ms） |
+| `knife4j.connection-setting.maxConnectionTotal` | `int` | `200` | 最大连接数 |
+| `knife4j.connection-setting.maxPreRoute` | `int` | `20` | 单路由最大连接数 |
+
+---
+
+## 配置示例
+
+### 最小配置（WebMvc + OpenAPI3）
+
+```yaml
+knife4j:
+  enable: true
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+```
+
+### 生产环境配置
+
+```yaml
+knife4j:
+  enable: true
+  production: true
+  basic:
+    enable: true
+    username: admin
+    password: ${DOC_PASSWORD}
+```
+
+### Gateway 聚合配置（DISCOVER 模式）
+
+```yaml
+knife4j:
+  gateway:
+    enabled: true
+    strategy: discover
+    discover:
+      enabled: true
+      version: openapi3
+      excludedServices:
+        - gateway-service
+    basic:
+      enable: true
+      username: admin
+      password: ${DOC_PASSWORD}
+```
+
+### Nacos 聚合配置
+
+```yaml
+knife4j:
+  enableAggregation: true
+  nacos:
+    enable: true
+    serviceUrl: http://127.0.0.1:8848/nacos
+    routes:
+      - name: 用户服务
+        serviceName: user-service
+        groupName: DEFAULT_GROUP
+        namespaceId: public
+

--- a/docs-site/reference/modules.md
+++ b/docs-site/reference/modules.md
@@ -1,39 +1,105 @@
+---
+title: 模块说明
+---
+
 # 模块说明
 
-仓库目前不是单一 Java 包，而是一组并行演进的模块。新文档站需要把这件事讲清楚，不然用户会误以为所有东西都已经在同一成熟度上。
+## 仓库顶层目录
 
-## 仓库顶层模块
-
-| 模块 | 当前角色 |
+| 目录 | 说明 |
 | --- | --- |
-| `knife4j` | Java 主工程，是真正对用户交付 starter 和 webjar 的地方 |
-| `knife4j-doc` | 历史 Docusaurus 文档站源码，仍保留大量旧资料 |
-| `docs-site` | 新的 VitePress 文档站原型，用来承接 `knife4j-next` 叙事 |
-| `knife4j-front` | 下一代前端工作区，包含解析核心、React UI、CLI 和扩展能力 |
-| `knife4j-vue` | 当前历史前端实现，更多承担“现有行为参考”角色 |
-| `knife4j-vue3` | 社区贡献的实验实现，暂不作为主线发布 |
-| `knife4j-insight` | 独立渲染/聚合方向的扩展能力 |
+| `knife4j/` | Java 主工程——用户实际引入的 starter 和 webjar 都在这里构建 |
+| `knife4j-front/` | 下一代前端工作区（React UI + parser-core） |
+| `knife4j-vue/` | 当前历史 Vue2 前端实现，承担"现有行为参考"角色 |
+| `knife4j-vue3/` | 社区贡献的实验性 Vue3 实现，暂不作为主线发布 |
+| `knife4j-insight/` | 独立渲染 / 聚合方向的扩展能力 |
+| `knife4j-doc/` | 历史 Docusaurus 文档站（已废弃，内容迁移到 `docs-site/`） |
+| `docs-site/` | 当前 VitePress 文档站 |
 
-## 现在最应该对外强调什么
+## Java 模块（`knife4j/` 下）
 
-### 1. 交付主线还是 Java 工程
+### 核心
 
-用户真正落地接入时，最关心的仍然是：
+| 模块 | 说明 | 用户是否直接引入 |
+| --- | --- | --- |
+| `knife4j-core` | 核心逻辑：过滤器、配置解析、vendor extension、OpenAPI 自定义器等 | 间接（starter 传递） |
+| `knife4j-dependencies` | BOM（dependencyManagement），统一管理所有版本 | 间接（父 POM 继承） |
 
-- 引哪个 starter
-- 能不能打开 `doc.html`
-- 网关聚合是否正常
+### UI（Webjar）
 
-所以文档站首页不能被“下一代前端”抢走重心。
+| 模块 | 说明 | 前端技术 |
+| --- | --- | --- |
+| `knife4j-openapi2-ui` | Swagger 2 专用 UI webjar，`doc.html` 入口 | Vue2 |
+| `knife4j-openapi3-ui` | OpenAPI 3 专用 UI webjar，`doc.html` 入口 | React |
 
-### 2. React 线是未来，不是假装现在已经完成
+### Starter（WebMvc）
 
-`knife4j-front` 很重要，但现在更适合被描述为：
+| 模块 | 适用 Boot 版本 | 依赖的 springdoc | 依赖的 UI |
+| --- | --- | --- | --- |
+| `knife4j-openapi2-spring-boot-starter` | 2.x | —（用 Springfox） | `knife4j-openapi2-ui`（Vue2） |
+| `knife4j-openapi3-spring-boot-starter` | 2.x | `springdoc-openapi-ui 1.8.0` | `knife4j-openapi3-ui`（React） |
+| `knife4j-openapi3-jakarta-spring-boot-starter` | 3.x | `springdoc-openapi-starter-webmvc-ui 2.8.9` | `knife4j-openapi3-ui`（React） |
 
-- 下一代 UI 和解析能力的工作区
-- 未来可能的主线前端方向
-- 先服务内部演进，再逐步对外承诺
+### Starter（WebFlux）
 
-### 3. 历史站点保留为资料库
+| 模块 | 适用 Boot 版本 | 说明 |
+| --- | --- | --- |
+| `knife4j-openapi3-webflux-spring-boot-starter` | 2.x | 纯依赖编排，无后端增强 |
+| `knife4j-openapi3-webflux-jakarta-spring-boot-starter` | 3.x | 纯依赖编排，无后端增强 |
 
-短期内旧 `knife4j-doc` 仍有价值，因为它沉淀了大量历史文档和旧链接。新站不需要第一天就全量搬迁，只需要先接住最关键的入口页。
+### Starter（Gateway & 聚合）
+
+| 模块 | 适用 Boot 版本 | 场景 |
+| --- | --- | --- |
+| `knife4j-gateway-spring-boot-starter` | 3.x | Spring Cloud Gateway 聚合 |
+| `knife4j-aggregation-spring-boot-starter` | 2.x | 独立聚合（Disk/Cloud/Nacos/Eureka/Polaris） |
+| `knife4j-aggregation-jakarta-spring-boot-starter` | 3.x | 独立聚合（Jakarta 版） |
+
+### 其他
+
+| 模块 | 说明 |
+| --- | --- |
+| `knife4j-demo` | 在线演示应用（Boot 3.4.5 + Jakarta starter + Dockerfile） |
+| `knife4j-smoke-tests` | 自动化冒烟测试（4 个子模块覆盖 Boot 2.x / 3.x / 3.5.x） |
+
+## 选型决策树
+
+```
+你的项目是什么？
+│
+├── 普通 Spring Boot WebMvc 应用
+│   ├── Boot 2.x + 要用 Swagger 2 / Springfox
+│   │   └── knife4j-openapi2-spring-boot-starter
+│   ├── Boot 2.x + 要用 OpenAPI 3
+│   │   └── knife4j-openapi3-spring-boot-starter
+│   └── Boot 3.x
+│       └── knife4j-openapi3-jakarta-spring-boot-starter
+│
+├── Spring Boot WebFlux 应用（非网关）
+│   ├── Boot 2.x
+│   │   └── knife4j-openapi3-webflux-spring-boot-starter
+│   └── Boot 3.x
+│       └── knife4j-openapi3-webflux-jakarta-spring-boot-starter
+│
+├── Spring Cloud Gateway 网关
+│   └── knife4j-gateway-spring-boot-starter（Boot 3.x）
+│
+└── 非网关的微服务聚合
+    ├── Boot 2.x
+    │   └── knife4j-aggregation-spring-boot-starter
+    └── Boot 3.x
+        └── knife4j-aggregation-jakarta-spring-boot-starter
+```
+
+## 前端工作区（`knife4j-front/` 下）
+
+| 模块 | 说明 |
+| --- | --- |
+| `knife4j-ui-react` | React 新前端，已集成进 `knife4j-openapi3-ui` webjar |
+| `parser-core` | 前端 OpenAPI 解析核心库 |
+
+## 注意事项
+
+- **不要同时引入多个 starter**。WebMvc / WebFlux / Gateway / Aggregation 是互斥的，选一个即可。
+- **openapi2 starter 不兼容 Boot 3.x**。它依赖 Springfox，Springfox 不支持 Jakarta。
+- **WebFlux starter 不含后端增强**。`@ApiOperationSupport`、`knife4j.setting.*` 等能力仅 WebMvc starter 提供。详见 [WebFlux 接入](../guide/webflux)。

--- a/docs-site/reference/version-ref.md
+++ b/docs-site/reference/version-ref.md
@@ -1,0 +1,73 @@
+---
+title: 版本对照
+---
+
+# 版本对照
+
+## knife4j-next 版本 vs Spring Boot 版本
+
+| knife4j-next 版本 | Spring Boot 2.x | Spring Boot 3.x | 说明 |
+| --- | --- | --- | --- |
+| `4.6.0.3` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | 当前版本，含 Boot 3.4/3.5 兼容修复 |
+| `4.6.0.2` | ✅ 2.7.18 | ✅ 3.4.0 | Gateway context-path 修复 |
+| `4.6.0.1` | ✅ 2.7.18 | ✅ 3.4.0 | Basic 认证绕过安全修复 |
+| `4.6.0` | ✅ 2.7.18 | ⚠️ 3.4.0（有已知问题） | 基于 upstream `4.6.0` |
+
+> knife4j-next 版本号策略：`<upstream版本>.<fork补丁号>`。例如 `4.6.0.3` = upstream `4.6.0` + 3 个 fork 专有补丁。
+
+## 核心依赖版本
+
+以下为 `knife4j-next 4.6.0.3` 内部管理的依赖版本，用户一般不需要手动指定。
+
+### Boot 2.x（非 Jakarta）线
+
+| 依赖 | 版本 |
+| --- | --- |
+| Spring Framework | `5.3.31` |
+| Spring Boot | `2.7.18` |
+| Springfox | `2.10.5` |
+| springdoc-openapi | `1.8.0` |
+| Swagger 2 models | `1.6.14` |
+| Servlet API | `4.0.1` |
+
+### Boot 3.x（Jakarta）线
+
+| 依赖 | 版本 |
+| --- | --- |
+| Spring Framework | `6.2.0` |
+| Spring Boot | `3.4.0` |
+| springdoc-openapi Jakarta | `2.8.9` |
+| Swagger v3 models | `2.2.26` |
+| Servlet Jakarta API | `6.1.0` |
+
+> smoke-tests 中 `boot3-jakarta-app` 使用 Boot `3.4.5`，`boot35-jakarta-app` 使用 Boot `3.5.0`，均通过验证。
+
+### 其他共享依赖
+
+| 依赖 | 版本 |
+| --- | --- |
+| Java 最低版本 | `1.8`（非 Jakarta）；`17`（Jakarta） |
+| SLF4J | `2.0.16` |
+| Hutool | `5.8.34` |
+| Gson | `2.11.0` |
+| Javassist | `3.30.2-GA` |
+| Lombok | `1.18.36` |
+
+## Upstream 版本对照
+
+| upstream 版本 | fork 基线 | fork 额外修复 |
+| --- | --- | --- |
+| `4.6.0` | `4.6.0` | — |
+| `4.6.0` | `4.6.0.1` | [#886](https://github.com/xiaoymin/knife4j/issues/886) Basic 认证绕过 |
+| `4.6.0` | `4.6.0.2` | [#954](https://github.com/xiaoymin/knife4j/issues/954) Gateway context-path |
+| `4.6.0` | `4.6.0.3` | [#874](https://github.com/xiaoymin/knife4j/issues/874) [#913](https://github.com/xiaoymin/knife4j/issues/913) Boot 3.4/3.5 兼容 + React UI 集成 |
+
+## 如何确认你项目中的实际版本
+
+```bash
+mvn dependency:tree -Dincludes=com.baizhukui
+mvn dependency:tree -Dincludes=org.springdoc
+```
+
+如果 springdoc 版本与上表不一致，说明你的项目中有其他依赖覆盖了版本管理。请检查是否有 BOM 或父 POM 引入了不同版本的 springdoc。
+

--- a/docs-site/release-notes/index.md
+++ b/docs-site/release-notes/index.md
@@ -1,6 +1,16 @@
+---
+title: 发布说明
+---
+
 # 发布说明
 
-## 当前版本
+本页记录 knife4j-next（`com.baizhukui` 坐标）所有版本的变更，以及上游 knife4j 的历史版本供参考。
+
+> 判断"值不值得升"？对照 [兼容矩阵](/reference/compatibility) 和 [迁移指引](/guide/migration)。
+
+---
+
+## knife4j-next 版本（com.baizhukui）
 
 ### 4.6.0.3
 
@@ -45,8 +55,133 @@
 
 ---
 
-## 关于这个页面
+## 上游 knife4j 版本（com.github.xiaoymin）
 
-每个版本修复了哪些兼容性问题、哪些问题仍在处理中，都会在这里持续更新。
+> 以下版本来自上游 `xiaoymin/knife4j`，knife4j-next 基于最后的 4.5.0 版本 fork。
 
-如果你想判断"现在这个版本值不值得升"，可以对照 [兼容矩阵](/reference/compatibility) 和 [迁移指引](/guide/migration)。
+### 4.5.0（2024-01-08）— 上游最终版本
+
+- 新增日语 i18n 支持（Gitee#PR98）
+- 修复 `EnvironmentPostProcessor` 与用户 `defaultProperties` 冲突（Gitee#PR100）
+- 修复 `addOrderExtension` NPE（Gitee#PR99）
+- **修复 Spring Boot 3 下 `@ApiOperationSupport` 的 `order` 不生效**（核心修复）
+- 修复 `springdoc.group-configs.packages-to-scan` 未设置时的 NPE（Gitee#I8O7E8）
+- 修复 `@Schema.description` 在实体参数上不渲染（Gitee#I8EVO3, GitHub#690）
+- 修复 OpenAPI 3 请求参数 `format` 属性展示异常（Gitee#I8KRWV）
+- 修复自定义文档中服务名含连字符时刷新报错（Gitee#I8EKAQ）
+- 移除文档 `favicon.ico` 引用（GitHub#716）
+- 企业插件扩展点（Orangeforms 低代码平台）
+
+---
+
+### 4.4.0（2023-12-10）— OpenAPI 自动注册
+
+- 修复 Eureka 大写服务名导致 gateway 聚合失败（Gitee#93）
+- 修复调试 body 请求文件下载乱码
+- 修复 gateway 聚合中 springdoc 子服务默认 `/default` 路径 404（Gitee#I7RAP7）
+- 修复 Boot 3 下 gateway Basic 认证密码不兼容（GitHub#PR652）
+- 修复 Boot 3 `javax.filter` 兼容性（GitHub#667）
+- 无默认分组时 UI 显示分组名称
+- 修复 `SecurityDocketUtils` 绑定 `SecurityContext` 到错误引用（Gitee#I88IYH）
+- 离线 HTML 文档改用国内 CDN（Gitee#I8C85P）
+- 升级 springdoc-openapi 至 **2.3.0**
+- 修复 `EnvironmentPostProcessor` 与用户 `defaultProperties` 冲突（GitHub#686）
+
+---
+
+### 4.3.0（2023-08-06）— Gateway 极简配置
+
+- `excluded-services` 支持正则匹配（如 `order.*`）
+- 修复两个子服务根路由转发时只聚合一个的问题
+- 修复 `DiscoveryClient` 作为默认转发路由时聚合失败
+- 修复 Swagger 2 聚合失败
+- 手动模式支持 Swagger 2 与 OpenAPI 3 **混合聚合**
+- 修复全部子服务为 Swagger 2 时的 `contextPath` 错误
+- 重构 gateway 内部，`discover` 模式提供 4 种路由来源策略
+- 修复 `@ApiSupport` 不生效（Gitee#PR89）
+- 修复 Swagger model 枚举值不展开（Gitee#PR90）
+- 修复组件冲突（GitHub#620）
+- 新增 `title` 属性支持（Gitee#I7KUYP）
+
+---
+
+### 4.2.0（2023-07-31）— Gateway 增强
+
+- 升级 Spring Boot 3 至 **3.0.7**，springdoc 至 **1.7.0** / **2.1.0**
+- `discover` 模式自动读取 gateway 路由 `prefix`
+- 支持多 group 类型（非仅 `default`）
+- 新增 `GatewayServiceExcludeService` SPI 用于排除服务（Gitee#I6YLMB）
+- 修复 Nginx / 二级代理路径问题（Gitee#I73AOG, #I6KYUJ; GitHub#609, #603, #586）
+- 新增 `tags-sorter` / `operations-sorter` 排序配置
+- gateway 组件支持 Basic 认证（GitHub#555）
+- 生成的 TypeScript 代码包含注释（Gitee#I6T78E, GitHub#568）
+- OpenAPI 2 `allOf` 支持（GitHub#PR589）
+- `jakarta` Basic 属性提示修复（GitHub#578）
+- **OpenAPI 3 开始支持 `@ApiSupport` 增强注解**（Gitee#I79WIJ）
+- `lombok`、`slf4j` 改为 `provided` scope（GitHub#591）
+
+---
+
+### 4.1.0（2023-03-23）— 16 项 Bug 修复 + Gateway 发现模式
+
+- 修复 gateway 聚合 OpenAPI 3 丢失 `context-path`
+- 升级 springdoc-openapi 至 **1.6.15** / **2.0.4**
+- 修复 `knife4j-openapi3-jakarta-spring-boot-starter` IDEA 属性提示
+- 修复自定义文档分组加载 Bug（GitHub#PR525）
+- 修复 `knife4j-dependencies` 模块缺少版本号
+- 修复缺少 `springdoc-openapi-ui` 依赖时的 NPE
+- 修复 OAS3 参数缺少 `field-description`
+- 修复 OAS3 扩展属性（order、author 等）不生效（Gitee#I6FB9I）
+- 修复部分字段翻译问题（GitHub#540）
+- 修复 `production` 模式启用增强属性时的 NPE（GitHub#527）
+- 修复 OpenAPI 3 tag-name 兼容性（Gitee#I6JATP）
+- 修复 URL 参数实体类不展示参数描述（Gitee#I6H8CD）
+- 修复 OAS3 上传组件识别（Gitee#I6HAW0, GitHub#538）
+- **新增 Spring WebFlux starter 打包**（GitHub#521）
+- Basic 认证新增 `include` 属性用于自定义包含路径（GitHub#530）
+- 全局搜索支持 tag-name 模糊搜索（Gitee#I6NWV6）
+- **Gateway 新增 `discover` 服务发现聚合模式**
+
+---
+
+### 4.0.0（2022-12-20）— 架构重写（大版本）
+
+- 统一所有模块版本号，**`artifactId` 名称变更**（Breaking Change）
+- **新增 Spring Boot 3 支持**，通过 `jakarta` starter
+- 采用 **springdoc-openapi** 作为 OpenAPI 3 底层框架（替代 springfox 3.0）
+- 保留 springfox 2.10.5 用于 OpenAPI 2 / Boot 2 路径
+- 重写 Knife4j-Desktop 聚合架构，发布官方 Docker 镜像
+- 全新模块布局：
+  - `knife4j-core`、`knife4j-dependencies`
+  - `knife4j-openapi2-ui`、`knife4j-openapi3-ui`
+  - `knife4j-openapi2-spring-boot-starter`（Boot < 3 + OAS2）
+  - `knife4j-openapi3-spring-boot-starter`（Boot < 3 + OAS3）
+  - `knife4j-openapi3-jakarta-spring-boot-starter`（Boot ≥ 3 + OAS3）
+  - `knife4j-gateway-spring-boot-starter`、`knife4j-aggregation-spring-boot-starter`
+- **配置属性命名改为 kebab-case**（Breaking Change）
+  - 如 `enableSwaggerModels` → `enable-swagger-models`
+  - 如 `footerCustomContent` → `footer-custom-content`
+
+---
+
+## 版本号说明
+
+knife4j-next 的版本号遵循 `<upstream-version>.<patch>` 格式：
+
+```
+4.5.0 → 上游 knife4j 4.5.0（最后上游版本）
+4.6.0.1 → fork 后第一个补丁版本
+4.6.0.2 → fork 后第二个补丁版本（安全修复 + Boot 3.4/3.5 兼容）
+4.6.0.3 → fork 后第三个补丁版本（React 前端集成）
+```
+
+从 4.6.0.1 开始，Maven 坐标变更为 `com.baizhukui`：
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>4.6.0.3</version>
+</dependency>
+```
+
+详见 [版本参考](/reference/version-ref) 和 [迁移指引](/guide/migration)。

--- a/docs-site/roadmap/index.md
+++ b/docs-site/roadmap/index.md
@@ -1,33 +1,135 @@
-# 下一步路线图
+---
+title: 路线图
+---
 
-这份路线图不是长期愿景海报，而是围绕你现在最现实的目标来排优先级：先成为一个能被社区信任的维护分支，再逐步变成真正的新主线。
+# 路线图
 
-## 接下来 30 天
+这份路线图不是长期愿景海报，而是围绕最现实的目标排优先级：先成为一个能被社区信任的维护分支，再逐步变成真正的新主线。
 
-- 清理高优先级兼容性 Issue
-- 发布一个让社区敢试用的稳定版本
-- 明确 Spring Boot 2.x / 3.x 的接入与迁移文档
-- 把新文档站作为 fork 的主入口先跑起来
+---
 
-## 接下来 60 天
+## 当前阶段：稳定维护 + React 前端对齐
 
-- 补齐网关聚合和 `doc.html` 相关 FAQ
-- 建立更清晰的兼容矩阵与示例工程
-- 用小版本持续发布，而不是憋大版本
-- 开始决定 React 前端对外公开的范围
+### 已完成 ✅
+
+| 领域 | 里程碑 | 状态 |
+| --- | --- | --- |
+| 基础设施 | Maven `groupId` 迁移至 `com.baizhukui` | ✅ |
+| 基础设施 | GitHub Actions CI/CD 流程补齐 | ✅ |
+| 安全 | 修复 `/v2/api-docs` 分号绕过 Basic 认证（#886） | ✅ |
+| 兼容性 | Spring Boot 3.4.x / 3.5.x 兼容（springdoc 2.8.9） | ✅ |
+| Bug 修复 | Gateway `context-path` 导致聚合 host 少斜杠（#954） | ✅ |
+| Demo | `knife4j-demo` 模块 + Docker 部署 | ✅ |
+| 文档 | VitePress 文档站全面重写 | ✅ |
+| React 前端 | 基础架构（路由、侧边栏、分组切换、搜索） | ✅ |
+| React 前端 | ApiDoc 接口文档展示（参数表格 + 响应结构） | ✅ |
+| React 前端 | ApiDebug 接口调试（表单填参 + 发请求 + 响应展示） | ✅ |
+| React 前端 | SwaggerModels 数据模型展示 | ✅ |
+| React 前端 | Authorize 鉴权配置（Bearer / Basic） | ✅ |
+| React 前端 | GlobalParam 全局参数 | ✅ |
+| React 前端 | Home 首页统计概览 | ✅ |
+| React 前端 | 离线文档导出（HTML / Word） | ✅ |
+| React 前端 | 真实 API 数据对接（/v3/api-docs） | ✅ |
+| React 前端 | 集成到 `knife4j-openapi3-ui` webjar | ✅ |
+
+### 进行中 🔧
+
+| 领域 | 里程碑 | 关联任务 | 说明 |
+| --- | --- | --- | --- |
+| React 前端 | 调试层抽取到 knife4j-core | TASK-032 | 纯 TS 解析层，无框架依赖 |
+| React 前端 | 按参数定义渲染填参表单 | TASK-026 | 依赖 TASK-032 |
+
+---
+
+## React UI 对齐 Vue2 功能缺口清单
+
+以下表格对比 Vue2 前端（`knife4j-vue`）与 React 前端（`knife4j-ui-react`）的功能覆盖。⬜ = 未实现，🔲 = 部分实现，✅ = 已实现。
+
+### 核心功能
+
+| 功能 | Vue2 | React | 缺口说明 |
+| --- | --- | --- | --- |
+| 接口文档展示 | ✅ | ✅ | — |
+| 接口调试（基础） | ✅ | 🔲 | React 仅支持简化输入，缺少按 OpenAPI 参数定义渲染表单 |
+| 数据模型展示 | ✅ | ✅ | — |
+| 分组切换 | ✅ | ✅ | — |
+| 接口搜索 | ✅ | ✅ | — |
+| Authorize 鉴权 | ✅ | 🔲 | React 支持 Bearer/Basic，但不按 securitySchemes 动态渲染 |
+| 全局参数 | ✅ | ✅ | — |
+| 离线文档导出 | ✅ | ✅ | — |
+| 首页统计 | ✅ | ✅ | — |
+
+### 调试页详细缺口
+
+| 功能 | Vue2 | React | 缺口说明 |
+| --- | --- | --- | --- |
+| 按参数定义渲染 path/query/header/cookie 表单 | ✅ | ⬜ | TASK-026 |
+| requestBody 多 Content-Type 切换 | ✅ | ⬜ | TASK-027 |
+| application/x-www-form-urlencoded 表单 | ✅ | ⬜ | TASK-027 |
+| multipart/form-data 文件上传 | ✅ | ⬜ | TASK-027 |
+| raw 模式（Text/JSON/XML 等） | ✅ | ⬜ | TASK-027 |
+| 发送前 required 校验 | ✅ | ⬜ | TASK-028 |
+| 请求预览（最终 URL/headers/body） | ✅ | ⬜ | TASK-028 |
+| 复制 curl 命令 | ✅ | ⬜ | TASK-028 |
+| 响应面板 Content/Raw/Headers/Curl Tab | ✅ | ⬜ | TASK-029 |
+| JSON 响应格式化 + 复制 | ✅ | 🔲 | React 仅展示原始 JSON，缺少格式化和复制 |
+| 二进制响应处理（图片预览/下载） | ✅ | ⬜ | TASK-029 |
+| 鉴权与全局参数自动合并 | ✅ | ⬜ | TASK-031 |
+| OAuth2 password/client_credentials | ✅ | ⬜ | TASK-033 |
+
+### 增强功能
+
+| 功能 | Vue2 | React | 缺口说明 |
+| --- | --- | --- | --- |
+| `@ApiSupport.order` Tag 排序 | ✅ | ⬜ | 后端已生效，UI 不排序 |
+| `@ApiSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
+| `@ApiOperationSupport.order` 操作排序 | ✅ | ⬜ | 后端已生效，UI 不排序 |
+| `@ApiOperationSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
+| 设置面板（Header 右上角整合） | ✅ | ⬜ | TASK-024 |
+| i18n 中英文切换 | ✅ | ⬜ | TASK-025 |
+| 自定义 Markdown 文档 | ✅ | ⬜ | 依赖 UI 设置面板 |
+| 全局搜索（跨分组） | ✅ | 🔲 | React 仅搜索当前分组 |
+| TypeScript 代码生成 | ✅ | ⬜ | — |
+
+### knife4j-core 抽取
+
+| 模块 | 状态 | 说明 |
+| --- | --- | --- |
+| `resolveRef(ref, doc)` | ⬜ | 统一 OAS2/OAS3 $ref 解析 |
+| `OperationDebugModel` | ⬜ | 从 operation 解析参数模型 |
+| `requestBuilder` | ⬜ | 统一请求构造 + curl 输出 |
+| `buildSchemaExample` | ⬜ | schema 示例生成（TASK-030） |
+| `buildSchemaFieldTree` | ⬜ | schema 字段树（TASK-030） |
+
+---
+
+## 优先级排序原则
+
+1. **稳定性优先**：Bug 修复和兼容性回归永远优先于新功能
+2. **调试能力对齐**：Vue2 能做的调试流程，React 也必须能做
+3. **核心层先行**：knife4j-core 抽取完成后，UI 层改动才可控
+4. **小步快跑**：一个 PR 只做一件事，可独立验证和回滚
+5. **不破坏现有体验**：任何改动不能让 `doc.html` 用户降级
+
+---
 
 ## 暂时不要做的事
 
 - 不要同时重构后端、前端、文档和品牌
 - 不要假设所有历史文档都要立刻迁完
 - 不要把实验性的 UI 线写成当前默认实现
+- 不要为了代码优雅牺牲向后兼容
+- 不要一次性迁移到 React（Vue2 前端仍然可用）
 
-## 新站在路线图里的职责
+---
 
-这个 VitePress 原型本身也是路线图的一部分。它承担的是：
+## 下一步
 
-- 统一对外叙事
-- 降低迁移用户的理解成本
-- 为之后接入域名和部署做准备
+1. **完成 TASK-032**：抽取调试/解析层到 knife4j-core
+2. **完成 TASK-026 ~ TASK-031**：React 调试页对齐 Vue2 能力
+3. **完成 TASK-023 review**：React 前端集成到 starter
+4. **补齐 i18n**（TASK-025）
+5. **补齐设置面板**（TASK-024）
+6. **评估 knife4j-core 的 OAS2/OAS3 统一解析层**（TASK-030）
 
-当你后面给出域名时，我们就可以把这套原型继续推进成正式站点，而不是从零再想一次结构。
+如果你想参与某个任务的实现，欢迎提 Issue 或 PR。详见 [GitHub 仓库](https://github.com/songxychn/knife4j-next)。


### PR DESCRIPTION
… 4 个参考页（version-ref/configuration/annotations）- 重写 5 个现有页（introduction/getting-started/migration/compatibility/modules）- 重写 release-notes 和 roadmap - 更新 .vitepress/config.ts 侧边栏和导航结构