### PR TITLE
feat(ui-react): TASK-025 i18n 中英文切换

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -505,3 +505,19 @@ summary:
 - 依赖 TASK-034 未合并，TASK-035 重新标为 blocked
 blockers:
 - TASK-034 PR 关闭未合并
+
+## 2026-04-25 13:14 UTC
+task: TASK-025
+agent: coordinator (heartbeat)
+branch: codex/TASK-025-i18n
+status: review
+summary:
+- 分支已有完整实现（react-i18next，zh-CN/en-US 约 130 条文案，Header 语言切换按钮）
+- npm ci && npm run build 通过，无 TypeScript 错误
+- 创建 PR #40
+validation:
+- cd knife4j-front/knife4j-ui-react && npm ci && npm run build: exit 0
+next:
+- 等待维护者 review PR #40
+blockers:
+- none

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -392,7 +392,7 @@ notes:
 - blocked 原因：等 TASK-023 集成完成后再做，避免在沙盒里调 UI 细节
 
 ### TASK-025
-status: ready
+status: review
 area: ui-react
 title: i18n 中英文切换
 branch: codex/TASK-025-i18n

--- a/knife4j-front/knife4j-ui-react/package.json
+++ b/knife4j-front/knife4j-ui-react/package.json
@@ -12,9 +12,12 @@
   "dependencies": {
     "@types/react-router-dom": "^5.3.3",
     "antd": "^5.7.3",
+    "i18next": "^23.7.6",
+    "i18next-browser-languagedetector": "^7.2.0",
     "knife4j-core": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^14.0.0",
     "react-resizable": "^3.0.5",
     "react-router-dom": "^6.14.2"
   },

--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -7,6 +7,7 @@ import {
 import { Layout, Button, Select, ConfigProvider, Tabs, theme } from 'antd';
 import { Resizable } from 'react-resizable';
 import { Outlet, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { GroupProvider, useGroup } from './context/GroupContext';
 import { AuthProvider } from './context/AuthContext';
 import SidebarSearchMenu from './compoents/SidebarSearchMenu';
@@ -15,7 +16,7 @@ import SettingsDrawer from './compoents/SettingsDrawer';
 const { Header, Sider, Content, Footer } = Layout;
 type TargetKey = React.MouseEvent | React.KeyboardEvent | string;
 
-const defaultPanes = [{ label: '主页', children: '', key: '/group/home' }];
+const HOME_KEY = '/group/home';
 
 const routeKeyToMenuKey = (key: string) => key.endsWith('/doc') ? key.slice(0, -4) : key;
 
@@ -34,14 +35,15 @@ const AppInner: React.FC = () => {
   const [siderWidth, setSiderWidth] = useState(320);
   const navigate = useNavigate();
   const { groups, setActiveGroupValue } = useGroup();
+  const { t, i18n } = useTranslation();
 
   const {
     token: { colorBgContainer },
   } = theme.useToken();
 
-  const [selectedKey, setSelectedKey] = useState('/group/home');
-  const [activeKey, setActiveKey] = useState(defaultPanes[0].key);
-  const [items, setItems] = useState(defaultPanes);
+  const [selectedKey, setSelectedKey] = useState(HOME_KEY);
+  const [activeKey, setActiveKey] = useState(HOME_KEY);
+  const [items, setItems] = useState([{ label: t('app.tab.home'), children: '', key: HOME_KEY }]);
 
   const handleResize = (
     _e: React.SyntheticEvent,
@@ -82,6 +84,15 @@ const AppInner: React.FC = () => {
   const onEdit = (targetKey: TargetKey, action: 'add' | 'remove') => {
     if (action === 'remove') remove(targetKey);
   };
+
+  const toggleLang = () => {
+    const next = i18n.language === 'zh-CN' ? 'en-US' : 'zh-CN';
+    i18n.changeLanguage(next);
+  };
+
+  const langLabel = i18n.language === 'zh-CN'
+    ? t('header.lang.en')
+    : t('header.lang.zh');
 
   const groupOptions = groups.map((g) => ({ value: g.value, label: g.label }));
   const tabItems = items.map((item) => ({
@@ -125,7 +136,7 @@ const AppInner: React.FC = () => {
             }}
           >
             <img src="webjars/knife4j-ui-react/knife4j-next-mark.svg" style={{ width: 28, height: 28 }} />
-            {!collapsed && <span>Knife4j Next</span>}
+            {!collapsed && <span>{t('app.brand')}</span>}
           </div>
 
           {/* Group switcher */}
@@ -163,8 +174,15 @@ const AppInner: React.FC = () => {
             onClick={() => setCollapsed(!collapsed)}
             style={{ fontSize: 16, width: 64, height: 64 }}
           />
-          OpenAPI 接口文档聚合中心
-          <span style={{ marginLeft: 'auto' }}>
+          {t('app.header.title')}
+          <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
+            <Button
+              type="text"
+              onClick={toggleLang}
+              style={{ fontSize: 14, height: 48, padding: '0 12px', fontWeight: 600 }}
+            >
+              {langLabel}
+            </Button>
             <Button
               type="text"
               icon={<SettingOutlined />}
@@ -198,7 +216,7 @@ const AppInner: React.FC = () => {
         </Content>
 
         <Footer style={footerStyle}>
-          Apache License 2.0 | Copyright 2019-Knife4j v5.0
+          {t('app.footer')}
         </Footer>
       </Layout>
     </Layout>

--- a/knife4j-front/knife4j-ui-react/src/compoents/SettingsDrawer.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SettingsDrawer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Drawer, Tabs } from 'antd';
+import { useTranslation } from 'react-i18next';
 import Authorize from '../pages/Authorize';
 import GlobalParam from '../pages/document/GlobalParam';
 import OfficeDoc from '../pages/document/OfficeDoc';
@@ -10,15 +11,17 @@ interface SettingsDrawerProps {
 }
 
 const SettingsDrawer: React.FC<SettingsDrawerProps> = ({ open, onClose }) => {
+  const { t } = useTranslation();
+
   const tabItems = [
-    { key: 'authorize', label: 'Authorize', children: <Authorize /> },
-    { key: 'globalParam', label: '全局参数', children: <GlobalParam /> },
-    { key: 'officeDoc', label: '离线文档', children: <OfficeDoc /> },
+    { key: 'authorize', label: t('settings.tab.authorize'), children: <Authorize /> },
+    { key: 'globalParam', label: t('settings.tab.globalParam'), children: <GlobalParam /> },
+    { key: 'officeDoc', label: t('settings.tab.offlineDoc'), children: <OfficeDoc /> },
   ];
 
   return (
     <Drawer
-      title="设置"
+      title={t('settings.title')}
       placement="right"
       width={600}
       open={open}

--- a/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { Input, Menu } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
 import { useGroup, ApiItem } from '../context/GroupContext';
 
 const METHOD_COLORS: Record<string, string> = {
@@ -39,6 +40,7 @@ interface SidebarSearchMenuProps {
 
 const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMenuClick }) => {
   const { activeGroup } = useGroup();
+  const { t } = useTranslation();
   const [searchText, setSearchText] = useState('');
 
   // Group apis by tag, filtered by search text
@@ -90,7 +92,7 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
       <div style={{ padding: '8px 8px 4px' }}>
         <Input
           className="knife4j-sidebar-search"
-          placeholder="搜索接口名/路径..."
+          placeholder={t('sidebar.search.placeholder')}
           prefix={<SearchOutlined style={{ color: 'rgba(255,255,255,0.45)' }} />}
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}

--- a/knife4j-front/knife4j-ui-react/src/i18n.ts
+++ b/knife4j-front/knife4j-ui-react/src/i18n.ts
@@ -1,0 +1,26 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import zhCN from './locales/zh-CN';
+import enUS from './locales/en-US';
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      'zh-CN': { translation: zhCN },
+      'en-US': { translation: enUS },
+    },
+    fallbackLng: 'zh-CN',
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+      lookupLocalStorage: 'knife4j-lang',
+    },
+  });
+
+export default i18n;

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -1,0 +1,139 @@
+const enUS = {
+  // App / Layout
+  'app.brand': 'Knife4j Next',
+  'app.header.title': 'OpenAPI Hub',
+  'app.tab.home': 'Home',
+  'app.footer': 'Apache License 2.0 | Copyright 2019-Knife4j v5.0',
+
+  // Header language switch
+  'header.lang.zh': '中',
+  'header.lang.en': 'EN',
+
+  // SidebarSearchMenu
+  'sidebar.search.placeholder': 'Search API name/path...',
+
+  // Home
+  'home.noData': 'No data',
+  'home.version': 'Version',
+  'home.description': 'Description',
+  'home.apiStats': 'API Statistics',
+  'home.total': 'Total',
+
+  // Schema
+  'schema.title': 'Data Models',
+  'schema.tag.mock': 'mock',
+  'schema.col.fieldName': 'Field Name',
+  'schema.col.type': 'Type',
+  'schema.col.format': 'Format',
+  'schema.col.required': 'Required',
+  'schema.col.description': 'Description',
+  'schema.required.yes': 'Yes',
+  'schema.required.no': 'No',
+  'schema.fields': 'fields',
+
+  // ApiDoc
+  'apiDoc.notFound.title': 'API doc not found',
+  'apiDoc.notFound.desc': 'No OpenAPI operation matched the current route. Please reopen from the left API list.',
+  'apiDoc.deprecated': 'Deprecated',
+  'apiDoc.requestParams': 'Request Parameters',
+  'apiDoc.col.paramName': 'Name',
+  'apiDoc.col.location': 'In',
+  'apiDoc.col.type': 'Type',
+  'apiDoc.col.required': 'Required',
+  'apiDoc.col.description': 'Description',
+  'apiDoc.noParams': 'No request parameters',
+  'apiDoc.requestBody': 'Request Body',
+  'apiDoc.body.notExpandable': 'Field expansion is not supported for this request body',
+  'apiDoc.noBody': 'No request body',
+  'apiDoc.responseStructure': 'Response Structure',
+  'apiDoc.col.statusCode': 'Status Code',
+  'apiDoc.col.schema': 'Schema',
+  'apiDoc.col.fieldName': 'Field Name',
+
+  // Operation mode tabs (doc / debug)
+  'operation.tab.doc': 'Doc',
+  'operation.tab.debug': 'Debug',
+
+  // ApiDebug
+  'apiDebug.notFound.title': 'Debug interface not found',
+  'apiDebug.notFound.desc': 'No OpenAPI operation matched the current route. Please reopen from the left API list.',
+  'apiDebug.col.paramName': 'Name',
+  'apiDebug.col.type': 'Type',
+  'apiDebug.col.value': 'Value',
+  'apiDebug.col.description': 'Description',
+  'apiDebug.tag.required': 'Required',
+  'apiDebug.tag.deprecated': 'Deprecated',
+  'apiDebug.tooltip.deprecated': 'This parameter is deprecated but can still be filled',
+  'apiDebug.tag.readOnly': 'ReadOnly',
+  'apiDebug.tooltip.readOnly': 'ReadOnly parameters usually do not need to be sent by the client',
+  'apiDebug.enum.placeholder': 'Select an enum value',
+  'apiDebug.inputNumber.required': 'Required',
+  'apiDebug.json.placeholder': 'Enter JSON',
+  'apiDebug.tab.path': 'Path',
+  'apiDebug.tab.query': 'Query',
+  'apiDebug.tab.header': 'Header',
+  'apiDebug.tab.cookie': 'Cookie',
+  'apiDebug.tab.body': 'Body',
+  'apiDebug.header.autoInject': 'Content-Type is auto-injected by the selected Body type (visible in cURL on send)',
+  'apiDebug.noHeaderParams': 'No header parameters',
+  'apiDebug.noBody': 'This API has no request body',
+  'apiDebug.send': 'Send',
+  'apiDebug.sending': 'Sending...',
+  'apiDebug.error.title': 'Request failed',
+  'apiDebug.response.headers': 'Response Headers',
+  'apiDebug.response.status': 'Status: ',
+  'apiDebug.response.body': 'Response Body',
+  'apiDebug.response.duration': 'Duration: ',
+  'apiDebug.col.header': 'Header',
+  'apiDebug.col.headerValue': 'Value',
+  'apiDebug.desc.default': 'Default: ',
+  'apiDebug.desc.example': 'Example: ',
+  'apiDebug.desc.enum': 'Enum: ',
+  'apiDebug.json.array': 'array',
+  'apiDebug.json.object': 'object',
+
+  // Authorize
+  'auth.title': 'Authorization',
+  'auth.tab.bearer': 'Bearer Token',
+  'auth.tab.basic': 'Basic Auth',
+  'auth.label.token': 'Token',
+  'auth.validation.token': 'Please enter token',
+  'auth.placeholder.token': 'Enter Bearer token',
+  'auth.label.username': 'Username',
+  'auth.validation.username': 'Please enter username',
+  'auth.placeholder.username': 'Username',
+  'auth.label.password': 'Password',
+  'auth.validation.password': 'Please enter password',
+  'auth.placeholder.password': 'Password',
+  'auth.btn.save': 'Save',
+  'auth.btn.clear': 'Clear Auth',
+  'auth.msg.bearerSaved': 'Bearer token saved',
+  'auth.msg.basicSaved': 'Basic auth saved',
+  'auth.msg.cleared': 'Auth cleared',
+
+  // GlobalParam
+  'globalParam.col.name': 'Name',
+  'globalParam.col.value': 'Value',
+  'globalParam.col.in': 'In',
+  'globalParam.col.action': 'Action',
+  'globalParam.placeholder.name': 'Parameter name',
+  'globalParam.validation.name': 'Name required',
+  'globalParam.placeholder.value': 'Parameter value',
+  'globalParam.validation.value': 'Value required',
+  'globalParam.btn.add': 'Add',
+
+  // OfficeDoc
+  'officeDoc.title': 'Offline Document Export',
+  'officeDoc.desc': 'Export the current API documentation as a downloadable offline file. Supports HTML and Word (.doc) formats.',
+  'officeDoc.alert.mockData': 'Mock data or unloaded document detected; exported content may be incomplete.',
+  'officeDoc.btn.html': 'Download HTML',
+  'officeDoc.btn.word': 'Download Word (.doc)',
+
+  // SettingsDrawer
+  'settings.title': 'Settings',
+  'settings.tab.authorize': 'Authorize',
+  'settings.tab.globalParam': 'Global Parameters',
+  'settings.tab.offlineDoc': 'Offline Docs',
+} as const;
+
+export default enUS;

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -1,0 +1,139 @@
+const zhCN = {
+  // App / Layout
+  'app.brand': 'Knife4j Next',
+  'app.header.title': 'OpenAPI 接口文档聚合中心',
+  'app.tab.home': '主页',
+  'app.footer': 'Apache License 2.0 | Copyright 2019-Knife4j v5.0',
+
+  // Header language switch
+  'header.lang.zh': '中',
+  'header.lang.en': 'EN',
+
+  // SidebarSearchMenu
+  'sidebar.search.placeholder': '搜索接口名/路径...',
+
+  // Home
+  'home.noData': '暂无数据',
+  'home.version': '版本',
+  'home.description': '描述',
+  'home.apiStats': '接口统计',
+  'home.total': '总计',
+
+  // Schema
+  'schema.title': '数据模型',
+  'schema.tag.mock': 'mock',
+  'schema.col.fieldName': '字段名',
+  'schema.col.type': '类型',
+  'schema.col.format': '格式',
+  'schema.col.required': '必填',
+  'schema.col.description': '说明',
+  'schema.required.yes': '是',
+  'schema.required.no': '否',
+  'schema.fields': '字段',
+
+  // ApiDoc
+  'apiDoc.notFound.title': '未找到接口文档',
+  'apiDoc.notFound.desc': '当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。',
+  'apiDoc.deprecated': '已废弃',
+  'apiDoc.requestParams': '请求参数',
+  'apiDoc.col.paramName': '参数名',
+  'apiDoc.col.location': '位置',
+  'apiDoc.col.type': '类型',
+  'apiDoc.col.required': '必填',
+  'apiDoc.col.description': '说明',
+  'apiDoc.noParams': '无请求参数',
+  'apiDoc.requestBody': '请求体',
+  'apiDoc.body.notExpandable': '当前请求体暂不支持字段展开',
+  'apiDoc.noBody': '无请求体',
+  'apiDoc.responseStructure': '响应结构',
+  'apiDoc.col.statusCode': '状态码',
+  'apiDoc.col.schema': 'Schema',
+  'apiDoc.col.fieldName': '字段名',
+
+  // Operation mode tabs (doc / debug)
+  'operation.tab.doc': '文档',
+  'operation.tab.debug': '调试',
+
+  // ApiDebug
+  'apiDebug.notFound.title': '未找到调试接口',
+  'apiDebug.notFound.desc': '当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。',
+  'apiDebug.col.paramName': '参数名',
+  'apiDebug.col.type': '类型',
+  'apiDebug.col.value': '值',
+  'apiDebug.col.description': '说明',
+  'apiDebug.tag.required': '必填',
+  'apiDebug.tag.deprecated': '已废弃',
+  'apiDebug.tooltip.deprecated': '该参数已废弃，但仍可填写',
+  'apiDebug.tag.readOnly': '只读',
+  'apiDebug.tooltip.readOnly': 'readOnly 参数通常不需要客户端传入',
+  'apiDebug.enum.placeholder': '选择一个枚举值',
+  'apiDebug.inputNumber.required': '必填',
+  'apiDebug.json.placeholder': '请输入 JSON',
+  'apiDebug.tab.path': 'Path',
+  'apiDebug.tab.query': 'Query',
+  'apiDebug.tab.header': 'Header',
+  'apiDebug.tab.cookie': 'Cookie',
+  'apiDebug.tab.body': 'Body',
+  'apiDebug.header.autoInject': 'Content-Type 由所选 Body 类型自动注入（在发送时可见于 cURL）',
+  'apiDebug.noHeaderParams': '无 header 参数',
+  'apiDebug.noBody': '该接口无请求体',
+  'apiDebug.send': '发送',
+  'apiDebug.sending': '请求中...',
+  'apiDebug.error.title': '请求失败',
+  'apiDebug.response.headers': '响应 Headers',
+  'apiDebug.response.status': '响应状态：',
+  'apiDebug.response.body': '响应体',
+  'apiDebug.response.duration': '耗时：',
+  'apiDebug.col.header': 'Header',
+  'apiDebug.col.headerValue': '值',
+  'apiDebug.desc.default': '默认：',
+  'apiDebug.desc.example': '示例：',
+  'apiDebug.desc.enum': '枚举：',
+  'apiDebug.json.array': '数组',
+  'apiDebug.json.object': '对象',
+
+  // Authorize
+  'auth.title': 'Authorization',
+  'auth.tab.bearer': 'Bearer Token',
+  'auth.tab.basic': 'Basic Auth',
+  'auth.label.token': 'Token',
+  'auth.validation.token': '请输入 Token',
+  'auth.placeholder.token': '输入 Bearer Token',
+  'auth.label.username': '用户名',
+  'auth.validation.username': '请输入用户名',
+  'auth.placeholder.username': '用户名',
+  'auth.label.password': '密码',
+  'auth.validation.password': '请输入密码',
+  'auth.placeholder.password': '密码',
+  'auth.btn.save': '保存',
+  'auth.btn.clear': '清除认证',
+  'auth.msg.bearerSaved': 'Bearer Token 已保存',
+  'auth.msg.basicSaved': 'Basic 认证已保存',
+  'auth.msg.cleared': '认证已清除',
+
+  // GlobalParam
+  'globalParam.col.name': '名称',
+  'globalParam.col.value': '值',
+  'globalParam.col.in': '位置',
+  'globalParam.col.action': '操作',
+  'globalParam.placeholder.name': '参数名',
+  'globalParam.validation.name': '名称不能为空',
+  'globalParam.placeholder.value': '参数值',
+  'globalParam.validation.value': '值不能为空',
+  'globalParam.btn.add': '添加',
+
+  // OfficeDoc
+  'officeDoc.title': '离线文档导出',
+  'officeDoc.desc': '将当前接口文档导出为可下载的离线文件，支持 HTML 和 Word（.doc）格式。',
+  'officeDoc.alert.mockData': '当前使用 Mock 数据或文档未加载，导出内容可能不完整。',
+  'officeDoc.btn.html': '下载 HTML',
+  'officeDoc.btn.word': '下载 Word (.doc)',
+
+  // SettingsDrawer
+  'settings.title': '设置',
+  'settings.tab.authorize': 'Authorize',
+  'settings.tab.globalParam': '全局参数',
+  'settings.tab.offlineDoc': '离线文档',
+} as const;
+
+export default zhCN;

--- a/knife4j-front/knife4j-ui-react/src/main.tsx
+++ b/knife4j-front/knife4j-ui-react/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
+import './i18n'
 import {
   RouterProvider
 } from "react-router-dom";
@@ -15,3 +16,4 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 
   </React.StrictMode >,
 )
+

--- a/knife4j-front/knife4j-ui-react/src/pages/Authorize.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Authorize.tsx
@@ -1,7 +1,9 @@
 import { Tabs, Form, Input, Button, message } from 'antd';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 
 export default function Authorize() {
+  const { t } = useTranslation();
   const { auth, setAuth, clearAuth } = useAuth();
   const [bearerForm] = Form.useForm();
   const [basicForm] = Form.useForm();
@@ -11,49 +13,49 @@ export default function Authorize() {
 
   const onSaveBearer = (values: { token: string }) => {
     setAuth({ type: 'bearer', token: values.token });
-    message.success('Bearer token saved');
+    message.success(t('auth.msg.bearerSaved'));
   };
 
   const onSaveBasic = (values: { username: string; password: string }) => {
     setAuth({ type: 'basic', username: values.username, password: values.password });
-    message.success('Basic auth saved');
+    message.success(t('auth.msg.basicSaved'));
   };
 
   const onClear = () => {
     clearAuth();
     bearerForm.resetFields();
     basicForm.resetFields();
-    message.success('Auth cleared');
+    message.success(t('auth.msg.cleared'));
   };
 
   const tabs = [
     {
       key: 'bearer',
-      label: 'Bearer Token',
+      label: t('auth.tab.bearer'),
       children: (
         <Form form={bearerForm} initialValues={initialBearer} onFinish={onSaveBearer} layout="vertical">
-          <Form.Item name="token" label="Token" rules={[{ required: true, message: 'Please enter token' }]}>
-            <Input.Password placeholder="Enter Bearer token" />
+          <Form.Item name="token" label={t('auth.label.token')} rules={[{ required: true, message: t('auth.validation.token') }]}>
+            <Input.Password placeholder={t('auth.placeholder.token')} />
           </Form.Item>
           <Form.Item>
-            <Button type="primary" htmlType="submit">Save</Button>
+            <Button type="primary" htmlType="submit">{t('auth.btn.save')}</Button>
           </Form.Item>
         </Form>
       ),
     },
     {
       key: 'basic',
-      label: 'Basic Auth',
+      label: t('auth.tab.basic'),
       children: (
         <Form form={basicForm} initialValues={initialBasic} onFinish={onSaveBasic} layout="vertical">
-          <Form.Item name="username" label="Username" rules={[{ required: true, message: 'Please enter username' }]}>
-            <Input placeholder="Username" />
+          <Form.Item name="username" label={t('auth.label.username')} rules={[{ required: true, message: t('auth.validation.username') }]}>
+            <Input placeholder={t('auth.placeholder.username')} />
           </Form.Item>
-          <Form.Item name="password" label="Password" rules={[{ required: true, message: 'Please enter password' }]}>
-            <Input.Password placeholder="Password" />
+          <Form.Item name="password" label={t('auth.label.password')} rules={[{ required: true, message: t('auth.validation.password') }]}>
+            <Input.Password placeholder={t('auth.placeholder.password')} />
           </Form.Item>
           <Form.Item>
-            <Button type="primary" htmlType="submit">Save</Button>
+            <Button type="primary" htmlType="submit">{t('auth.btn.save')}</Button>
           </Form.Item>
         </Form>
       ),
@@ -62,11 +64,11 @@ export default function Authorize() {
 
   return (
     <div id="knife4j-authorize" style={{ maxWidth: 480, padding: 24 }}>
-      <h2>Authorization</h2>
+      <h2>{t('auth.title')}</h2>
       <Tabs items={tabs} />
       {auth && (
         <Button danger onClick={onClear} style={{ marginTop: 8 }}>
-          Clear Auth
+          {t('auth.btn.clear')}
         </Button>
       )}
     </div>

--- a/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { Card, Descriptions, Statistic, Row, Col, Typography, Spin } from 'antd';
+import { useTranslation } from 'react-i18next';
 import { useGroup } from '../context/GroupContext';
 
 const { Title, Paragraph } = Typography;
@@ -6,6 +7,7 @@ const { Title, Paragraph } = Typography;
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch'] as const;
 
 export default function Home() {
+  const { t } = useTranslation();
   const { swaggerDoc, loading } = useGroup();
 
   if (loading) {
@@ -13,7 +15,7 @@ export default function Home() {
   }
 
   if (!swaggerDoc) {
-    return <div style={{ padding: 24 }}>暂无数据</div>;
+    return <div style={{ padding: 24 }}>{t('home.noData')}</div>;
   }
 
   const { info, paths } = swaggerDoc;
@@ -36,19 +38,19 @@ export default function Home() {
 
       <Card style={{ marginBottom: 24 }}>
         <Descriptions column={1} size="small">
-          <Descriptions.Item label="版本">{info.version ?? '-'}</Descriptions.Item>
+          <Descriptions.Item label={t('home.version')}>{info.version ?? '-'}</Descriptions.Item>
           {info.description && (
-            <Descriptions.Item label="描述">
+            <Descriptions.Item label={t('home.description')}>
               <Paragraph style={{ margin: 0 }}>{info.description}</Paragraph>
             </Descriptions.Item>
           )}
         </Descriptions>
       </Card>
 
-      <Card title="接口统计">
+      <Card title={t('home.apiStats')}>
         <Row gutter={16}>
           <Col span={4}>
-            <Statistic title="总计" value={total} />
+            <Statistic title={t('home.total')} value={total} />
           </Col>
           <Col span={4}>
             <Statistic title="GET" value={counts.get} valueStyle={{ color: '#61affe' }} />

--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -1,5 +1,6 @@
 import { Badge, Collapse, Spin, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import { useTranslation } from 'react-i18next';
 import { useGroup } from '../context/GroupContext';
 import type { SchemaObject } from '../types/swagger';
 
@@ -113,48 +114,47 @@ const TYPE_COLOR: Record<string, string> = {
   object: 'geekblue',
 };
 
-// ---- 字段表格列定义 ----
-
-const fieldColumns: ColumnsType<SchemaField> = [
-  {
-    title: '字段名',
-    dataIndex: 'name',
-    width: 180,
-    render: (v) => <Text code>{v}</Text>,
-  },
-  {
-    title: '类型',
-    dataIndex: 'type',
-    width: 100,
-    render: (v) => <Tag color={TYPE_COLOR[v] ?? 'default'}>{v}</Tag>,
-  },
-  {
-    title: '格式',
-    dataIndex: 'format',
-    width: 110,
-    render: (v) => v ? <Text type="secondary">{v}</Text> : <Text type="secondary">—</Text>,
-  },
-  {
-    title: '必填',
-    dataIndex: 'required',
-    width: 70,
-    render: (v) => v
-      ? <Badge status="error" text="是" />
-      : <Badge status="default" text="否" />,
-  },
-  {
-    title: '说明',
-    dataIndex: 'description',
-  },
-];
-
 // ---- 页面 ----
 
 export default function Schema() {
+  const { t } = useTranslation();
   const { schemas, loading, usingMock } = useGroup();
   const models: ModelDef[] = usingMock || Object.keys(schemas).length === 0
     ? MOCK_SCHEMAS
     : schemasToModels(schemas);
+
+  const fieldColumns: ColumnsType<SchemaField> = [
+    {
+      title: t('schema.col.fieldName'),
+      dataIndex: 'name',
+      width: 180,
+      render: (v) => <Text code>{v}</Text>,
+    },
+    {
+      title: t('schema.col.type'),
+      dataIndex: 'type',
+      width: 100,
+      render: (v) => <Tag color={TYPE_COLOR[v] ?? 'default'}>{v}</Tag>,
+    },
+    {
+      title: t('schema.col.format'),
+      dataIndex: 'format',
+      width: 110,
+      render: (v) => v ? <Text type="secondary">{v}</Text> : <Text type="secondary">—</Text>,
+    },
+    {
+      title: t('schema.col.required'),
+      dataIndex: 'required',
+      width: 70,
+      render: (v) => v
+        ? <Badge status="error" text={t('schema.required.yes')} />
+        : <Badge status="default" text={t('schema.required.no')} />,
+    },
+    {
+      title: t('schema.col.description'),
+      dataIndex: 'description',
+    },
+  ];
 
   const collapseItems = models.map((model) => ({
     key: model.name,
@@ -166,7 +166,7 @@ export default function Schema() {
             {model.description}
           </Text>
         )}
-        <Tag style={{ marginLeft: 12 }} color="default">{model.fields.length} 字段</Tag>
+        <Tag style={{ marginLeft: 12 }} color="default">{model.fields.length} {t('schema.fields')}</Tag>
       </span>
     ),
     children: (
@@ -187,8 +187,8 @@ export default function Schema() {
   return (
     <div style={{ padding: '24px', maxWidth: 1100 }}>
       <Title level={4} style={{ marginBottom: 16 }}>
-        数据模型
-        {usingMock && <Tag color="orange" style={{ marginLeft: 8, fontSize: 11 }}>mock</Tag>}
+        {t('schema.title')}
+        {usingMock && <Tag color="orange" style={{ marginLeft: 8, fontSize: 11 }}>{t('schema.tag.mock')}</Tag>}
       </Title>
       {loading ? (
         <Spin />

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -4,6 +4,7 @@ import {
 } from 'antd';
 import { SendOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
+import { useTranslation } from 'react-i18next';
 import {
   buildOperationDebugModel,
   buildRequest as coreBuildRequest,
@@ -98,6 +99,7 @@ interface ParamInputProps {
 }
 
 function ParamInput({ param, value, onChange }: ParamInputProps) {
+  const { t } = useTranslation();
   // enum → Select
   if (param.enum && param.enum.length > 0) {
     return (
@@ -106,7 +108,7 @@ function ParamInput({ param, value, onChange }: ParamInputProps) {
         value={value || undefined}
         onChange={onChange}
         allowClear
-        placeholder={param.description ?? '选择一个枚举值'}
+        placeholder={param.description ?? t('apiDebug.enum.placeholder')}
         options={param.enum.map((item) => ({ value: String(item), label: String(item) }))}
         style={{ width: '100%' }}
       />
@@ -136,7 +138,7 @@ function ParamInput({ param, value, onChange }: ParamInputProps) {
         size="small"
         value={Number.isFinite(numValue) ? numValue : undefined}
         onChange={(next) => onChange(next === null || next === undefined ? '' : String(next))}
-        placeholder={param.required ? '必填' : param.description}
+        placeholder={param.required ? t('apiDebug.inputNumber.required') : param.description}
         style={{ width: '100%' }}
         step={param.type === 'integer' ? 1 : undefined}
       />
@@ -150,7 +152,7 @@ function ParamInput({ param, value, onChange }: ParamInputProps) {
         size="small"
         value={value}
         onChange={(event) => onChange(event.target.value)}
-        placeholder={`${param.type === 'array' ? '数组' : '对象'} — 请输入 JSON`}
+        placeholder={`${param.type === 'array' ? t('apiDebug.json.array') : t('apiDebug.json.object')} — ${t('apiDebug.json.placeholder')}`}
         autoSize={{ minRows: 2, maxRows: 6 }}
         style={{ fontFamily: 'monospace', fontSize: 12 }}
       />
@@ -163,7 +165,7 @@ function ParamInput({ param, value, onChange }: ParamInputProps) {
       size="small"
       value={value}
       onChange={(event) => onChange(event.target.value)}
-      placeholder={param.required ? '必填' : (param.description ?? '')}
+      placeholder={param.required ? t('apiDebug.inputNumber.required') : (param.description ?? '')}
       readOnly={param.readOnly}
     />
   );
@@ -172,6 +174,7 @@ function ParamInput({ param, value, onChange }: ParamInputProps) {
 // ─── Name cell（附带 deprecated/readOnly 标记）────────
 
 function ParamNameCell({ param }: { param: DebugParam }) {
+  const { t } = useTranslation();
   const deprecated = param.deprecated;
   const readOnly = param.readOnly;
   return (
@@ -185,15 +188,15 @@ function ParamNameCell({ param }: { param: DebugParam }) {
       >
         {param.name}
       </Text>
-      {param.required && <Tag color="red" style={{ marginInlineEnd: 0 }}>必填</Tag>}
+      {param.required && <Tag color="red" style={{ marginInlineEnd: 0 }}>{t('apiDebug.tag.required')}</Tag>}
       {deprecated && (
-        <Tooltip title="该参数已废弃，但仍可填写">
-          <Tag color="default" style={{ marginInlineEnd: 0 }}>已废弃</Tag>
+        <Tooltip title={t('apiDebug.tooltip.deprecated')}>
+          <Tag color="default" style={{ marginInlineEnd: 0 }}>{t('apiDebug.tag.deprecated')}</Tag>
         </Tooltip>
       )}
       {readOnly && (
-        <Tooltip title="readOnly 参数通常不需要客户端传入">
-          <Tag color="warning" style={{ marginInlineEnd: 0 }}>只读</Tag>
+        <Tooltip title={t('apiDebug.tooltip.readOnly')}>
+          <Tag color="warning" style={{ marginInlineEnd: 0 }}>{t('apiDebug.tag.readOnly')}</Tag>
         </Tooltip>
       )}
     </Space>
@@ -203,6 +206,7 @@ function ParamNameCell({ param }: { param: DebugParam }) {
 // ─── 主组件 ────────────────────────────────────────────
 
 export default function ApiDebug() {
+  const { t } = useTranslation();
   const { loading: docLoading, swaggerDoc, operation } = useCurrentOperation();
   const [baseUrl, setBaseUrl] = useState(currentOrigin());
   const [method, setMethod] = useState('GET');
@@ -251,14 +255,14 @@ export default function ApiDebug() {
 
   const paramColumns = useMemo<ColumnsType<DebugParam>>(() => [
     {
-      title: '参数名',
+      title: t('apiDebug.col.paramName'),
       dataIndex: 'name',
       key: 'name',
       width: 220,
       render: (_value: string, record: DebugParam) => <ParamNameCell param={record} />,
     },
     {
-      title: '类型',
+      title: t('apiDebug.col.type'),
       dataIndex: 'type',
       key: 'type',
       width: 110,
@@ -270,7 +274,7 @@ export default function ApiDebug() {
       ),
     },
     {
-      title: '值',
+      title: t('apiDebug.col.value'),
       dataIndex: 'value',
       key: 'value',
       render: (_value: string, record: DebugParam) => (
@@ -282,7 +286,7 @@ export default function ApiDebug() {
       ),
     },
     {
-      title: '说明',
+      title: t('apiDebug.col.description'),
       key: 'description',
       width: 280,
       render: (_value, record: DebugParam) => (
@@ -290,31 +294,31 @@ export default function ApiDebug() {
           {record.description && <Text style={{ fontSize: 12 }}>{record.description}</Text>}
           {record.default !== undefined && (
             <Text type="secondary" style={{ fontSize: 11 }}>
-              默认：<Text code style={{ fontSize: 11 }}>{stringify(record.default, record.type)}</Text>
+              {t('apiDebug.desc.default')}<Text code style={{ fontSize: 11 }}>{stringify(record.default, record.type)}</Text>
             </Text>
           )}
           {record.example !== undefined && (
             <Text type="secondary" style={{ fontSize: 11 }}>
-              示例：<Text code style={{ fontSize: 11 }}>{stringify(record.example, record.type)}</Text>
+              {t('apiDebug.desc.example')}<Text code style={{ fontSize: 11 }}>{stringify(record.example, record.type)}</Text>
             </Text>
           )}
           {record.enum && record.enum.length > 0 && (
             <Text type="secondary" style={{ fontSize: 11 }}>
-              枚举：{record.enum.slice(0, 3).map((item) => String(item)).join(', ')}
+              {t('apiDebug.desc.enum')}{record.enum.slice(0, 3).map((item) => String(item)).join(', ')}
               {record.enum.length > 3 ? '…' : ''}
             </Text>
           )}
         </Space>
       ),
     },
-  ], [paramValues]);
+  ], [paramValues, t]);
 
   if (docLoading) {
     return <Spin style={{ display: 'block', margin: '80px auto' }} />;
   }
 
   if (!swaggerDoc || !operation || !debugModel) {
-    return <Alert type="warning" showIcon message="未找到调试接口" description="当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。" />;
+    return <Alert type="warning" showIcon message={t('apiDebug.notFound.title')} description={t('apiDebug.notFound.desc')} />;
   }
 
   /** 按 in 过滤已填值 */
@@ -390,7 +394,7 @@ export default function ApiDebug() {
   const tabItems = [
     {
       key: 'path',
-      label: `Path (${debugModel.pathParams.length})`,
+      label: `${t('apiDebug.tab.path')} (${debugModel.pathParams.length})`,
       disabled: debugModel.pathParams.length === 0,
       children: (
         <Table size="small" dataSource={debugModel.pathParams} columns={paramColumns} pagination={false} rowKey={paramKey} />
@@ -398,7 +402,7 @@ export default function ApiDebug() {
     },
     {
       key: 'query',
-      label: `Query (${debugModel.queryParams.length})`,
+      label: `${t('apiDebug.tab.query')} (${debugModel.queryParams.length})`,
       disabled: debugModel.queryParams.length === 0,
       children: (
         <Table size="small" dataSource={debugModel.queryParams} columns={paramColumns} pagination={false} rowKey={paramKey} />
@@ -406,7 +410,7 @@ export default function ApiDebug() {
     },
     {
       key: 'header',
-      label: `Header (${debugModel.headerParams.length})`,
+      label: `${t('apiDebug.tab.header')} (${debugModel.headerParams.length})`,
       disabled: debugModel.headerParams.length === 0 && debugModel.bodyContents.length === 0,
       children: (
         <Table
@@ -417,15 +421,15 @@ export default function ApiDebug() {
           rowKey={paramKey}
           locale={{
             emptyText: debugModel.bodyContents.length > 0
-              ? 'Content-Type 由所选 Body 类型自动注入（在发送时可见于 cURL）'
-              : '无 header 参数',
+              ? t('apiDebug.header.autoInject')
+              : t('apiDebug.noHeaderParams'),
           }}
         />
       ),
     },
     {
       key: 'cookie',
-      label: `Cookie (${debugModel.cookieParams.length})`,
+      label: `${t('apiDebug.tab.cookie')} (${debugModel.cookieParams.length})`,
       disabled: debugModel.cookieParams.length === 0,
       children: (
         <Table size="small" dataSource={debugModel.cookieParams} columns={paramColumns} pagination={false} rowKey={paramKey} />
@@ -433,7 +437,7 @@ export default function ApiDebug() {
     },
     {
       key: 'body',
-      label: `Body${debugModel.bodyContents.length > 0 ? ` (${debugModel.bodyContents[0].mediaType})` : ''}`,
+      label: `${t('apiDebug.tab.body')}${debugModel.bodyContents.length > 0 ? ` (${debugModel.bodyContents[0].mediaType})` : ''}`,
       disabled: debugModel.bodyContents.length === 0,
       children: (
         <TextArea
@@ -444,7 +448,7 @@ export default function ApiDebug() {
           placeholder={
             debugModel.bodyContents.length > 0
               ? `${debugModel.bodyContents[0].mediaType} request body`
-              : '该接口无请求体'
+              : t('apiDebug.noBody')
           }
           disabled={debugModel.bodyContents.length === 0}
         />
@@ -475,28 +479,28 @@ export default function ApiDebug() {
         />
         <Input value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} style={{ width: 240 }} />
         <Input value={path} onChange={(event) => setPath(event.target.value)} style={{ flex: 1 }} />
-        <Button type="primary" icon={<SendOutlined />} onClick={handleSend} loading={loading}>发送</Button>
+        <Button type="primary" icon={<SendOutlined />} onClick={handleSend} loading={loading}>{t('apiDebug.send')}</Button>
       </Space.Compact>
 
       <Tabs defaultActiveKey={defaultTab} size="small" items={tabItems} />
 
       <Divider style={{ margin: '16px 0' }} />
 
-      {loading && <Spin tip="请求中..." style={{ display: 'block', margin: '24px auto' }} />}
-      {error && <Alert type="error" message="请求失败" description={<pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{error}</pre>} showIcon />}
+      {loading && <Spin tip={t('apiDebug.sending')} style={{ display: 'block', margin: '24px auto' }} />}
+      {error && <Alert type="error" message={t('apiDebug.error.title')} description={<pre style={{ margin: 0, whiteSpace: 'pre-wrap' }}>{error}</pre>} showIcon />}
       {response && (
         <div>
           <Space style={{ marginBottom: 8 }}>
-            <Text strong>响应状态：</Text>
+            <Text strong>{t('apiDebug.response.status')}</Text>
             <Tag color={statusColor(response.status)}>{response.status} {response.statusText}</Tag>
-            <Text type="secondary">耗时：{response.duration} ms</Text>
+            <Text type="secondary">{t('apiDebug.response.duration')}{response.duration} ms</Text>
           </Space>
           <Tabs
             size="small"
             items={[
               {
                 key: 'body',
-                label: '响应体',
+                label: t('apiDebug.response.body'),
                 children: (
                   <pre style={{ background: '#f6f8fa', padding: 12, borderRadius: 4, fontSize: 13, maxHeight: 400, overflow: 'auto', margin: 0 }}>
                     {prettyBody()}
@@ -505,14 +509,14 @@ export default function ApiDebug() {
               },
               {
                 key: 'headers',
-                label: '响应 Headers',
+                label: t('apiDebug.response.headers'),
                 children: (
                   <Table
                     size="small"
                     dataSource={Object.entries(response.headers).map(([key, value]) => ({ key, name: key, value }))}
                     columns={[
-                      { title: 'Header', dataIndex: 'name', key: 'name', width: 240 },
-                      { title: '值', dataIndex: 'value', key: 'value' },
+                      { title: t('apiDebug.col.header'), dataIndex: 'name', key: 'name', width: 240 },
+                      { title: t('apiDebug.col.headerValue'), dataIndex: 'value', key: 'value' },
                     ]}
                     pagination={false}
                   />

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -1,5 +1,6 @@
 import { Alert, Badge, Spin, Table, Tag, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import { useTranslation } from 'react-i18next';
 import type { ParameterObject, ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
 import { OperationModeTabs, useCurrentOperation } from './useCurrentOperation';
 
@@ -72,75 +73,12 @@ function responseSchema(response: ResponseObject): string {
   return schemaName(schema);
 }
 
-const paramColumns: ColumnsType<ParamRow> = [
-  {
-    title: '参数名',
-    dataIndex: 'name',
-    width: 180,
-    render: (value) => <Text code>{value}</Text>,
-  },
-  {
-    title: '位置',
-    dataIndex: 'in',
-    width: 90,
-    render: (value) => {
-      const colorMap: Record<string, string> = {
-        path: 'blue', query: 'cyan', header: 'purple', cookie: 'orange', body: 'geekblue', formData: 'lime',
-      };
-      return <Tag color={colorMap[value] ?? 'default'}>{value}</Tag>;
-    },
-  },
-  { title: '类型', dataIndex: 'type', width: 130 },
-  {
-    title: '必填',
-    dataIndex: 'required',
-    width: 80,
-    render: (value) => value ? <Badge status="error" text="是" /> : <Badge status="default" text="否" />,
-  },
-  { title: '说明', dataIndex: 'description' },
-];
-
-const bodyColumns: ColumnsType<BodyRow> = [
-  {
-    title: '字段名',
-    dataIndex: 'name',
-    width: 180,
-    render: (value) => <Text code>{value}</Text>,
-  },
-  { title: '类型', dataIndex: 'type', width: 130 },
-  {
-    title: '必填',
-    dataIndex: 'required',
-    width: 80,
-    render: (value) => value ? <Badge status="error" text="是" /> : <Badge status="default" text="否" />,
-  },
-  { title: '说明', dataIndex: 'description' },
-];
-
-const responseColumns: ColumnsType<ResponseRow> = [
-  {
-    title: '状态码',
-    dataIndex: 'statusCode',
-    width: 100,
-    render: (value) => {
-      const color = value.startsWith('2') ? 'success' : value.startsWith('4') ? 'warning' : 'error';
-      return <Tag color={color}>{value}</Tag>;
-    },
-  },
-  { title: '说明', dataIndex: 'description' },
-  {
-    title: 'Schema',
-    dataIndex: 'schema',
-    width: 180,
-    render: (value) => value ? <Text code>{value}</Text> : <Text type="secondary">—</Text>,
-  },
-];
-
 const METHOD_COLOR: Record<string, string> = {
   GET: 'green', POST: 'blue', PUT: 'orange', DELETE: 'red', PATCH: 'cyan', HEAD: 'purple', OPTIONS: 'default',
 };
 
 export default function ApiDoc() {
+  const { t } = useTranslation();
   const { loading, swaggerDoc, operation } = useCurrentOperation();
 
   if (loading) {
@@ -148,8 +86,72 @@ export default function ApiDoc() {
   }
 
   if (!swaggerDoc || !operation) {
-    return <Alert type="warning" showIcon message="未找到接口文档" description="当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。" />;
+    return <Alert type="warning" showIcon message={t('apiDoc.notFound.title')} description={t('apiDoc.notFound.desc')} />;
   }
+
+  const paramColumns: ColumnsType<ParamRow> = [
+    {
+      title: t('apiDoc.col.paramName'),
+      dataIndex: 'name',
+      width: 180,
+      render: (value) => <Text code>{value}</Text>,
+    },
+    {
+      title: t('apiDoc.col.location'),
+      dataIndex: 'in',
+      width: 90,
+      render: (value) => {
+        const colorMap: Record<string, string> = {
+          path: 'blue', query: 'cyan', header: 'purple', cookie: 'orange', body: 'geekblue', formData: 'lime',
+        };
+        return <Tag color={colorMap[value] ?? 'default'}>{value}</Tag>;
+      },
+    },
+    { title: t('apiDoc.col.type'), dataIndex: 'type', width: 130 },
+    {
+      title: t('apiDoc.col.required'),
+      dataIndex: 'required',
+      width: 80,
+      render: (value) => value ? <Badge status="error" text={t('schema.required.yes')} /> : <Badge status="default" text={t('schema.required.no')} />,
+    },
+    { title: t('apiDoc.col.description'), dataIndex: 'description' },
+  ];
+
+  const bodyColumns: ColumnsType<BodyRow> = [
+    {
+      title: t('schema.col.fieldName'),
+      dataIndex: 'name',
+      width: 180,
+      render: (value) => <Text code>{value}</Text>,
+    },
+    { title: t('apiDoc.col.type'), dataIndex: 'type', width: 130 },
+    {
+      title: t('apiDoc.col.required'),
+      dataIndex: 'required',
+      width: 80,
+      render: (value) => value ? <Badge status="error" text={t('schema.required.yes')} /> : <Badge status="default" text={t('schema.required.no')} />,
+    },
+    { title: t('apiDoc.col.description'), dataIndex: 'description' },
+  ];
+
+  const responseColumns: ColumnsType<ResponseRow> = [
+    {
+      title: t('apiDoc.col.statusCode'),
+      dataIndex: 'statusCode',
+      width: 100,
+      render: (value) => {
+        const color = value.startsWith('2') ? 'success' : value.startsWith('4') ? 'warning' : 'error';
+        return <Tag color={color}>{value}</Tag>;
+      },
+    },
+    { title: t('apiDoc.col.description'), dataIndex: 'description' },
+    {
+      title: t('apiDoc.col.schema'),
+      dataIndex: 'schema',
+      width: 180,
+      render: (value) => value ? <Text code>{value}</Text> : <Text type="secondary">—</Text>,
+    },
+  ];
 
   const method = operation.method.toUpperCase();
   const op = operation.operation;
@@ -179,33 +181,33 @@ export default function ApiDoc() {
           {method}
         </Tag>
         <Text code style={{ fontSize: 15 }}>{operation.path}</Text>
-        {op.deprecated && <Tag color="red">已废弃</Tag>}
+        {op.deprecated && <Tag color="red">{t('apiDoc.deprecated')}</Tag>}
       </div>
 
       <Title level={4} style={{ marginTop: 0 }}>{op.summary ?? operation.path}</Title>
       {op.description && <Paragraph type="secondary">{op.description}</Paragraph>}
 
-      <Title level={5} style={{ marginTop: 24 }}>请求参数</Title>
+      <Title level={5} style={{ marginTop: 24 }}>{t('apiDoc.requestParams')}</Title>
       <Table<ParamRow>
         columns={paramColumns}
         dataSource={parameters}
         pagination={false}
         size="small"
         bordered
-        locale={{ emptyText: '无请求参数' }}
+        locale={{ emptyText: t('apiDoc.noParams') }}
       />
 
-      <Title level={5} style={{ marginTop: 24 }}>请求体</Title>
+      <Title level={5} style={{ marginTop: 24 }}>{t('apiDoc.requestBody')}</Title>
       <Table<BodyRow>
         columns={bodyColumns}
         dataSource={bodyRows}
         pagination={false}
         size="small"
         bordered
-        locale={{ emptyText: bodySchema ? '当前请求体暂不支持字段展开' : '无请求体' }}
+        locale={{ emptyText: bodySchema ? t('apiDoc.body.notExpandable') : t('apiDoc.noBody') }}
       />
 
-      <Title level={5} style={{ marginTop: 24 }}>响应结构</Title>
+      <Title level={5} style={{ marginTop: 24 }}>{t('apiDoc.responseStructure')}</Title>
       <Table<ResponseRow>
         columns={responseColumns}
         dataSource={responses}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Tabs } from 'antd';
+import { useTranslation } from 'react-i18next';
 import { useGroup } from '../../context/GroupContext';
 import type { MenuOperation, SwaggerDoc } from '../../types/swagger';
 
@@ -41,6 +42,7 @@ interface OperationModeTabsProps {
 export function OperationModeTabs({ activeKey }: OperationModeTabsProps) {
   const navigate = useNavigate();
   const { group, tag, operaterId } = useParams();
+  const { t } = useTranslation();
 
   return (
     <Tabs
@@ -50,8 +52,8 @@ export function OperationModeTabs({ activeKey }: OperationModeTabsProps) {
         navigate(`/${encodeURIComponent(group)}/${encodeURIComponent(tag)}/${encodeURIComponent(operaterId)}/${key}`);
       }}
       items={[
-        { key: 'doc', label: '文档' },
-        { key: 'debug', label: '调试' },
+        { key: 'doc', label: t('operation.tab.doc') },
+        { key: 'debug', label: t('operation.tab.debug') },
       ]}
     />
   );

--- a/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
@@ -1,32 +1,34 @@
 import { useState } from 'react';
 import { Table, Form, Input, Select, Button, Space } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
 import { GlobalParamProvider, useGlobalParam, GlobalParamItem } from '../../context/GlobalParamContext';
 
 export { useGlobalParam };
 
-const columns = (onDelete: (id: string) => void) => [
-  { title: 'Name', dataIndex: 'name', key: 'name' },
-  { title: 'Value', dataIndex: 'value', key: 'value' },
-  { title: 'In', dataIndex: 'in', key: 'in' },
-  {
-    title: 'Action',
-    key: 'action',
-    render: (_: unknown, record: GlobalParamItem) => (
-      <Button
-        type="text"
-        danger
-        icon={<DeleteOutlined />}
-        onClick={() => onDelete(record.id)}
-      />
-    ),
-  },
-];
-
 function GlobalParamInner() {
+  const { t } = useTranslation();
   const { params, addParam, removeParam } = useGlobalParam();
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
+
+  const columns = [
+    { title: t('globalParam.col.name'), dataIndex: 'name', key: 'name' },
+    { title: t('globalParam.col.value'), dataIndex: 'value', key: 'value' },
+    { title: t('globalParam.col.in'), dataIndex: 'in', key: 'in' },
+    {
+      title: t('globalParam.col.action'),
+      key: 'action',
+      render: (_: unknown, record: GlobalParamItem) => (
+        <Button
+          type="text"
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => removeParam(record.id)}
+        />
+      ),
+    },
+  ];
 
   const onFinish = (values: { name: string; value: string; in: 'header' | 'query' }) => {
     setLoading(true);
@@ -44,11 +46,11 @@ function GlobalParamInner() {
         initialValues={{ in: 'header' }}
         style={{ marginBottom: 16 }}
       >
-        <Form.Item name="name" rules={[{ required: true, message: 'Name required' }]}>
-          <Input placeholder="Parameter name" />
+        <Form.Item name="name" rules={[{ required: true, message: t('globalParam.validation.name') }]}>
+          <Input placeholder={t('globalParam.placeholder.name')} />
         </Form.Item>
-        <Form.Item name="value" rules={[{ required: true, message: 'Value required' }]}>
-          <Input placeholder="Parameter value" />
+        <Form.Item name="value" rules={[{ required: true, message: t('globalParam.validation.value') }]}>
+          <Input placeholder={t('globalParam.placeholder.value')} />
         </Form.Item>
         <Form.Item name="in">
           <Select style={{ width: 100 }}>
@@ -59,7 +61,7 @@ function GlobalParamInner() {
         <Form.Item>
           <Space>
             <Button type="primary" htmlType="submit" loading={loading}>
-              Add
+              {t('globalParam.btn.add')}
             </Button>
           </Space>
         </Form.Item>
@@ -67,7 +69,7 @@ function GlobalParamInner() {
 
       <Table
         dataSource={params}
-        columns={columns(removeParam)}
+        columns={columns}
         rowKey="id"
         pagination={false}
         size="small"

--- a/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
@@ -1,5 +1,6 @@
 import { Button, Space, Typography, Alert } from 'antd';
 import { FileTextOutlined, FileWordOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
 import { useGroup } from '../../context/GroupContext';
 import type { SwaggerDoc, MenuTag, OperationObject, ParameterObject, SchemaObject } from '../../types/swagger';
 
@@ -215,6 +216,7 @@ function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
 }
 
 export default function OfficeDoc() {
+  const { t } = useTranslation();
   const { swaggerDoc, menuTags, loading, usingMock } = useGroup();
 
   function handleDownloadHtml() {
@@ -235,15 +237,15 @@ export default function OfficeDoc() {
 
   return (
     <div id="knife4j-office-doc-page" style={{ padding: 24, maxWidth: 800 }}>
-      <Title level={4} style={{ marginBottom: 8 }}>离线文档导出</Title>
+      <Title level={4} style={{ marginBottom: 8 }}>{t('officeDoc.title')}</Title>
       <Paragraph type="secondary" style={{ marginBottom: 20 }}>
-        将当前接口文档导出为可下载的离线文件，支持 HTML 和 Word（.doc）格式。
+        {t('officeDoc.desc')}
       </Paragraph>
 
       {noData && (
         <Alert
           type="warning"
-          message="当前使用 Mock 数据或文档未加载，导出内容可能不完整。"
+          message={t('officeDoc.alert.mockData')}
           style={{ marginBottom: 16 }}
         />
       )}
@@ -256,7 +258,7 @@ export default function OfficeDoc() {
           disabled={loading || !swaggerDoc || usingMock}
           loading={loading}
         >
-          下载 HTML
+          {t('officeDoc.btn.html')}
         </Button>
         <Button
           icon={<FileWordOutlined />}
@@ -264,7 +266,7 @@ export default function OfficeDoc() {
           disabled={loading || !swaggerDoc || usingMock}
           loading={loading}
         >
-          下载 Word (.doc)
+          {t('officeDoc.btn.word')}
         </Button>
       </Space>
     </div>

--- a/knife4j-front/package-lock.json
+++ b/knife4j-front/package-lock.json
@@ -42,9 +42,12 @@
       "dependencies": {
         "@types/react-router-dom": "^5.3.3",
         "antd": "^5.7.3",
+        "i18next": "^23.7.6",
+        "i18next-browser-languagedetector": "^7.2.0",
         "knife4j-core": "*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^14.0.0",
         "react-resizable": "^3.0.5",
         "react-router-dom": "^6.14.2"
       },
@@ -64,8 +67,7 @@
     },
     "knife4j-ui-react/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/eslint-plugin/download/@typescript-eslint/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha1-MIMMHKgf1fPCcU5STEMD4BlPnNM=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -100,8 +102,7 @@
     },
     "knife4j-ui-react/node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/parser/download/@typescript-eslint/parser-6.21.0.tgz",
-      "integrity": "sha1-r4/PZv7uLtyGvF0c9F4zsGML81s=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -129,8 +130,7 @@
     },
     "knife4j-ui-react/node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "http://r.npm.sankuai.com/typescript/download/typescript-5.9.3.tgz",
-      "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -143,8 +143,7 @@
     },
     "node_modules/@ant-design/colors": {
       "version": "7.2.1",
-      "resolved": "http://r.npm.sankuai.com/@ant-design/colors/download/@ant-design/colors-7.2.1.tgz",
-      "integrity": "sha1-O7wcbBhVACDRYioAZ/8DSSMY35g=",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@ant-design/fast-color": "^2.0.6"
@@ -152,8 +151,7 @@
     },
     "node_modules/@ant-design/cssinjs": {
       "version": "1.24.0",
-      "resolved": "http://r.npm.sankuai.com/@ant-design/cssinjs/download/@ant-design/cssinjs-1.24.0.tgz",
-      "integrity": "sha1-fbCR8D8Ymrx3oTy9J6IpOALNcoU=",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.24.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -171,8 +169,7 @@
     },
     "node_modules/@ant-design/cssinjs-utils": {
       "version": "1.1.3",
-      "resolved": "http://r.npm.sankuai.com/@ant-design/cssinjs-utils/download/@ant-design/cssinjs-utils-1.1.3.tgz",
-      "integrity": "sha1-XdeRJgV5IKaZLVezjdhOLAtweXc=",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
@@ -186,8 +183,7 @@
     },
     "node_modules/@ant-design/fast-color": {
       "version": "2.0.6",
-      "resolved": "http://r.npm.sankuai.com/@ant-design/fast-color/download/@ant-design/fast-color-2.0.6.tgz",
-      "integrity": "sha1-q01EVcFULJAX02fC+oyj5CFdC6I=",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7"
@@ -198,8 +194,7 @@
     },
     "node_modules/@ant-design/icons": {
       "version": "5.6.1",
-      "resolved": "http://r.npm.sankuai.com/@ant-design/icons/download/@ant-design/icons-5.6.1.tgz",
-      "integrity": "sha1-cpD83D2W/z/KeT7TmQU80prV29M=",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
@@ -218,14 +213,12 @@
     },
     "node_modules/@ant-design/icons-svg": {
       "version": "4.4.2",
-      "resolved": "http://r.npm.sankuai.com/@ant-design/icons-svg/download/@ant-design/icons-svg-4.4.2.tgz",
-      "integrity": "sha1-7Svn+02CrH4dRaVKWwbWzs+L5vY=",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
       "license": "MIT"
     },
     "node_modules/@ant-design/react-slick": {
       "version": "1.1.2",
-      "resolved": "http://r.npm.sankuai.com/@ant-design/react-slick/download/@ant-design/react-slick-1.1.2.tgz",
-      "integrity": "sha1-+Ezj5NDclB8CsW8dHW16Nx/7tPE=",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.4",
@@ -240,8 +233,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "http://r.npm.sankuai.com/@babel/code-frame/download/@babel/code-frame-7.29.0.tgz",
-      "integrity": "sha1-fNelnxWzzA3NgDA493knEqfQsVw=",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -255,8 +247,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.0",
-      "resolved": "http://r.npm.sankuai.com/@babel/compat-data/download/@babel/compat-data-7.29.0.tgz",
-      "integrity": "sha1-ANA+jArCTdm+lCxTcJkMvh8X2I0=",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -265,8 +256,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.0",
-      "resolved": "http://r.npm.sankuai.com/@babel/core/download/@babel/core-7.29.0.tgz",
-      "integrity": "sha1-UoateF33951lbojOhuZQ0Wyl8yI=",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -296,8 +286,7 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "http://r.npm.sankuai.com/semver/download/semver-6.3.1.tgz",
-      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -306,8 +295,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "resolved": "http://r.npm.sankuai.com/@babel/generator/download/@babel/generator-7.29.1.tgz",
-      "integrity": "sha1-0Jh2KQERq7sA75Yqe4OlMH+6DVA=",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -323,8 +311,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-compilation-targets/download/@babel/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha1-MsSj9B8S7RUyF5sQik10bhBcKyU=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -340,8 +327,7 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "http://r.npm.sankuai.com/semver/download/semver-6.3.1.tgz",
-      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -350,8 +336,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-globals/download/@babel/helper-globals-7.28.0.tgz",
-      "integrity": "sha1-uUMN8qpOF7woZl6t6uiqHZheZnQ=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -360,8 +345,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-module-imports/download/@babel/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha1-YGMsvW/7cLIoIxhyARFnYqA+LVw=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -374,8 +358,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-module-transforms/download/@babel/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha1-kxLZ2eVu3DWutulcJdQQa1C56x4=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -392,8 +375,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-plugin-utils/download/@babel/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha1-bxPqJRtoyFMumF/VMvKHQaivmsg=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -402,8 +384,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-string-parser/download/@babel/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha1-VNp5YJerGc5n7Z+ItHuy7Ek2doc=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -412,8 +393,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha1-AQtpOPq3y333SqK7wGqlA7j+X7Q=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -422,8 +402,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "http://r.npm.sankuai.com/@babel/helper-validator-option/download/@babel/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha1-+lL1sefbGrBJRFtCHERxMDiXcC8=",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -432,8 +411,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.2",
-      "resolved": "http://r.npm.sankuai.com/@babel/helpers/download/@babel/helpers-7.29.2.tgz",
-      "integrity": "sha1-nPvMsCuOIpiSwLBwOAUswahwnEk=",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -446,8 +424,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
-      "resolved": "http://r.npm.sankuai.com/@babel/parser/download/@babel/parser-7.29.2.tgz",
-      "integrity": "sha1-WL1QuaeVHRNJiKGuF3o175pwO6E=",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -462,8 +439,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-async-generators/download/@babel/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -475,8 +451,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-bigint/download/@babel/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -488,8 +463,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-class-properties/download/@babel/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -501,8 +475,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-class-static-block/download/@babel/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha1-GV34mxRrS3izv4l/16JXyEZZ1AY=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -517,8 +490,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-import-attributes/download/@babel/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha1-tx1ZFGZfYBJOEzaW8XzXZpBixQM=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -533,8 +505,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-import-meta/download/@babel/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -546,8 +517,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-json-strings/download/@babel/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -559,8 +529,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-jsx/download/@babel/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha1-+Moou9hIg7X+oORHxjW4G6c5l+4=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -575,8 +544,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-logical-assignment-operators/download/@babel/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -588,8 +556,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-nullish-coalescing-operator/download/@babel/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -601,8 +568,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-numeric-separator/download/@babel/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -614,8 +580,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-object-rest-spread/download/@babel/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -627,8 +592,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-optional-catch-binding/download/@babel/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -640,8 +604,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-optional-chaining/download/@babel/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -653,8 +616,7 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-private-property-in-object/download/@babel/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha1-DcZnHsDqIrbpShEU+FeXDNOd4a0=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -669,8 +631,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-top-level-await/download/@babel/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -685,8 +646,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/plugin-syntax-typescript/download/@babel/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha1-x7Ld8dCoERRbHegA0avRRq+S46I=",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -701,8 +661,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
-      "resolved": "http://r.npm.sankuai.com/@babel/runtime/download/@babel/runtime-7.29.2.tgz",
-      "integrity": "sha1-mm4tBfS2aS4YAc1PsXatgjkw7V4=",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -710,8 +669,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
-      "resolved": "http://r.npm.sankuai.com/@babel/template/download/@babel/template-7.28.6.tgz",
-      "integrity": "sha1-Dn5W7O23iu72bOeXKwgvznaiPlc=",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -725,8 +683,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "resolved": "http://r.npm.sankuai.com/@babel/traverse/download/@babel/traverse-7.29.0.tgz",
-      "integrity": "sha1-8yPQUAFEAlPurTychYrb4AuQMQo=",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -744,8 +701,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "http://r.npm.sankuai.com/@babel/types/download/@babel/types-7.29.0.tgz",
-      "integrity": "sha1-n1seg4xEbnLPPNS5GBUrjGBeN8c=",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -758,27 +714,23 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "resolved": "http://r.npm.sankuai.com/@bcoe/v8-coverage/download/@bcoe/v8-coverage-0.2.3.tgz",
-      "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk=",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
-      "resolved": "http://r.npm.sankuai.com/@emotion/hash/download/@emotion/hash-0.8.0.tgz",
-      "integrity": "sha1-u7/2iXj+/b5ozLUzvIy+HRr7VBM=",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
-      "resolved": "http://r.npm.sankuai.com/@emotion/unitless/download/@emotion/unitless-0.7.5.tgz",
-      "integrity": "sha1-dyESkcGQCnALinjPr9oxYNdpSe0=",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "license": "MIT"
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/android-arm/download/@esbuild/android-arm-0.18.20.tgz",
-      "integrity": "sha1-/tsmW8OlichMwR+BCATyNJR8NoI=",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
       "cpu": [
         "arm"
       ],
@@ -794,8 +746,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/android-arm64/download/@esbuild/android-arm64-0.18.20.tgz",
-      "integrity": "sha1-mEtPnI0Dd0Q8wt/O8mbQIkRZNiI=",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
       "cpu": [
         "arm64"
       ],
@@ -811,8 +762,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/android-x64/download/@esbuild/android-x64-0.18.20.tgz",
-      "integrity": "sha1-Nc9BnEz8i6voiT0pbNmQ6en3VvI=",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -828,8 +778,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/darwin-arm64/download/@esbuild/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha1-CBcsvsz5X7w4M5mn85z73a6w18E=",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
       "cpu": [
         "arm64"
       ],
@@ -845,8 +794,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/darwin-x64/download/@esbuild/darwin-x64-0.18.20.tgz",
-      "integrity": "sha1-1w1XkNi/R1VWtn0Pi3xb3/BT2F0=",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -862,8 +810,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/freebsd-arm64/download/@esbuild/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha1-mHVc0ScH+T8hDiSU1qS1G5aXf1Q=",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
       "cpu": [
         "arm64"
       ],
@@ -879,8 +826,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/freebsd-x64/download/@esbuild/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha1-wesr/wORX4fCnOzkwaf6H0I7Bm4=",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -896,8 +842,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-arm/download/@esbuild/linux-arm-0.18.20.tgz",
-      "integrity": "sha1-PmF8YfM1CKJxUO5BdUPIq1rMc7A=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
       "cpu": [
         "arm"
       ],
@@ -913,8 +858,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-arm64/download/@esbuild/linux-arm64-0.18.20.tgz",
-      "integrity": "sha1-utQji9j0/CW1oCEoDHcKtfw6AqA=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
       "cpu": [
         "arm64"
       ],
@@ -930,8 +874,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-ia32/download/@esbuild/linux-ia32-0.18.20.tgz",
-      "integrity": "sha1-aZORzMupruYBm3+YkuuZIZ8VcKc=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
       "cpu": [
         "ia32"
       ],
@@ -947,8 +890,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-loong64/download/@esbuild/linux-loong64-0.18.20.tgz",
-      "integrity": "sha1-5vzLeqwXjdL/uYYEZayJ1/I7l30=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
       "cpu": [
         "loong64"
       ],
@@ -964,8 +906,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-mips64el/download/@esbuild/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha1-7v86k33pwjEN4wYiqVetG9kYMjE=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
       "cpu": [
         "mips64el"
       ],
@@ -981,8 +922,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-ppc64/download/@esbuild/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha1-L3FWveILAVJ5k+aIFDWtebqVmfs=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
       "cpu": [
         "ppc64"
       ],
@@ -998,8 +938,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-riscv64/download/@esbuild/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha1-Zig4nyEBI9i0dDBFr4yqfU3fx6Y=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
       "cpu": [
         "riscv64"
       ],
@@ -1015,8 +954,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-s390x/download/@esbuild/linux-s390x-0.18.20.tgz",
-      "integrity": "sha1-JV6B+yibEBAmExhYq5n7pj3PAHE=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
       "cpu": [
         "s390x"
       ],
@@ -1032,8 +970,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/linux-x64/download/@esbuild/linux-x64-0.18.20.tgz",
-      "integrity": "sha1-x2kLNBevMYqbb5bfMDGohlF20zg=",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -1049,8 +986,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/netbsd-x64/download/@esbuild/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha1-MOjNij3e1jl14t8kOMoQlgHr4NE=",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -1066,8 +1002,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/openbsd-x64/download/@esbuild/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha1-eBKvMbIFBVh0yAguqc+asNpiF64=",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -1083,8 +1018,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/sunos-x64/download/@esbuild/sunos-x64-0.18.20.tgz",
-      "integrity": "sha1-1cJ1w7TnPJsOzTjRymLAIPiHq50=",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -1100,8 +1034,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/win32-arm64/download/@esbuild/win32-arm64-0.18.20.tgz",
-      "integrity": "sha1-c7x/Wp+Kd4BfNX+rl/KQ0OSCCsk=",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
       "cpu": [
         "arm64"
       ],
@@ -1117,8 +1050,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/win32-ia32/download/@esbuild/win32-ia32-0.18.20.tgz",
-      "integrity": "sha1-7JPL8O8QhcwS5x4NZh0gVp/0IQI=",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
       "cpu": [
         "ia32"
       ],
@@ -1134,8 +1066,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/@esbuild/win32-x64/download/@esbuild/win32-x64-0.18.20.tgz",
-      "integrity": "sha1-eGxfQfBDsHr7GvN2g9fDNmiFj20=",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
       "cpu": [
         "x64"
       ],
@@ -1151,8 +1082,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "http://r.npm.sankuai.com/@eslint-community/eslint-utils/download/@eslint-community/eslint-utils-4.9.1.tgz",
-      "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1170,8 +1100,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "http://r.npm.sankuai.com/@eslint-community/regexpp/download/@eslint-community/regexpp-4.12.2.tgz",
-      "integrity": "sha1-vM32Fbz3tujbgw7AuNIcmiXeWXs=",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1180,8 +1109,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
-      "resolved": "http://r.npm.sankuai.com/@eslint/eslintrc/download/@eslint/eslintrc-2.1.4.tgz",
-      "integrity": "sha1-OIomnw8lwbatwxe1osVXFIlMcK0=",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1204,8 +1132,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "http://r.npm.sankuai.com/brace-expansion/download/brace-expansion-1.1.14.tgz",
-      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1215,8 +1142,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "http://r.npm.sankuai.com/minimatch/download/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1228,8 +1154,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
-      "resolved": "http://r.npm.sankuai.com/@eslint/js/download/@eslint/js-8.57.1.tgz",
-      "integrity": "sha1-3mM9s+wu9qPIni8ZA4Bj6KEi4sI=",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1238,8 +1163,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
-      "resolved": "http://r.npm.sankuai.com/@humanwhocodes/config-array/download/@humanwhocodes/config-array-0.13.0.tgz",
-      "integrity": "sha1-+5B2JN8yVtBLmqLfUNeql+xkh0g=",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
@@ -1254,8 +1178,7 @@
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "http://r.npm.sankuai.com/brace-expansion/download/brace-expansion-1.1.14.tgz",
-      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1265,8 +1188,7 @@
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "http://r.npm.sankuai.com/minimatch/download/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1278,8 +1200,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "http://r.npm.sankuai.com/@humanwhocodes/module-importer/download/@humanwhocodes/module-importer-1.0.1.tgz",
-      "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1292,15 +1213,13 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.3",
-      "resolved": "http://r.npm.sankuai.com/@humanwhocodes/object-schema/download/@humanwhocodes/object-schema-2.0.3.tgz",
-      "integrity": "sha1-Siho111taWPkI7z5C3/RvjQ0CdM=",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "http://r.npm.sankuai.com/@istanbuljs/load-nyc-config/download/@istanbuljs/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1316,8 +1235,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "http://r.npm.sankuai.com/argparse/download/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1326,8 +1244,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "http://r.npm.sankuai.com/find-up/download/find-up-4.1.0.tgz",
-      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1340,8 +1257,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.2",
-      "resolved": "http://r.npm.sankuai.com/js-yaml/download/js-yaml-3.14.2.tgz",
-      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1354,8 +1270,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "http://r.npm.sankuai.com/locate-path/download/locate-path-5.0.0.tgz",
-      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1367,8 +1282,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "http://r.npm.sankuai.com/p-limit/download/p-limit-2.3.0.tgz",
-      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1383,8 +1297,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "http://r.npm.sankuai.com/p-locate/download/p-locate-4.1.0.tgz",
-      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1396,8 +1309,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "http://r.npm.sankuai.com/resolve-from/download/resolve-from-5.0.0.tgz",
-      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1406,8 +1318,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
-      "resolved": "http://r.npm.sankuai.com/@istanbuljs/schema/download/@istanbuljs/schema-0.1.6.tgz",
-      "integrity": "sha1-jcmvoqwVBssaWPiZQPHBJERsjfM=",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1416,8 +1327,7 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/console/download/@jest/console-29.7.0.tgz",
-      "integrity": "sha1-zUgi29uEUpJlxaK9tSmjycyVD/w=",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1434,8 +1344,7 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/core/download/@jest/core-29.7.0.tgz",
-      "integrity": "sha1-tszMI58w/zZglljFpeIpF1fORI8=",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1482,8 +1391,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/environment/download/@jest/environment-29.7.0.tgz",
-      "integrity": "sha1-JNYfVP8feG881Ac7S5RBY4O68qc=",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1498,8 +1406,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/expect/download/@jest/expect-29.7.0.tgz",
-      "integrity": "sha1-dqPtsMt1O3Dfv+Iyg1ENPUVDK/I=",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1512,8 +1419,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/expect-utils/download/@jest/expect-utils-29.7.0.tgz",
-      "integrity": "sha1-Aj7+XSaopw8hZ30KGvwPCkTjocY=",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1525,8 +1431,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/fake-timers/download/@jest/fake-timers-29.7.0.tgz",
-      "integrity": "sha1-/ZG/H/+xbX0NJKQmqxpHpJiBpWU=",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1543,8 +1448,7 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/globals/download/@jest/globals-29.7.0.tgz",
-      "integrity": "sha1-jZKQ+exH/3cmB/qGTKHVou+uHU0=",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1559,8 +1463,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/reporters/download/@jest/reporters-29.7.0.tgz",
-      "integrity": "sha1-BLJi7LO4+qg7Cz0yFiOXI5Po9Mc=",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1603,8 +1506,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/@jest/schemas/download/@jest/schemas-29.6.3.tgz",
-      "integrity": "sha1-Qwtc6KTgBEp+OBlmMwWnswkcjgM=",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1616,8 +1518,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/@jest/source-map/download/@jest/source-map-29.6.3.tgz",
-      "integrity": "sha1-2Quncglc83o0peuUE/G1YqCFVMQ=",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1631,8 +1532,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/test-result/download/@jest/test-result-29.7.0.tgz",
-      "integrity": "sha1-jbmoCqGgl7siYlcmhnNLrtmxZXw=",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1647,8 +1547,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/test-sequencer/download/@jest/test-sequencer-29.7.0.tgz",
-      "integrity": "sha1-bO+XfOHTmDSjrqiHoXJmKKbwcs4=",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1663,8 +1562,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/@jest/transform/download/@jest/transform-29.7.0.tgz",
-      "integrity": "sha1-3y3Zw0bH13aLigZjmZRkDGQuKEw=",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1690,8 +1588,7 @@
     },
     "node_modules/@jest/types": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/@jest/types/download/@jest/types-29.6.3.tgz",
-      "integrity": "sha1-ETH4z2NOfoTF53urEvBSr1hfulk=",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1708,8 +1605,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "http://r.npm.sankuai.com/@jridgewell/gen-mapping/download/@jridgewell/gen-mapping-0.3.13.tgz",
-      "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1719,8 +1615,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "http://r.npm.sankuai.com/@jridgewell/remapping/download/@jridgewell/remapping-2.3.5.tgz",
-      "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1730,8 +1625,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "http://r.npm.sankuai.com/@jridgewell/resolve-uri/download/@jridgewell/resolve-uri-3.1.2.tgz",
-      "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1740,15 +1634,13 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "http://r.npm.sankuai.com/@jridgewell/sourcemap-codec/download/@jridgewell/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "http://r.npm.sankuai.com/@jridgewell/trace-mapping/download/@jridgewell/trace-mapping-0.3.31.tgz",
-      "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1758,8 +1650,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "http://r.npm.sankuai.com/@nodelib/fs.scandir/download/@nodelib/fs.scandir-2.1.5.tgz",
-      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1772,8 +1663,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "http://r.npm.sankuai.com/@nodelib/fs.stat/download/@nodelib/fs.stat-2.0.5.tgz",
-      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1782,8 +1672,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "http://r.npm.sankuai.com/@nodelib/fs.walk/download/@nodelib/fs.walk-1.2.8.tgz",
-      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1796,8 +1685,7 @@
     },
     "node_modules/@rc-component/async-validator": {
       "version": "5.1.0",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/async-validator/download/@rc-component/async-validator-5.1.0.tgz",
-      "integrity": "sha1-6B8x5nbZytxx5DELvxdJx6WIIpE=",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.4"
@@ -1808,8 +1696,7 @@
     },
     "node_modules/@rc-component/color-picker": {
       "version": "2.0.1",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/color-picker/download/@rc-component/color-picker-2.0.1.tgz",
-      "integrity": "sha1-a5uWFSRmqdRHXL5ytAtZS/2hZL4=",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@ant-design/fast-color": "^2.0.6",
@@ -1824,8 +1711,7 @@
     },
     "node_modules/@rc-component/context": {
       "version": "1.4.0",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/context/download/@rc-component/context-1.4.0.tgz",
-      "integrity": "sha1-3G+wIdZ3NUavjwFq5M6a6giDleg=",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -1838,8 +1724,7 @@
     },
     "node_modules/@rc-component/mini-decimal": {
       "version": "1.1.3",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/mini-decimal/download/@rc-component/mini-decimal-1.1.3.tgz",
-      "integrity": "sha1-Rh0M0qke/TySUDdj2MAGJVUtIR8=",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0"
@@ -1850,8 +1735,7 @@
     },
     "node_modules/@rc-component/mutate-observer": {
       "version": "1.1.0",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/mutate-observer/download/@rc-component/mutate-observer-1.1.0.tgz",
-      "integrity": "sha1-7lPMiLeKrePNBlNgkhWkR3k4b9g=",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -1868,8 +1752,7 @@
     },
     "node_modules/@rc-component/portal": {
       "version": "1.1.2",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/portal/download/@rc-component/portal-1.1.2.tgz",
-      "integrity": "sha1-VdseUdeE4DRELpcAU2+qpqtj/HE=",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -1886,8 +1769,7 @@
     },
     "node_modules/@rc-component/qrcode": {
       "version": "1.1.1",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/qrcode/download/@rc-component/qrcode-1.1.1.tgz",
-      "integrity": "sha1-kJ8YG7mnRp0ypulsfzVHbUvZIAg=",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7"
@@ -1902,8 +1784,7 @@
     },
     "node_modules/@rc-component/tour": {
       "version": "1.15.1",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/tour/download/@rc-component/tour-1.15.1.tgz",
-      "integrity": "sha1-m3mAglQYX8GelkFy2Z4l6MaADe0=",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -1922,8 +1803,7 @@
     },
     "node_modules/@rc-component/trigger": {
       "version": "2.3.1",
-      "resolved": "http://r.npm.sankuai.com/@rc-component/trigger/download/@rc-component/trigger-2.3.1.tgz",
-      "integrity": "sha1-g/wMQWWlj9xmvZFxCC0IrPMb5rs=",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
@@ -1943,8 +1823,7 @@
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
-      "resolved": "http://r.npm.sankuai.com/@remix-run/router/download/@remix-run/router-1.23.2.tgz",
-      "integrity": "sha1-FWxLSBwL7iKhn3kkcopnEg3gaXE=",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -1952,22 +1831,19 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
-      "resolved": "http://r.npm.sankuai.com/@rolldown/pluginutils/download/@rolldown/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha1-R9K/TO9tRwsi9YMbQg+JZOC/dV8=",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
-      "resolved": "http://r.npm.sankuai.com/@sinclair/typebox/download/@sinclair/typebox-0.27.10.tgz",
-      "integrity": "sha1-vu/mdfGFP3NnauzJFbK9KsmMT8Y=",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "resolved": "http://r.npm.sankuai.com/@sinonjs/commons/download/@sinonjs/commons-3.0.1.tgz",
-      "integrity": "sha1-ECk1fkTKkBphVYX20nc428iQhM0=",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1976,8 +1852,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "resolved": "http://r.npm.sankuai.com/@sinonjs/fake-timers/download/@sinonjs/fake-timers-10.3.0.tgz",
-      "integrity": "sha1-Vf3/Hsq581QBkSna9N8N1Nkj6mY=",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1986,8 +1861,7 @@
     },
     "node_modules/@swc/core": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core/download/@swc/core-1.15.30.tgz",
-      "integrity": "sha1-L3fV7TsN+WSqyKqiUdxD7YIhAMw=",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.30.tgz",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2027,8 +1901,7 @@
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-darwin-arm64/download/@swc/core-darwin-arm64-1.15.30.tgz",
-      "integrity": "sha1-I0R/HDDJFV/jVgLeQ5K07PoKVMw=",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
       "cpu": [
         "arm64"
       ],
@@ -2044,8 +1917,7 @@
     },
     "node_modules/@swc/core-darwin-x64": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-darwin-x64/download/@swc/core-darwin-x64-1.15.30.tgz",
-      "integrity": "sha1-FubjX/9bB8cS2K9EeD2lmsZK1c8=",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz",
       "cpu": [
         "x64"
       ],
@@ -2061,8 +1933,7 @@
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-linux-arm-gnueabihf/download/@swc/core-linux-arm-gnueabihf-1.15.30.tgz",
-      "integrity": "sha1-q8595zQwEQmn3yPCL2ttIz47nek=",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz",
       "cpu": [
         "arm"
       ],
@@ -2078,8 +1949,7 @@
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-linux-arm64-gnu/download/@swc/core-linux-arm64-gnu-1.15.30.tgz",
-      "integrity": "sha1-mk5BjNu/5kUG3RJGmlU8B+GST+8=",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz",
       "cpu": [
         "arm64"
       ],
@@ -2095,8 +1965,7 @@
     },
     "node_modules/@swc/core-linux-arm64-musl": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-linux-arm64-musl/download/@swc/core-linux-arm64-musl-1.15.30.tgz",
-      "integrity": "sha1-TNaMyyr3HD7FObFaoVyP0wSDPSY=",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz",
       "cpu": [
         "arm64"
       ],
@@ -2112,8 +1981,7 @@
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-linux-ppc64-gnu/download/@swc/core-linux-ppc64-gnu-1.15.30.tgz",
-      "integrity": "sha1-VhmX08Xzktt+NHPLS7xD5taxFgw=",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz",
       "cpu": [
         "ppc64"
       ],
@@ -2129,8 +1997,7 @@
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-linux-s390x-gnu/download/@swc/core-linux-s390x-gnu-1.15.30.tgz",
-      "integrity": "sha1-1vHV3OynlJCTBVhMtp+A3ZGCBBA=",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz",
       "cpu": [
         "s390x"
       ],
@@ -2146,8 +2013,7 @@
     },
     "node_modules/@swc/core-linux-x64-gnu": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-linux-x64-gnu/download/@swc/core-linux-x64-gnu-1.15.30.tgz",
-      "integrity": "sha1-w+kcYPJlpizsYBRfDS2TH+sc9Bo=",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz",
       "cpu": [
         "x64"
       ],
@@ -2163,8 +2029,7 @@
     },
     "node_modules/@swc/core-linux-x64-musl": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-linux-x64-musl/download/@swc/core-linux-x64-musl-1.15.30.tgz",
-      "integrity": "sha1-P9ES5hepUUOPc5MLUUrfGTdQZ/s=",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz",
       "cpu": [
         "x64"
       ],
@@ -2180,8 +2045,7 @@
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-win32-arm64-msvc/download/@swc/core-win32-arm64-msvc-1.15.30.tgz",
-      "integrity": "sha1-0AXc6S5OwbCniYZnyc9eUhXkYxw=",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz",
       "cpu": [
         "arm64"
       ],
@@ -2197,8 +2061,7 @@
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-win32-ia32-msvc/download/@swc/core-win32-ia32-msvc-1.15.30.tgz",
-      "integrity": "sha1-Z+v6oiJmg1o9gndgFML0KDRgYr0=",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz",
       "cpu": [
         "ia32"
       ],
@@ -2214,8 +2077,7 @@
     },
     "node_modules/@swc/core-win32-x64-msvc": {
       "version": "1.15.30",
-      "resolved": "http://r.npm.sankuai.com/@swc/core-win32-x64-msvc/download/@swc/core-win32-x64-msvc-1.15.30.tgz",
-      "integrity": "sha1-y2ArU/nNzftYDOzbArU2M51LAEs=",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.30.tgz",
       "cpu": [
         "x64"
       ],
@@ -2231,15 +2093,13 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "resolved": "http://r.npm.sankuai.com/@swc/counter/download/@swc/counter-0.1.3.tgz",
-      "integrity": "sha1-zHRjvQKUlhHGMpWW/M0rDseCsOk=",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.26",
-      "resolved": "http://r.npm.sankuai.com/@swc/types/download/@swc/types-0.1.26.tgz",
-      "integrity": "sha1-KpdqGHDK7xmSMW3aFGQVDuNpaLU=",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2248,8 +2108,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "http://r.npm.sankuai.com/@types/babel__core/download/@types/babel__core-7.20.5.tgz",
-      "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2262,8 +2121,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "http://r.npm.sankuai.com/@types/babel__generator/download/@types/babel__generator-7.27.0.tgz",
-      "integrity": "sha1-tYGSlMUReZV6+uw0FEL5NB5BCKk=",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2272,8 +2130,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "http://r.npm.sankuai.com/@types/babel__template/download/@types/babel__template-7.4.4.tgz",
-      "integrity": "sha1-VnJRNwHBshmbxtrWNqnXSRWGdm8=",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2283,8 +2140,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "http://r.npm.sankuai.com/@types/babel__traverse/download/@types/babel__traverse-7.28.0.tgz",
-      "integrity": "sha1-B9cT1szg0mXJhJ2wy+YtP2Hzb3Q=",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2293,14 +2149,12 @@
     },
     "node_modules/@types/crypto-js": {
       "version": "4.2.2",
-      "resolved": "http://r.npm.sankuai.com/@types/crypto-js/download/@types/crypto-js-4.2.2.tgz",
-      "integrity": "sha1-dxxKdo2U61kizCAqMAlVggTfDOo=",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
-      "resolved": "http://r.npm.sankuai.com/@types/graceful-fs/download/@types/graceful-fs-4.1.9.tgz",
-      "integrity": "sha1-Kga8D2iiCrN7PjaqI4vmq99J6LQ=",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2309,21 +2163,18 @@
     },
     "node_modules/@types/history": {
       "version": "4.7.11",
-      "resolved": "http://r.npm.sankuai.com/@types/history/download/@types/history-4.7.11.tgz",
-      "integrity": "sha1-VliLF66PUMU5g6Uk/DzEdDeWnWQ=",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
-      "resolved": "http://r.npm.sankuai.com/@types/istanbul-lib-coverage/download/@types/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha1-dznCMqH+6bTTzomF8xTAxtM1Sdc=",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
-      "resolved": "http://r.npm.sankuai.com/@types/istanbul-lib-report/download/@types/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha1-UwR2FK5y4Z/AQB2HLeOuK0zjUL8=",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2332,8 +2183,7 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
-      "resolved": "http://r.npm.sankuai.com/@types/istanbul-reports/download/@types/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha1-DwPj0vZw+9rFhuNLQzeDBwzBb1Q=",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2342,8 +2192,7 @@
     },
     "node_modules/@types/jest": {
       "version": "29.5.14",
-      "resolved": "http://r.npm.sankuai.com/@types/jest/download/@types/jest-29.5.14.tgz",
-      "integrity": "sha1-K5EJEvodaFbK3NDB+Vr33x1gSeU=",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2353,21 +2202,18 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "http://r.npm.sankuai.com/@types/json-schema/download/@types/json-schema-7.0.15.tgz",
-      "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
-      "resolved": "http://r.npm.sankuai.com/@types/lodash/download/@types/lodash-4.17.24.tgz",
-      "integrity": "sha1-SuM0/GLA6RXKjtjjXcxtTuspIV8=",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
-      "resolved": "http://r.npm.sankuai.com/@types/node/download/@types/node-25.6.0.tgz",
-      "integrity": "sha1-Tgm62bRphx8tD2gUAZjL1xT07co=",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2376,14 +2222,12 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "http://r.npm.sankuai.com/@types/prop-types/download/@types/prop-types-15.7.15.tgz",
-      "integrity": "sha1-5uWobWAr6spxzlFj+t9fldcJMcc=",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
-      "resolved": "http://r.npm.sankuai.com/@types/react/download/@types/react-18.3.28.tgz",
-      "integrity": "sha1-CoWxpyQ7QljZ9ib0N5e6GOtfh4E=",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2392,8 +2236,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "resolved": "http://r.npm.sankuai.com/@types/react-dom/download/@types/react-dom-18.3.7.tgz",
-      "integrity": "sha1-uJ3fLNg7T+r8xOLqQa/fuVoNGU8=",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2402,8 +2245,7 @@
     },
     "node_modules/@types/react-resizable": {
       "version": "3.0.8",
-      "resolved": "http://r.npm.sankuai.com/@types/react-resizable/download/@types/react-resizable-3.0.8.tgz",
-      "integrity": "sha1-snABtNJiyCzAdict9LjvkdlIeRg=",
+      "resolved": "https://registry.npmjs.org/@types/react-resizable/-/react-resizable-3.0.8.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2412,8 +2254,7 @@
     },
     "node_modules/@types/react-router": {
       "version": "5.1.20",
-      "resolved": "http://r.npm.sankuai.com/@types/react-router/download/@types/react-router-5.1.20.tgz",
-      "integrity": "sha1-iOzKoSKoJAXvPvvKql3N2fAhOHw=",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
       "license": "MIT",
       "dependencies": {
         "@types/history": "^4.7.11",
@@ -2422,8 +2263,7 @@
     },
     "node_modules/@types/react-router-dom": {
       "version": "5.3.3",
-      "resolved": "http://r.npm.sankuai.com/@types/react-router-dom/download/@types/react-router-dom-5.3.3.tgz",
-      "integrity": "sha1-6da0pm/NvWUaXxBsJlajAIjMHoM=",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@types/history": "^4.7.11",
@@ -2433,22 +2273,19 @@
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
-      "resolved": "http://r.npm.sankuai.com/@types/semver/download/@types/semver-7.7.1.tgz",
-      "integrity": "sha1-POOvGlUk7zJ9Lank/YttlcjXBSg=",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "resolved": "http://r.npm.sankuai.com/@types/stack-utils/download/@types/stack-utils-2.0.3.tgz",
-      "integrity": "sha1-YgkyHrLBcSp+dGZCK4yx/A2d1dg=",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
-      "resolved": "http://r.npm.sankuai.com/@types/yargs/download/@types/yargs-17.0.35.tgz",
-      "integrity": "sha1-BwE+RqpNfX1QpJ4VYEwcU0DU6yQ=",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2457,15 +2294,13 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
-      "resolved": "http://r.npm.sankuai.com/@types/yargs-parser/download/@types/yargs-parser-21.0.3.tgz",
-      "integrity": "sha1-gV4wt4bS6PDc2F/VvPXhoE0AjxU=",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/eslint-plugin/download/@typescript-eslint/eslint-plugin-5.62.0.tgz",
-      "integrity": "sha1-ru8DKNFyueN9m6ttvBO4ftiJd9s=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2499,8 +2334,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/scope-manager/download/@typescript-eslint/scope-manager-5.62.0.tgz",
-      "integrity": "sha1-2UV8zGoLjWs30OslKiMCJHjFRgw=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2517,8 +2351,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/type-utils/download/@typescript-eslint/type-utils-5.62.0.tgz",
-      "integrity": "sha1-KG8DicQWgTds2tlrMJzt0X1wNGo=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2545,8 +2378,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/types/download/@typescript-eslint/types-5.62.0.tgz",
-      "integrity": "sha1-JYYH5g7/ownwZ2CJMcPfb+1B/S8=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2559,8 +2391,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/typescript-estree/download/@typescript-eslint/typescript-estree-5.62.0.tgz",
-      "integrity": "sha1-fRd5S3f6vKxhXWpI+xQzMNli65s=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2587,8 +2418,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/utils/download/@typescript-eslint/utils-5.62.0.tgz",
-      "integrity": "sha1-FB6AnHFjbkp12qOfrtL7X0sQ34Y=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2614,8 +2444,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/visitor-keys/download/@typescript-eslint/visitor-keys-5.62.0.tgz",
-      "integrity": "sha1-IXQBGRfOWCh1lU/+L2kS1ZMeNT4=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2632,8 +2461,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "http://r.npm.sankuai.com/eslint-scope/download/eslint-scope-5.1.1.tgz",
-      "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2646,8 +2474,7 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "http://r.npm.sankuai.com/estraverse/download/estraverse-4.3.0.tgz",
-      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2656,8 +2483,7 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/parser/download/@typescript-eslint/parser-5.62.0.tgz",
-      "integrity": "sha1-G2PQgthJovyuilaSSPvi7huKVsc=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2684,8 +2510,7 @@
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/scope-manager/download/@typescript-eslint/scope-manager-5.62.0.tgz",
-      "integrity": "sha1-2UV8zGoLjWs30OslKiMCJHjFRgw=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2702,8 +2527,7 @@
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/types/download/@typescript-eslint/types-5.62.0.tgz",
-      "integrity": "sha1-JYYH5g7/ownwZ2CJMcPfb+1B/S8=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2716,8 +2540,7 @@
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/typescript-estree/download/@typescript-eslint/typescript-estree-5.62.0.tgz",
-      "integrity": "sha1-fRd5S3f6vKxhXWpI+xQzMNli65s=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2744,8 +2567,7 @@
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/visitor-keys/download/@typescript-eslint/visitor-keys-5.62.0.tgz",
-      "integrity": "sha1-IXQBGRfOWCh1lU/+L2kS1ZMeNT4=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2762,8 +2584,7 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/scope-manager/download/@typescript-eslint/scope-manager-6.21.0.tgz",
-      "integrity": "sha1-6oqb/I8VBKasXVmm3zCNOgYworE=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2780,8 +2601,7 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/type-utils/download/@typescript-eslint/type-utils-6.21.0.tgz",
-      "integrity": "sha1-ZHMoHP7U2sq+gAToUhzuC9nUwB4=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2808,8 +2628,7 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/types/download/@typescript-eslint/types-6.21.0.tgz",
-      "integrity": "sha1-IFckxRI6j+9+zRlQdfpuhbrDQ20=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2822,8 +2641,7 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/typescript-estree/download/@typescript-eslint/typescript-estree-6.21.0.tgz",
-      "integrity": "sha1-xHrnkB2zuL3cPs1z2v8tCJVojEY=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2851,8 +2669,7 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/utils/download/@typescript-eslint/utils-6.21.0.tgz",
-      "integrity": "sha1-RxTnprOedzwcjpfsWH9SCEDNgTQ=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2877,8 +2694,7 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "6.21.0",
-      "resolved": "http://r.npm.sankuai.com/@typescript-eslint/visitor-keys/download/@typescript-eslint/visitor-keys-6.21.0.tgz",
-      "integrity": "sha1-h6mdB3qlB+IOI4sR1WzCat5F/kc=",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2895,15 +2711,13 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "resolved": "http://r.npm.sankuai.com/@ungap/structured-clone/download/@ungap/structured-clone-1.3.0.tgz",
-      "integrity": "sha1-0Gu7OE689sUF/eHD0O1N3/4Kr/g=",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.11.0",
-      "resolved": "http://r.npm.sankuai.com/@vitejs/plugin-react-swc/download/@vitejs/plugin-react-swc-3.11.0.tgz",
-      "integrity": "sha1-2CzDB9UwGXp3tQI4hgzzGYkP/Bc=",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.11.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2916,8 +2730,7 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "http://r.npm.sankuai.com/acorn/download/acorn-8.16.0.tgz",
-      "integrity": "sha1-TOecib5Ar+ev6POtuQKh8c6awIo=",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2929,8 +2742,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "http://r.npm.sankuai.com/acorn-jsx/download/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2939,8 +2751,7 @@
     },
     "node_modules/ajv": {
       "version": "6.15.0",
-      "resolved": "http://r.npm.sankuai.com/ajv/download/ajv-6.15.0.tgz",
-      "integrity": "sha1-B+mCx0YmFnqnoklcU4F4ktcTlJI=",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2956,8 +2767,7 @@
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "resolved": "http://r.npm.sankuai.com/ansi-escapes/download/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2972,8 +2782,7 @@
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
       "version": "0.21.3",
-      "resolved": "http://r.npm.sankuai.com/type-fest/download/type-fest-0.21.3.tgz",
-      "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -2985,8 +2794,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "http://r.npm.sankuai.com/ansi-regex/download/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2995,8 +2803,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "http://r.npm.sankuai.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3011,8 +2818,7 @@
     },
     "node_modules/antd": {
       "version": "5.29.3",
-      "resolved": "http://r.npm.sankuai.com/antd/download/antd-5.29.3.tgz",
-      "integrity": "sha1-QE7an5cWsv+bBiUd/stwKNfE3kA=",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.29.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.2.1",
@@ -3076,8 +2882,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "http://r.npm.sankuai.com/anymatch/download/anymatch-3.1.3.tgz",
-      "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3090,15 +2895,13 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "http://r.npm.sankuai.com/argparse/download/argparse-2.0.1.tgz",
-      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
-      "resolved": "http://r.npm.sankuai.com/array-union/download/array-union-2.1.0.tgz",
-      "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3107,8 +2910,7 @@
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/babel-jest/download/babel-jest-29.7.0.tgz",
-      "integrity": "sha1-9DaZGSJbaExWCFmYrGPb0FvgINU=",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3129,8 +2931,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "resolved": "http://r.npm.sankuai.com/babel-plugin-istanbul/download/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3146,8 +2947,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "resolved": "http://r.npm.sankuai.com/istanbul-lib-instrument/download/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha1-0QyIhcISVXThwjHKyt+VVnXhzj0=",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3163,8 +2963,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "http://r.npm.sankuai.com/semver/download/semver-6.3.1.tgz",
-      "integrity": "sha1-VW0u+GiRRuRtzqS/3QlfNDTf/LQ=",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3173,8 +2972,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/babel-plugin-jest-hoist/download/babel-plugin-jest-hoist-29.6.3.tgz",
-      "integrity": "sha1-qtvpQ0ZBgqiSLDySfDBn/0DSRiY=",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3189,8 +2987,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
-      "resolved": "http://r.npm.sankuai.com/babel-preset-current-node-syntax/download/babel-preset-current-node-syntax-1.2.0.tgz",
-      "integrity": "sha1-IHMNbNx92l2JQByrEKxqMgZ6zeY=",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3216,8 +3013,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/babel-preset-jest/download/babel-preset-jest-29.6.3.tgz",
-      "integrity": "sha1-+gX6UQ59STiW17DdIDNgHIQPFxw=",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3233,15 +3029,13 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "http://r.npm.sankuai.com/balanced-match/download/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.21",
-      "resolved": "http://r.npm.sankuai.com/baseline-browser-mapping/download/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha1-E2+fGB7g18puPtv0LZVZdj0sEUE=",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3253,8 +3047,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
-      "resolved": "http://r.npm.sankuai.com/brace-expansion/download/brace-expansion-2.1.0.tgz",
-      "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3263,8 +3056,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "http://r.npm.sankuai.com/braces/download/braces-3.0.3.tgz",
-      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3276,8 +3068,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
-      "resolved": "http://r.npm.sankuai.com/browserslist/download/browserslist-4.28.2.tgz",
-      "integrity": "sha1-9QtlNi70iXTKn1CzaAVm14a4EdI=",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "dev": true,
       "funding": [
         {
@@ -3310,8 +3101,7 @@
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
-      "resolved": "http://r.npm.sankuai.com/bs-logger/download/bs-logger-0.2.6.tgz",
-      "integrity": "sha1-6302UwenLPl0zGzadraDVK0za9g=",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3323,8 +3113,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "resolved": "http://r.npm.sankuai.com/bser/download/bser-2.1.1.tgz",
-      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3333,15 +3122,13 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "http://r.npm.sankuai.com/buffer-from/download/buffer-from-1.1.2.tgz",
-      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "http://r.npm.sankuai.com/callsites/download/callsites-3.1.0.tgz",
-      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3350,8 +3137,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "http://r.npm.sankuai.com/camelcase/download/camelcase-5.3.1.tgz",
-      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3360,8 +3146,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
-      "resolved": "http://r.npm.sankuai.com/caniuse-lite/download/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha1-BGYMfeFfRF2G3RCsiKiTasBpjkU=",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
       "dev": true,
       "funding": [
         {
@@ -3381,8 +3166,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "http://r.npm.sankuai.com/chalk/download/chalk-4.1.2.tgz",
-      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3398,8 +3182,7 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
-      "resolved": "http://r.npm.sankuai.com/char-regex/download/char-regex-1.0.2.tgz",
-      "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8=",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3408,8 +3191,7 @@
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
-      "resolved": "http://r.npm.sankuai.com/ci-info/download/ci-info-3.9.0.tgz",
-      "integrity": "sha1-QnmmICinsfJi80c/yWBfXiGMWbQ=",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "dev": true,
       "funding": [
         {
@@ -3424,27 +3206,23 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
-      "resolved": "http://r.npm.sankuai.com/cjs-module-lexer/download/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha1-D3lzHrjP4exyrNQGbvrJ1hmRsA0=",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
-      "resolved": "http://r.npm.sankuai.com/class-transformer/download/class-transformer-0.5.1.tgz",
-      "integrity": "sha1-JBR9Xf/Sps6pMKMlCmd63flqszY=",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "license": "MIT"
     },
     "node_modules/classnames": {
       "version": "2.5.1",
-      "resolved": "http://r.npm.sankuai.com/classnames/download/classnames-2.5.1.tgz",
-      "integrity": "sha1-undMYUvg8BbaEFyFjnFZ6ujnaHs=",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "http://r.npm.sankuai.com/cliui/download/cliui-8.0.1.tgz",
-      "integrity": "sha1-DASwddsCy/5g3I5s8vVIaxo2CKo=",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3458,8 +3236,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "http://r.npm.sankuai.com/clsx/download/clsx-2.1.1.tgz",
-      "integrity": "sha1-7tOXyf2L2IK/sY3qtxAgSaLzKZk=",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3467,8 +3244,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "resolved": "http://r.npm.sankuai.com/co/download/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3478,15 +3254,13 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
-      "resolved": "http://r.npm.sankuai.com/collect-v8-coverage/download/collect-v8-coverage-1.0.3.tgz",
-      "integrity": "sha1-zB8B640CKYy8mkN8dMcKtOUhC4A=",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "http://r.npm.sankuai.com/color-convert/download/color-convert-2.0.1.tgz",
-      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3498,35 +3272,30 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "http://r.npm.sankuai.com/color-name/download/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/compute-scroll-into-view": {
       "version": "3.1.1",
-      "resolved": "http://r.npm.sankuai.com/compute-scroll-into-view/download/compute-scroll-into-view-3.1.1.tgz",
-      "integrity": "sha1-AsM4bsUx+2qYgZZziOU+hWTz6ao=",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "http://r.npm.sankuai.com/concat-map/download/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "http://r.npm.sankuai.com/convert-source-map/download/convert-source-map-2.0.0.tgz",
-      "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
-      "resolved": "http://r.npm.sankuai.com/copy-to-clipboard/download/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha1-VaxDoduK5jmkvZlRHBSM3RuDobA=",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
@@ -3534,8 +3303,7 @@
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/create-jest/download/create-jest-29.7.0.tgz",
-      "integrity": "sha1-o1XFs8seGvAroXf+ev1/7uSaUyA=",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3556,8 +3324,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "http://r.npm.sankuai.com/cross-spawn/download/cross-spawn-7.0.6.tgz",
-      "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3571,26 +3338,22 @@
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
-      "resolved": "http://r.npm.sankuai.com/crypto-js/download/crypto-js-4.2.0.tgz",
-      "integrity": "sha1-TZMWOezf0S/4DoGG26avLC6FZjE=",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "http://r.npm.sankuai.com/csstype/download/csstype-3.2.3.tgz",
-      "integrity": "sha1-7EjA8+mT5QZIyG2lWeJhCZXPmJo=",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "license": "MIT"
     },
     "node_modules/dayjs": {
       "version": "1.11.20",
-      "resolved": "http://r.npm.sankuai.com/dayjs/download/dayjs-1.11.20.tgz",
-      "integrity": "sha1-iNkZ/WOdyZFBXaX0y28bZlCBGTg=",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "http://r.npm.sankuai.com/debug/download/debug-4.4.3.tgz",
-      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3607,8 +3370,7 @@
     },
     "node_modules/dedent": {
       "version": "1.7.2",
-      "resolved": "http://r.npm.sankuai.com/dedent/download/dedent-1.7.2.tgz",
-      "integrity": "sha1-NOImSrU4MB4nz3sHvyNpwZuqjdk=",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3622,15 +3384,13 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "http://r.npm.sankuai.com/deep-is/download/deep-is-0.1.4.tgz",
-      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "http://r.npm.sankuai.com/deepmerge/download/deepmerge-4.3.1.tgz",
-      "integrity": "sha1-RLXyFHzTsA1LVhN2hZZvJv0l3Uo=",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3639,8 +3399,7 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "resolved": "http://r.npm.sankuai.com/detect-newline/download/detect-newline-3.1.0.tgz",
-      "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3649,8 +3408,7 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/diff-sequences/download/diff-sequences-29.6.3.tgz",
-      "integrity": "sha1-Ter4lNEUB8Ue/IQYAS+ecLhOqSE=",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3659,8 +3417,7 @@
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "resolved": "http://r.npm.sankuai.com/dir-glob/download/dir-glob-3.0.1.tgz",
-      "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3672,8 +3429,7 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "http://r.npm.sankuai.com/doctrine/download/doctrine-3.0.0.tgz",
-      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3685,15 +3441,13 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
-      "resolved": "http://r.npm.sankuai.com/electron-to-chromium/download/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha1-ZDfMCKfZuRSpgSDhgvN3k8nq/9Q=",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "resolved": "http://r.npm.sankuai.com/emittery/download/emittery-0.13.1.tgz",
-      "integrity": "sha1-wEuMNFdJDghHrlH87Tr1LTOOPa0=",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3705,15 +3459,13 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "http://r.npm.sankuai.com/emoji-regex/download/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "http://r.npm.sankuai.com/error-ex/download/error-ex-1.3.4.tgz",
-      "integrity": "sha1-s6jYu2+S7swWKePifTyGB6ijJBQ=",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3722,8 +3474,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "http://r.npm.sankuai.com/es-errors/download/es-errors-1.3.0.tgz",
-      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3732,8 +3483,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.18.20",
-      "resolved": "http://r.npm.sankuai.com/esbuild/download/esbuild-0.18.20.tgz",
-      "integrity": "sha1-Rwn1o0gBtDt5mrfW2C9yhKm3p6Y=",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3770,8 +3520,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "http://r.npm.sankuai.com/escalade/download/escalade-3.2.0.tgz",
-      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3780,8 +3529,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/escape-string-regexp/download/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3793,8 +3541,7 @@
     },
     "node_modules/eslint": {
       "version": "8.57.1",
-      "resolved": "http://r.npm.sankuai.com/eslint/download/eslint-8.57.1.tgz",
-      "integrity": "sha1-ffEJZUq6fju+XI6uUzxeRh08bKk=",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
@@ -3850,8 +3597,7 @@
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.5",
-      "resolved": "http://r.npm.sankuai.com/eslint-plugin-prettier/download/eslint-plugin-prettier-4.2.5.tgz",
-      "integrity": "sha1-kco/LwGoTxJyzOBOlxdVBJTA/gY=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.5.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3872,8 +3618,7 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.2",
-      "resolved": "http://r.npm.sankuai.com/eslint-plugin-react-hooks/download/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha1-yCnrBsDm9ISz+7hal+V3hPMoxZY=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3885,8 +3630,7 @@
     },
     "node_modules/eslint-plugin-react-refresh": {
       "version": "0.4.26",
-      "resolved": "http://r.npm.sankuai.com/eslint-plugin-react-refresh/download/eslint-plugin-react-refresh-0.4.26.tgz",
-      "integrity": "sha1-K83RCeqftOC1a7G1FGz4hBshtiY=",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3895,8 +3639,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
-      "resolved": "http://r.npm.sankuai.com/eslint-scope/download/eslint-scope-7.2.2.tgz",
-      "integrity": "sha1-3rT5JWM5DzIAaJSvYqItuhxGQj8=",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3912,8 +3655,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "http://r.npm.sankuai.com/eslint-visitor-keys/download/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3925,8 +3667,7 @@
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "http://r.npm.sankuai.com/brace-expansion/download/brace-expansion-1.1.14.tgz",
-      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3936,8 +3677,7 @@
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "http://r.npm.sankuai.com/minimatch/download/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3949,8 +3689,7 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
-      "resolved": "http://r.npm.sankuai.com/espree/download/espree-9.6.1.tgz",
-      "integrity": "sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8=",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3967,8 +3706,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "http://r.npm.sankuai.com/esprima/download/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -3981,8 +3719,7 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "http://r.npm.sankuai.com/esquery/download/esquery-1.7.0.tgz",
-      "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3994,8 +3731,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "http://r.npm.sankuai.com/esrecurse/download/esrecurse-4.3.0.tgz",
-      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4007,8 +3743,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "http://r.npm.sankuai.com/estraverse/download/estraverse-5.3.0.tgz",
-      "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4017,8 +3752,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "http://r.npm.sankuai.com/esutils/download/esutils-2.0.3.tgz",
-      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4027,8 +3761,7 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "http://r.npm.sankuai.com/execa/download/execa-5.1.1.tgz",
-      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4051,8 +3784,7 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "resolved": "http://r.npm.sankuai.com/exit/download/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -4060,8 +3792,7 @@
     },
     "node_modules/expect": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/expect/download/expect-29.7.0.tgz",
-      "integrity": "sha1-V4h0WQ3LMhRRQITAgRXYruYeEbw=",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4077,22 +3808,19 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "http://r.npm.sankuai.com/fast-deep-equal/download/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
-      "resolved": "http://r.npm.sankuai.com/fast-diff/download/fast-diff-1.3.0.tgz",
-      "integrity": "sha1-7OQH+lUKZNY4U2zXJ+EpxhYW4PA=",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "http://r.npm.sankuai.com/fast-glob/download/fast-glob-3.3.3.tgz",
-      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4108,8 +3836,7 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "http://r.npm.sankuai.com/glob-parent/download/glob-parent-5.1.2.tgz",
-      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4121,22 +3848,19 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "http://r.npm.sankuai.com/fast-json-stable-stringify/download/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://r.npm.sankuai.com/fast-levenshtein/download/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "http://r.npm.sankuai.com/fastq/download/fastq-1.20.1.tgz",
-      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4145,8 +3869,7 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "resolved": "http://r.npm.sankuai.com/fb-watchman/download/fb-watchman-2.0.2.tgz",
-      "integrity": "sha1-6VJO5rXHfp5QAa8PhfOtu4YjJVw=",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4155,8 +3878,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "http://r.npm.sankuai.com/file-entry-cache/download/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4168,8 +3890,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "http://r.npm.sankuai.com/fill-range/download/fill-range-7.1.1.tgz",
-      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4181,8 +3902,7 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "http://r.npm.sankuai.com/find-up/download/find-up-5.0.0.tgz",
-      "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4198,8 +3918,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",
-      "resolved": "http://r.npm.sankuai.com/flat-cache/download/flat-cache-3.2.0.tgz",
-      "integrity": "sha1-LAwtUEDJmxYydxqdEFclwBFTY+4=",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4213,22 +3932,19 @@
     },
     "node_modules/flatted": {
       "version": "3.4.2",
-      "resolved": "http://r.npm.sankuai.com/flatted/download/flatted-3.4.2.tgz",
-      "integrity": "sha1-9cI8EH8PN96NvfJPE3IrO5jVJyY=",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://r.npm.sankuai.com/fs.realpath/download/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "http://r.npm.sankuai.com/fsevents/download/fsevents-2.3.3.tgz",
-      "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4242,8 +3958,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "http://r.npm.sankuai.com/function-bind/download/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4252,8 +3967,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "http://r.npm.sankuai.com/gensync/download/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4262,8 +3976,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "http://r.npm.sankuai.com/get-caller-file/download/get-caller-file-2.0.5.tgz",
-      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4272,8 +3985,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "resolved": "http://r.npm.sankuai.com/get-package-type/download/get-package-type-0.1.0.tgz",
-      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4282,8 +3994,7 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "http://r.npm.sankuai.com/get-stream/download/get-stream-6.0.1.tgz",
-      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4295,8 +4006,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "http://r.npm.sankuai.com/glob/download/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
@@ -4317,8 +4027,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "http://r.npm.sankuai.com/glob-parent/download/glob-parent-6.0.2.tgz",
-      "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4330,8 +4039,7 @@
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "http://r.npm.sankuai.com/brace-expansion/download/brace-expansion-1.1.14.tgz",
-      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4341,8 +4049,7 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "http://r.npm.sankuai.com/minimatch/download/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4354,8 +4061,7 @@
     },
     "node_modules/globals": {
       "version": "13.24.0",
-      "resolved": "http://r.npm.sankuai.com/globals/download/globals-13.24.0.tgz",
-      "integrity": "sha1-hDKhnXjODB6DOUnDats0VAC7EXE=",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4370,8 +4076,7 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
-      "resolved": "http://r.npm.sankuai.com/globby/download/globby-11.1.0.tgz",
-      "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4391,22 +4096,19 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "http://r.npm.sankuai.com/graceful-fs/download/graceful-fs-4.2.11.tgz",
-      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "resolved": "http://r.npm.sankuai.com/graphemer/download/graphemer-1.4.0.tgz",
-      "integrity": "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY=",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
-      "resolved": "http://r.npm.sankuai.com/handlebars/download/handlebars-4.7.9.tgz",
-      "integrity": "sha1-bxOQgqtY3E5aDlHv59ta6JDVag8=",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4427,8 +4129,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/has-flag/download/has-flag-4.0.0.tgz",
-      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4437,8 +4138,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.3",
-      "resolved": "http://r.npm.sankuai.com/hasown/download/hasown-2.0.3.tgz",
-      "integrity": "sha1-XlwrFbYDcKTHkww4Pft2vxe8QDw=",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4450,25 +4150,63 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "resolved": "http://r.npm.sankuai.com/html-escaper/download/html-escaper-2.0.2.tgz",
-      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "http://r.npm.sankuai.com/human-signals/download/human-signals-2.1.0.tgz",
-      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
       }
     },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.2.tgz",
+      "integrity": "sha512-6b7r75uIJDWCcCflmbof+sJ94k9UQO4X0YR62oUfqGI/GjCLVzlCwu8TFdRZIqVLzWbzNcmkmhfqKEr4TLz4HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "http://r.npm.sankuai.com/ignore/download/ignore-5.3.2.tgz",
-      "integrity": "sha1-PNQOcp82Q/2HywTlC/DrcivFlvU=",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4477,8 +4215,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "http://r.npm.sankuai.com/import-fresh/download/import-fresh-3.3.1.tgz",
-      "integrity": "sha1-nOy1ZQPAraHydB271lRuSxO1fM8=",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4494,8 +4231,7 @@
     },
     "node_modules/import-local": {
       "version": "3.2.0",
-      "resolved": "http://r.npm.sankuai.com/import-local/download/import-local-3.2.0.tgz",
-      "integrity": "sha1-w9XHRXmMAqb4uJdyarpRABhu4mA=",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4514,8 +4250,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://r.npm.sankuai.com/imurmurhash/download/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4524,8 +4259,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "http://r.npm.sankuai.com/inflight/download/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "license": "ISC",
@@ -4536,22 +4270,19 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "http://r.npm.sankuai.com/inherits/download/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "http://r.npm.sankuai.com/is-arrayish/download/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "http://r.npm.sankuai.com/is-core-module/download/is-core-module-2.16.1.tgz",
-      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4566,8 +4297,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "http://r.npm.sankuai.com/is-extglob/download/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4576,8 +4306,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "http://r.npm.sankuai.com/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4586,8 +4315,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "http://r.npm.sankuai.com/is-generator-fn/download/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg=",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4596,8 +4324,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "http://r.npm.sankuai.com/is-glob/download/is-glob-4.0.3.tgz",
-      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4609,8 +4336,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "http://r.npm.sankuai.com/is-number/download/is-number-7.0.0.tgz",
-      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4619,8 +4345,7 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "resolved": "http://r.npm.sankuai.com/is-path-inside/download/is-path-inside-3.0.3.tgz",
-      "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4629,8 +4354,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "http://r.npm.sankuai.com/is-stream/download/is-stream-2.0.1.tgz",
-      "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4642,15 +4366,13 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "http://r.npm.sankuai.com/isexe/download/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "resolved": "http://r.npm.sankuai.com/istanbul-lib-coverage/download/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha1-LRZsSwZE1Do58Ev2wu3R5YXzF1Y=",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4659,8 +4381,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "resolved": "http://r.npm.sankuai.com/istanbul-lib-instrument/download/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha1-+hVAHfbBWHS8shBfdzMl14xmZ2U=",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4676,8 +4397,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "resolved": "http://r.npm.sankuai.com/istanbul-lib-report/download/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha1-kIMFusmlvRdaxqdEier9D8JEWn0=",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4691,8 +4411,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "resolved": "http://r.npm.sankuai.com/istanbul-lib-source-maps/download/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha1-iV86cJ/PujTG3lpCk5Ai8+Q1hVE=",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4706,8 +4425,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
-      "resolved": "http://r.npm.sankuai.com/istanbul-reports/download/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha1-y0U1FitXhKpiPO4hpyUs8sgHrJM=",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4720,8 +4438,7 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest/download/jest-29.7.0.tgz",
-      "integrity": "sha1-mUZ2/CQXfwiPHF43N/VpcgT/JhM=",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4747,8 +4464,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-changed-files/download/jest-changed-files-29.7.0.tgz",
-      "integrity": "sha1-HAbQfnfHjhWF0CBCTe3BDW4XrDo=",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4762,8 +4478,7 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-circus/download/jest-circus-29.7.0.tgz",
-      "integrity": "sha1-toF6RfzINdixbVli0MAmRz7jZoo=",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4794,8 +4509,7 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-cli/download/jest-cli-29.7.0.tgz",
-      "integrity": "sha1-VZLJQHmODK5nfuwWkmTy2DmjeZU=",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4828,8 +4542,7 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-config/download/jest-config-29.7.0.tgz",
-      "integrity": "sha1-vL2ogG28wBseMWpGu3QIWoSwJF8=",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4874,8 +4587,7 @@
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-diff/download/jest-diff-29.7.0.tgz",
-      "integrity": "sha1-AXk0pm67fs9vIF6EaZvhCv1wRYo=",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4890,8 +4602,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-docblock/download/jest-docblock-29.7.0.tgz",
-      "integrity": "sha1-j922rcPNyVXJPiqH9hz9NQ1dEZo=",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4903,8 +4614,7 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-each/download/jest-each-29.7.0.tgz",
-      "integrity": "sha1-FiqbPyMovdmRvqq/+7dHReVld9E=",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4920,8 +4630,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-environment-node/download/jest-environment-node-29.7.0.tgz",
-      "integrity": "sha1-C5PhEd2o7BILyDAObR+5V24WQ3Y=",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4938,8 +4647,7 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/jest-get-type/download/jest-get-type-29.6.3.tgz",
-      "integrity": "sha1-NvSZ/c6hl8EEWhJzGcBIFyOQj9E=",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4948,8 +4656,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-haste-map/download/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha1-PCOWUkSC9aBQY3bmyFjDu8wXsQQ=",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4974,8 +4681,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-leak-detector/download/jest-leak-detector-29.7.0.tgz",
-      "integrity": "sha1-W37A2t/f7Ayjg9yaoBbTa16kxyg=",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4988,8 +4694,7 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-matcher-utils/download/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha1-ro/sef8kn9WSzoDj7kdOg6bETxI=",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5004,8 +4709,7 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-message-util/download/jest-message-util-29.7.0.tgz",
-      "integrity": "sha1-i8OS4gTpXf51ZKu+cqQE4o5R9/M=",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5025,8 +4729,7 @@
     },
     "node_modules/jest-mock": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-mock/download/jest-mock-29.7.0.tgz",
-      "integrity": "sha1-ToNs9g6Zxvz6vp+Z0Bfz/dUKY0c=",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5040,8 +4743,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "resolved": "http://r.npm.sankuai.com/jest-pnp-resolver/download/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha1-kwsVRhZNStWTfVVA5xHU041MrS4=",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5058,8 +4760,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
-      "resolved": "http://r.npm.sankuai.com/jest-regex-util/download/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha1-SlVtnHdq9o4cX0gZT00DJ9JOilI=",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5068,8 +4769,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-resolve/download/jest-resolve-29.7.0.tgz",
-      "integrity": "sha1-ZNaomS3Sb2NasMAeXu9Dmca8vDA=",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5089,8 +4789,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-resolve-dependencies/download/jest-resolve-dependencies-29.7.0.tgz",
-      "integrity": "sha1-GwTywJXzf8d2/0CAPckpIbHohCg=",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5103,8 +4802,7 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-runner/download/jest-runner-29.7.0.tgz",
-      "integrity": "sha1-gJrwctQIpT3P0uhJpMl20xMvcY4=",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5136,8 +4834,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-runtime/download/jest-runtime-29.7.0.tgz",
-      "integrity": "sha1-7+yzFBz303Z6OgzI98mZBYfT2Bc=",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5170,8 +4867,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-snapshot/download/jest-snapshot-29.7.0.tgz",
-      "integrity": "sha1-wsV0w/UYZdobsykDZ3imm/iKa+U=",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5202,8 +4898,7 @@
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-util/download/jest-util-29.7.0.tgz",
-      "integrity": "sha1-I8K2K/sivoK0TemAVYAv83EPwLw=",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5220,8 +4915,7 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-validate/download/jest-validate-29.7.0.tgz",
-      "integrity": "sha1-e/cFURxk2lkdRrFfzkFADVIUfZw=",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5238,8 +4932,7 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "http://r.npm.sankuai.com/camelcase/download/camelcase-6.3.0.tgz",
-      "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5251,8 +4944,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-watcher/download/jest-watcher-29.7.0.tgz",
-      "integrity": "sha1-eBDTDWGcOmIJMiPOa7NZyhsoovI=",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5271,8 +4963,7 @@
     },
     "node_modules/jest-worker": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/jest-worker/download/jest-worker-29.7.0.tgz",
-      "integrity": "sha1-rK0HOsu663JivVOJ4bz0PhAFjUo=",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5287,8 +4978,7 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "http://r.npm.sankuai.com/supports-color/download/supports-color-8.1.1.tgz",
-      "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5303,14 +4993,12 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/js-tokens/download/js-tokens-4.0.0.tgz",
-      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "http://r.npm.sankuai.com/js-yaml/download/js-yaml-4.1.1.tgz",
-      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5322,8 +5010,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "http://r.npm.sankuai.com/jsesc/download/jsesc-3.1.0.tgz",
-      "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5335,36 +5022,31 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "http://r.npm.sankuai.com/json-buffer/download/json-buffer-3.0.1.tgz",
-      "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "http://r.npm.sankuai.com/json-parse-even-better-errors/download/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://r.npm.sankuai.com/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "http://r.npm.sankuai.com/json-stable-stringify-without-jsonify/download/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json2mq": {
       "version": "0.2.0",
-      "resolved": "http://r.npm.sankuai.com/json2mq/download/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "license": "MIT",
       "dependencies": {
         "string-convert": "^0.2.0"
@@ -5372,8 +5054,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "http://r.npm.sankuai.com/json5/download/json5-2.2.3.tgz",
-      "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5385,8 +5066,7 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "http://r.npm.sankuai.com/keyv/download/keyv-4.5.4.tgz",
-      "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5395,8 +5075,7 @@
     },
     "node_modules/kleur": {
       "version": "3.0.3",
-      "resolved": "http://r.npm.sankuai.com/kleur/download/kleur-3.0.3.tgz",
-      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4=",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5413,8 +5092,7 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "resolved": "http://r.npm.sankuai.com/leven/download/leven-3.1.0.tgz",
-      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5423,8 +5101,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "http://r.npm.sankuai.com/levn/download/levn-0.4.1.tgz",
-      "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5437,15 +5114,13 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "http://r.npm.sankuai.com/lines-and-columns/download/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "http://r.npm.sankuai.com/locate-path/download/locate-path-6.0.0.tgz",
-      "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5460,28 +5135,24 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "resolved": "http://r.npm.sankuai.com/lodash/download/lodash-4.18.1.tgz",
-      "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "http://r.npm.sankuai.com/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "http://r.npm.sankuai.com/lodash.merge/download/lodash.merge-4.6.2.tgz",
-      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "http://r.npm.sankuai.com/loose-envify/download/loose-envify-1.4.0.tgz",
-      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5492,8 +5163,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "http://r.npm.sankuai.com/lru-cache/download/lru-cache-5.1.1.tgz",
-      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5502,8 +5172,7 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/make-dir/download/make-dir-4.0.0.tgz",
-      "integrity": "sha1-w8IwencSd82WODBfkVwprnQbYU4=",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5518,15 +5187,13 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "http://r.npm.sankuai.com/make-error/download/make-error-1.3.6.tgz",
-      "integrity": "sha1-LrLjfqm2fEiR9oShOUeZr0hM96I=",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "resolved": "http://r.npm.sankuai.com/makeerror/download/makeerror-1.0.12.tgz",
-      "integrity": "sha1-Pl3SB5qC6BLpg8xmEMSiyw6qgBo=",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5535,15 +5202,13 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "http://r.npm.sankuai.com/merge-stream/download/merge-stream-2.0.0.tgz",
-      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "http://r.npm.sankuai.com/merge2/download/merge2-1.4.1.tgz",
-      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5552,8 +5217,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "http://r.npm.sankuai.com/micromatch/download/micromatch-4.0.8.tgz",
-      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5566,8 +5230,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "http://r.npm.sankuai.com/mimic-fn/download/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5576,8 +5239,7 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.3",
-      "resolved": "http://r.npm.sankuai.com/minimatch/download/minimatch-9.0.3.tgz",
-      "integrity": "sha1-puAMPeRMOlQr+q5wq/wiQgptqCU=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5592,8 +5254,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "http://r.npm.sankuai.com/minimist/download/minimist-1.2.8.tgz",
-      "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5602,15 +5263,13 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "http://r.npm.sankuai.com/ms/download/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "http://r.npm.sankuai.com/nanoid/download/nanoid-3.3.11.tgz",
-      "integrity": "sha1-T08RLO++MDIC8hmYOBKJNiZtGFs=",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "dev": true,
       "funding": [
         {
@@ -5628,43 +5287,37 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "http://r.npm.sankuai.com/natural-compare/download/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
-      "resolved": "http://r.npm.sankuai.com/natural-compare-lite/download/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "resolved": "http://r.npm.sankuai.com/neo-async/download/neo-async-2.6.2.tgz",
-      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "http://r.npm.sankuai.com/node-int64/download/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.38",
-      "resolved": "http://r.npm.sankuai.com/node-releases/download/node-releases-2.0.38.tgz",
-      "integrity": "sha1-eRVpueRCSgROEsOr+tQY7YPOmUc=",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "http://r.npm.sankuai.com/normalize-path/download/normalize-path-3.0.0.tgz",
-      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5673,8 +5326,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "http://r.npm.sankuai.com/npm-run-path/download/npm-run-path-4.0.1.tgz",
-      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5686,8 +5338,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "http://r.npm.sankuai.com/object-assign/download/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5695,8 +5346,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "http://r.npm.sankuai.com/once/download/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5705,8 +5355,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "http://r.npm.sankuai.com/onetime/download/onetime-5.1.2.tgz",
-      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5721,8 +5370,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "http://r.npm.sankuai.com/optionator/download/optionator-0.9.4.tgz",
-      "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5739,8 +5387,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "http://r.npm.sankuai.com/p-limit/download/p-limit-3.1.0.tgz",
-      "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5755,8 +5402,7 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "http://r.npm.sankuai.com/p-locate/download/p-locate-5.0.0.tgz",
-      "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5771,8 +5417,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "http://r.npm.sankuai.com/p-try/download/p-try-2.2.0.tgz",
-      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5781,8 +5426,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "http://r.npm.sankuai.com/parent-module/download/parent-module-1.0.1.tgz",
-      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5794,8 +5438,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "http://r.npm.sankuai.com/parse-json/download/parse-json-5.2.0.tgz",
-      "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5813,8 +5456,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/path-exists/download/path-exists-4.0.0.tgz",
-      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5823,8 +5465,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://r.npm.sankuai.com/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5833,8 +5474,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "http://r.npm.sankuai.com/path-key/download/path-key-3.1.1.tgz",
-      "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5843,15 +5483,13 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "http://r.npm.sankuai.com/path-parse/download/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/path-type/download/path-type-4.0.0.tgz",
-      "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5860,15 +5498,13 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "http://r.npm.sankuai.com/picocolors/download/picocolors-1.1.1.tgz",
-      "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "http://r.npm.sankuai.com/picomatch/download/picomatch-2.3.2.tgz",
-      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5880,8 +5516,7 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "resolved": "http://r.npm.sankuai.com/pirates/download/pirates-4.0.7.tgz",
-      "integrity": "sha1-ZDtKGMQlfIplEEtz8wSc6aChXiI=",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5890,8 +5525,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "http://r.npm.sankuai.com/pkg-dir/download/pkg-dir-4.2.0.tgz",
-      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5903,8 +5537,7 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "http://r.npm.sankuai.com/find-up/download/find-up-4.1.0.tgz",
-      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5917,8 +5550,7 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "http://r.npm.sankuai.com/locate-path/download/locate-path-5.0.0.tgz",
-      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5930,8 +5562,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "http://r.npm.sankuai.com/p-limit/download/p-limit-2.3.0.tgz",
-      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5946,8 +5577,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "http://r.npm.sankuai.com/p-locate/download/p-locate-4.1.0.tgz",
-      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5959,8 +5589,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.10",
-      "resolved": "http://r.npm.sankuai.com/postcss/download/postcss-8.5.10.tgz",
-      "integrity": "sha1-iZLYwwrPPxIWnnwJUUoS/tfkg1Y=",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "dev": true,
       "funding": [
         {
@@ -5988,8 +5617,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "http://r.npm.sankuai.com/prelude-ls/download/prelude-ls-1.2.1.tgz",
-      "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5998,8 +5626,7 @@
     },
     "node_modules/prettier": {
       "version": "2.8.8",
-      "resolved": "http://r.npm.sankuai.com/prettier/download/prettier-2.8.8.tgz",
-      "integrity": "sha1-6MXX6YpDBf/j3i4fxKyhpxwosdo=",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6014,8 +5641,7 @@
     },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.1",
-      "resolved": "http://r.npm.sankuai.com/prettier-linter-helpers/download/prettier-linter-helpers-1.0.1.tgz",
-      "integrity": "sha1-ajH4ikutbHrdolPeErpO2uqA680=",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6027,8 +5653,7 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
-      "resolved": "http://r.npm.sankuai.com/pretty-format/download/pretty-format-29.7.0.tgz",
-      "integrity": "sha1-ykLHWDEPNlv6caC9oKgHFgt3aBI=",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6042,8 +5667,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "http://r.npm.sankuai.com/ansi-styles/download/ansi-styles-5.2.0.tgz",
-      "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6055,8 +5679,7 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "resolved": "http://r.npm.sankuai.com/prompts/download/prompts-2.4.2.tgz",
-      "integrity": "sha1-e1fnOzpIAprRDr1E90sBcipMsGk=",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6069,8 +5692,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "http://r.npm.sankuai.com/prop-types/download/prop-types-15.8.1.tgz",
-      "integrity": "sha1-Z9h78aaU9IQ1zzMsJK8QIUoxQLU=",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6080,14 +5702,12 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "http://r.npm.sankuai.com/react-is/download/react-is-16.13.1.tgz",
-      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "http://r.npm.sankuai.com/punycode/download/punycode-2.3.1.tgz",
-      "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6096,8 +5716,7 @@
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
-      "resolved": "http://r.npm.sankuai.com/pure-rand/download/pure-rand-6.1.0.tgz",
-      "integrity": "sha1-0XPPIyWCMZdsy9sFJHyXh5V2BPI=",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "dev": true,
       "funding": [
         {
@@ -6113,8 +5732,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "http://r.npm.sankuai.com/queue-microtask/download/queue-microtask-1.2.3.tgz",
-      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "dev": true,
       "funding": [
         {
@@ -6134,8 +5752,7 @@
     },
     "node_modules/rc-cascader": {
       "version": "3.34.0",
-      "resolved": "http://r.npm.sankuai.com/rc-cascader/download/rc-cascader-3.34.0.tgz",
-      "integrity": "sha1-Vvk2q2sSKbq31VhwHOm56WU2WCw=",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.34.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",
@@ -6151,8 +5768,7 @@
     },
     "node_modules/rc-checkbox": {
       "version": "3.5.0",
-      "resolved": "http://r.npm.sankuai.com/rc-checkbox/download/rc-checkbox-3.5.0.tgz",
-      "integrity": "sha1-OuJEHjoyF3TTkPdlOecGhk/PX/A=",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6166,8 +5782,7 @@
     },
     "node_modules/rc-collapse": {
       "version": "3.9.0",
-      "resolved": "http://r.npm.sankuai.com/rc-collapse/download/rc-collapse-3.9.0.tgz",
-      "integrity": "sha1-lyQEznck4cnR0kdlQ+EXVASjaAY=",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6182,8 +5797,7 @@
     },
     "node_modules/rc-dialog": {
       "version": "9.6.0",
-      "resolved": "http://r.npm.sankuai.com/rc-dialog/download/rc-dialog-9.6.0.tgz",
-      "integrity": "sha1-3HolXGrRy1YCHDphx96G7ojHw3E=",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6199,8 +5813,7 @@
     },
     "node_modules/rc-drawer": {
       "version": "7.3.0",
-      "resolved": "http://r.npm.sankuai.com/rc-drawer/download/rc-drawer-7.3.0.tgz",
-      "integrity": "sha1-G7X+X52ji2orKn3/yfy2RyUqMo8=",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.3.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
@@ -6216,8 +5829,7 @@
     },
     "node_modules/rc-dropdown": {
       "version": "4.2.1",
-      "resolved": "http://r.npm.sankuai.com/rc-dropdown/download/rc-dropdown-4.2.1.tgz",
-      "integrity": "sha1-RHKesqQnLgNT0xrAYNoh5gasyxw=",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -6232,8 +5844,7 @@
     },
     "node_modules/rc-field-form": {
       "version": "2.7.1",
-      "resolved": "http://r.npm.sankuai.com/rc-field-form/download/rc-field-form-2.7.1.tgz",
-      "integrity": "sha1-i7HXxr9A4rmbSUgWlyJSwyfZtaA=",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
@@ -6250,8 +5861,7 @@
     },
     "node_modules/rc-image": {
       "version": "7.12.0",
-      "resolved": "http://r.npm.sankuai.com/rc-image/download/rc-image-7.12.0.tgz",
-      "integrity": "sha1-lekxRwHmaCF9ETwfKbTwGsAlyv4=",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -6268,8 +5878,7 @@
     },
     "node_modules/rc-input": {
       "version": "1.8.0",
-      "resolved": "http://r.npm.sankuai.com/rc-input/download/rc-input-1.8.0.tgz",
-      "integrity": "sha1-0vRAS+/r8vvcKDkNVJTDAvdK6XQ=",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -6283,8 +5892,7 @@
     },
     "node_modules/rc-input-number": {
       "version": "9.5.0",
-      "resolved": "http://r.npm.sankuai.com/rc-input-number/download/rc-input-number-9.5.0.tgz",
-      "integrity": "sha1-tHlj0PLL2Fqy8brf3AiakEwHPzg=",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6300,8 +5908,7 @@
     },
     "node_modules/rc-mentions": {
       "version": "2.20.0",
-      "resolved": "http://r.npm.sankuai.com/rc-mentions/download/rc-mentions-2.20.0.tgz",
-      "integrity": "sha1-O76sA1KwLgzj4SRK20hwG7aQO/c=",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.20.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
@@ -6319,8 +5926,7 @@
     },
     "node_modules/rc-menu": {
       "version": "9.16.1",
-      "resolved": "http://r.npm.sankuai.com/rc-menu/download/rc-menu-9.16.1.tgz",
-      "integrity": "sha1-nfEWjkHYfccWTFghc+Gh0yARiZ8=",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6337,8 +5943,7 @@
     },
     "node_modules/rc-motion": {
       "version": "2.9.5",
-      "resolved": "http://r.npm.sankuai.com/rc-motion/download/rc-motion-2.9.5.tgz",
-      "integrity": "sha1-Esbq1P01X5TwDem7TxXfV21nfgw=",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -6352,8 +5957,7 @@
     },
     "node_modules/rc-notification": {
       "version": "5.6.4",
-      "resolved": "http://r.npm.sankuai.com/rc-notification/download/rc-notification-5.6.4.tgz",
-      "integrity": "sha1-6onDnBPNUX/f2X/mPwM3b6u3hUQ=",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.4.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6371,8 +5975,7 @@
     },
     "node_modules/rc-overflow": {
       "version": "1.5.0",
-      "resolved": "http://r.npm.sankuai.com/rc-overflow/download/rc-overflow-1.5.0.tgz",
-      "integrity": "sha1-AuWKFRmeOSrfzIfg1unnyOV/J3E=",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -6387,8 +5990,7 @@
     },
     "node_modules/rc-pagination": {
       "version": "5.1.0",
-      "resolved": "http://r.npm.sankuai.com/rc-pagination/download/rc-pagination-5.1.0.tgz",
-      "integrity": "sha1-puY6LF2ynmL5kSgusYotPucluos=",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.1.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6402,8 +6004,7 @@
     },
     "node_modules/rc-picker": {
       "version": "4.11.3",
-      "resolved": "http://r.npm.sankuai.com/rc-picker/download/rc-picker-4.11.3.tgz",
-      "integrity": "sha1-fn462DqkYcKEuDkcaXSS0cNNLLg=",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -6441,8 +6042,7 @@
     },
     "node_modules/rc-progress": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/rc-progress/download/rc-progress-4.0.0.tgz",
-      "integrity": "sha1-U4IUfZrdM9Ol+9JkABNz32RA4SY=",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-4.0.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6456,8 +6056,7 @@
     },
     "node_modules/rc-rate": {
       "version": "2.13.1",
-      "resolved": "http://r.npm.sankuai.com/rc-rate/download/rc-rate-2.13.1.tgz",
-      "integrity": "sha1-Ka96PUdoNi6dQ4j5Vai2OJUmt/0=",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6474,8 +6073,7 @@
     },
     "node_modules/rc-resize-observer": {
       "version": "1.4.3",
-      "resolved": "http://r.npm.sankuai.com/rc-resize-observer/download/rc-resize-observer-1.4.3.tgz",
-      "integrity": "sha1-T9QfpWG6UTYrUVWgfDXXyJoepWk=",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
@@ -6490,8 +6088,7 @@
     },
     "node_modules/rc-segmented": {
       "version": "2.7.1",
-      "resolved": "http://r.npm.sankuai.com/rc-segmented/download/rc-segmented-2.7.1.tgz",
-      "integrity": "sha1-CKWYsU51URfFs30jiVXC1Q6qXTM=",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -6506,8 +6103,7 @@
     },
     "node_modules/rc-select": {
       "version": "14.16.8",
-      "resolved": "http://r.npm.sankuai.com/rc-select/download/rc-select-14.16.8.tgz",
-      "integrity": "sha1-eOZ4LxzMHwPZADvD7/pO1gnSmpc=",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.8.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6528,8 +6124,7 @@
     },
     "node_modules/rc-slider": {
       "version": "11.1.9",
-      "resolved": "http://r.npm.sankuai.com/rc-slider/download/rc-slider-11.1.9.tgz",
-      "integrity": "sha1-2HITD79OxR8oVD1i6QRRCR1vUgg=",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.9.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6546,8 +6141,7 @@
     },
     "node_modules/rc-steps": {
       "version": "6.0.1",
-      "resolved": "http://r.npm.sankuai.com/rc-steps/download/rc-steps-6.0.1.tgz",
-      "integrity": "sha1-whNs0Ah3M/bVCSCahKXIDcKaJ00=",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.16.7",
@@ -6564,8 +6158,7 @@
     },
     "node_modules/rc-switch": {
       "version": "4.1.0",
-      "resolved": "http://r.npm.sankuai.com/rc-switch/download/rc-switch-4.1.0.tgz",
-      "integrity": "sha1-832BtODFr9EnT9hTZ7FzBr8l59c=",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.1.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -6579,8 +6172,7 @@
     },
     "node_modules/rc-table": {
       "version": "7.54.0",
-      "resolved": "http://r.npm.sankuai.com/rc-table/download/rc-table-7.54.0.tgz",
-      "integrity": "sha1-3t1OoY0RifKs35CoDwTYygER4Wo=",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.54.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6600,8 +6192,7 @@
     },
     "node_modules/rc-tabs": {
       "version": "15.7.0",
-      "resolved": "http://r.npm.sankuai.com/rc-tabs/download/rc-tabs-15.7.0.tgz",
-      "integrity": "sha1-FMou5iE9AEkai2euJuLTXCVr8Zo=",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.7.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -6622,8 +6213,7 @@
     },
     "node_modules/rc-textarea": {
       "version": "1.10.2",
-      "resolved": "http://r.npm.sankuai.com/rc-textarea/download/rc-textarea-1.10.2.tgz",
-      "integrity": "sha1-RZ41dKlcMpOcZ5MEWh5NsEy1FMw=",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.10.2.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6639,8 +6229,7 @@
     },
     "node_modules/rc-tooltip": {
       "version": "6.4.0",
-      "resolved": "http://r.npm.sankuai.com/rc-tooltip/download/rc-tooltip-6.4.0.tgz",
-      "integrity": "sha1-6DLtA5KHICXlmSjPwa2QRWVkZ/0=",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
@@ -6655,8 +6244,7 @@
     },
     "node_modules/rc-tree": {
       "version": "5.13.1",
-      "resolved": "http://r.npm.sankuai.com/rc-tree/download/rc-tree-5.13.1.tgz",
-      "integrity": "sha1-82ozqUoSgvSwloUhbAFIcIl0iRA=",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -6675,8 +6263,7 @@
     },
     "node_modules/rc-tree-select": {
       "version": "5.27.0",
-      "resolved": "http://r.npm.sankuai.com/rc-tree-select/download/rc-tree-select-5.27.0.tgz",
-      "integrity": "sha1-PapilyroCEbayWv0d20ancnHxMY=",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",
@@ -6692,8 +6279,7 @@
     },
     "node_modules/rc-upload": {
       "version": "4.11.0",
-      "resolved": "http://r.npm.sankuai.com/rc-upload/download/rc-upload-4.11.0.tgz",
-      "integrity": "sha1-ws7ZBaiziz5cSEk9OIyg6Dc94Ys=",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.11.0.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -6707,8 +6293,7 @@
     },
     "node_modules/rc-util": {
       "version": "5.44.4",
-      "resolved": "http://r.npm.sankuai.com/rc-util/download/rc-util-5.44.4.tgz",
-      "integrity": "sha1-ie6QN2g8ygHNYPGmu9p2FFfda6U=",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -6721,8 +6306,7 @@
     },
     "node_modules/rc-virtual-list": {
       "version": "3.19.2",
-      "resolved": "http://r.npm.sankuai.com/rc-virtual-list/download/rc-virtual-list-3.19.2.tgz",
-      "integrity": "sha1-HdLXgsmjzL5Te7hzRH1z+Dr43g8=",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.19.2.tgz",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
@@ -6740,8 +6324,7 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "http://r.npm.sankuai.com/react/download/react-18.3.1.tgz",
-      "integrity": "sha1-SauJIAnFOTNiW9FrJTP8dUyrKJE=",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -6752,8 +6335,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "http://r.npm.sankuai.com/react-dom/download/react-dom-18.3.1.tgz",
-      "integrity": "sha1-wiZdeVEbV9R5s90/36UVNklMXLQ=",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -6765,8 +6347,7 @@
     },
     "node_modules/react-draggable": {
       "version": "4.5.0",
-      "resolved": "http://r.npm.sankuai.com/react-draggable/download/react-draggable-4.5.0.tgz",
-      "integrity": "sha1-CydMy2ll/Pl+04/PfjzCI7xIzfU=",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1",
@@ -6777,16 +6358,36 @@
         "react-dom": ">= 16.3.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.3.tgz",
+      "integrity": "sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "http://r.npm.sankuai.com/react-is/download/react-is-18.3.1.tgz",
-      "integrity": "sha1-6DVX3BLq5jqZ4AOkY4ix3LtE234=",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "license": "MIT"
     },
     "node_modules/react-resizable": {
       "version": "3.1.3",
-      "resolved": "http://r.npm.sankuai.com/react-resizable/download/react-resizable-3.1.3.tgz",
-      "integrity": "sha1-uMP4rv+3sLLCMGv8enQkYuWBJfs=",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.1.3.tgz",
       "license": "MIT",
       "dependencies": {
         "prop-types": "15.x",
@@ -6799,8 +6400,7 @@
     },
     "node_modules/react-router": {
       "version": "6.30.3",
-      "resolved": "http://r.npm.sankuai.com/react-router/download/react-router-6.30.3.tgz",
-      "integrity": "sha1-mUs8zb4Ogf6E1PmYEA9iWE378c8=",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.2"
@@ -6814,8 +6414,7 @@
     },
     "node_modules/react-router-dom": {
       "version": "6.30.3",
-      "resolved": "http://r.npm.sankuai.com/react-router-dom/download/react-router-dom-6.30.3.tgz",
-      "integrity": "sha1-Qq5txMcVi/sLk18WK5Yhsp3d90A=",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.2",
@@ -6831,8 +6430,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "http://r.npm.sankuai.com/require-directory/download/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6841,14 +6439,12 @@
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
-      "resolved": "http://r.npm.sankuai.com/resize-observer-polyfill/download/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha1-DpAg3T0hAkRY1OvSfiPkAmmBBGQ=",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "http://r.npm.sankuai.com/resolve/download/resolve-1.22.12.tgz",
-      "integrity": "sha1-9bKmgIl8acI4oTzRaxVnH4tzVJ8=",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6869,8 +6465,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "http://r.npm.sankuai.com/resolve-cwd/download/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6882,8 +6477,7 @@
     },
     "node_modules/resolve-cwd/node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "http://r.npm.sankuai.com/resolve-from/download/resolve-from-5.0.0.tgz",
-      "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk=",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6892,8 +6486,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/resolve-from/download/resolve-from-4.0.0.tgz",
-      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6902,8 +6495,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
-      "resolved": "http://r.npm.sankuai.com/resolve.exports/download/resolve.exports-2.0.3.tgz",
-      "integrity": "sha1-QZVebxtAE7dYb4c3SaY13qB+vj8=",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6912,8 +6504,7 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "http://r.npm.sankuai.com/reusify/download/reusify-1.1.0.tgz",
-      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6923,8 +6514,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "http://r.npm.sankuai.com/rimraf/download/rimraf-3.0.2.tgz",
-      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
@@ -6940,8 +6530,7 @@
     },
     "node_modules/rollup": {
       "version": "3.30.0",
-      "resolved": "http://r.npm.sankuai.com/rollup/download/rollup-3.30.0.tgz",
-      "integrity": "sha1-P6UG/uLFup1UCjjahwZzds1Vlm0=",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6957,8 +6546,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "http://r.npm.sankuai.com/run-parallel/download/run-parallel-1.2.0.tgz",
-      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "dev": true,
       "funding": [
         {
@@ -6981,8 +6569,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-      "resolved": "http://r.npm.sankuai.com/scheduler/download/scheduler-0.23.2.tgz",
-      "integrity": "sha1-QUumSjsoKJLpRM8hCOzAeNEVzcM=",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -6990,8 +6577,7 @@
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
-      "resolved": "http://r.npm.sankuai.com/scroll-into-view-if-needed/download/scroll-into-view-if-needed-3.1.0.tgz",
-      "integrity": "sha1-+pUkUYx5m0Wi72u/+5K8rQKW0B8=",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "license": "MIT",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
@@ -6999,8 +6585,7 @@
     },
     "node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "http://r.npm.sankuai.com/semver/download/semver-7.7.4.tgz",
-      "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7012,8 +6597,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "http://r.npm.sankuai.com/shebang-command/download/shebang-command-2.0.0.tgz",
-      "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7025,8 +6609,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "http://r.npm.sankuai.com/shebang-regex/download/shebang-regex-3.0.0.tgz",
-      "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7035,22 +6618,19 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "http://r.npm.sankuai.com/signal-exit/download/signal-exit-3.0.7.tgz",
-      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "http://r.npm.sankuai.com/sisteransi/download/sisteransi-1.0.5.tgz",
-      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "http://r.npm.sankuai.com/slash/download/slash-3.0.0.tgz",
-      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7059,8 +6639,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "http://r.npm.sankuai.com/source-map/download/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7069,8 +6648,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "http://r.npm.sankuai.com/source-map-js/download/source-map-js-1.2.1.tgz",
-      "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7079,8 +6657,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "resolved": "http://r.npm.sankuai.com/source-map-support/download/source-map-support-0.5.13.tgz",
-      "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7090,15 +6667,13 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://r.npm.sankuai.com/sprintf-js/download/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "resolved": "http://r.npm.sankuai.com/stack-utils/download/stack-utils-2.0.6.tgz",
-      "integrity": "sha1-qvB0gWnAL8M8gjKrzPkz9Uocw08=",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7110,8 +6685,7 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "resolved": "http://r.npm.sankuai.com/escape-string-regexp/download/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7120,14 +6694,12 @@
     },
     "node_modules/string-convert": {
       "version": "0.2.1",
-      "resolved": "http://r.npm.sankuai.com/string-convert/download/string-convert-0.2.1.tgz",
-      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c=",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
       "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "resolved": "http://r.npm.sankuai.com/string-length/download/string-length-4.0.2.tgz",
-      "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7140,8 +6712,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "http://r.npm.sankuai.com/string-width/download/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7155,8 +6726,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "http://r.npm.sankuai.com/strip-ansi/download/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7168,8 +6738,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "http://r.npm.sankuai.com/strip-bom/download/strip-bom-4.0.0.tgz",
-      "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7178,8 +6747,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "http://r.npm.sankuai.com/strip-final-newline/download/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7188,8 +6756,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "http://r.npm.sankuai.com/strip-json-comments/download/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7201,14 +6768,12 @@
     },
     "node_modules/stylis": {
       "version": "4.3.6",
-      "resolved": "http://r.npm.sankuai.com/stylis/download/stylis-4.3.6.tgz",
-      "integrity": "sha1-fHuXGRy08ZXwPsq31S95Au03gyA=",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "http://r.npm.sankuai.com/supports-color/download/supports-color-7.2.0.tgz",
-      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7220,8 +6785,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "http://r.npm.sankuai.com/supports-preserve-symlinks-flag/download/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7233,8 +6797,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "resolved": "http://r.npm.sankuai.com/test-exclude/download/test-exclude-6.0.0.tgz",
-      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7248,8 +6811,7 @@
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "http://r.npm.sankuai.com/brace-expansion/download/brace-expansion-1.1.14.tgz",
-      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7259,8 +6821,7 @@
     },
     "node_modules/test-exclude/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "http://r.npm.sankuai.com/minimatch/download/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7272,15 +6833,13 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "http://r.npm.sankuai.com/text-table/download/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",
-      "resolved": "http://r.npm.sankuai.com/throttle-debounce/download/throttle-debounce-5.0.2.tgz",
-      "integrity": "sha1-7FVJ2E4FPwQ8n9Dypt2JL/hEVrE=",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=12.22"
@@ -7288,15 +6847,13 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "resolved": "http://r.npm.sankuai.com/tmpl/download/tmpl-1.0.5.tgz",
-      "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w=",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "http://r.npm.sankuai.com/to-regex-range/download/to-regex-range-5.0.1.tgz",
-      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7308,14 +6865,12 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
-      "resolved": "http://r.npm.sankuai.com/toggle-selection/download/toggle-selection-1.0.6.tgz",
-      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
-      "resolved": "http://r.npm.sankuai.com/ts-api-utils/download/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha1-v8IhX+ZSj+yrKw+6VwouikJjsGQ=",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7327,8 +6882,7 @@
     },
     "node_modules/ts-jest": {
       "version": "29.4.9",
-      "resolved": "http://r.npm.sankuai.com/ts-jest/download/ts-jest-29.4.9.tgz",
-      "integrity": "sha1-R9wz0PXDa93O3Rav764oXgsEnS0=",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7380,8 +6934,7 @@
     },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
-      "resolved": "http://r.npm.sankuai.com/type-fest/download/type-fest-4.41.0.tgz",
-      "integrity": "sha1-auHI5XMSc8K/H1itOcuuLJGkbFg=",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -7393,15 +6946,13 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "http://r.npm.sankuai.com/tslib/download/tslib-1.14.1.tgz",
-      "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "resolved": "http://r.npm.sankuai.com/tsutils/download/tsutils-3.21.0.tgz",
-      "integrity": "sha1-tIcX05TOpsHglpg+7Vjp1hcVtiM=",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7416,8 +6967,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "http://r.npm.sankuai.com/type-check/download/type-check-0.4.0.tgz",
-      "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7429,8 +6979,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "resolved": "http://r.npm.sankuai.com/type-detect/download/type-detect-4.0.8.tgz",
-      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7439,8 +6988,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "http://r.npm.sankuai.com/type-fest/download/type-fest-0.20.2.tgz",
-      "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -7452,8 +7000,7 @@
     },
     "node_modules/typescript": {
       "version": "4.9.5",
-      "resolved": "http://r.npm.sankuai.com/typescript/download/typescript-4.9.5.tgz",
-      "integrity": "sha1-CVl5+bzA0J2jJNWNA86Pg3TL5lo=",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7466,8 +7013,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
-      "resolved": "http://r.npm.sankuai.com/uglify-js/download/uglify-js-3.19.3.tgz",
-      "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
@@ -7480,15 +7026,13 @@
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
-      "resolved": "http://r.npm.sankuai.com/undici-types/download/undici-types-7.19.2.tgz",
-      "integrity": "sha1-G2f8JtDxV6DLo6WKW1weIna4uio=",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "http://r.npm.sankuai.com/update-browserslist-db/download/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "dev": true,
       "funding": [
         {
@@ -7518,8 +7062,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "http://r.npm.sankuai.com/uri-js/download/uri-js-4.4.1.tgz",
-      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -7528,8 +7071,7 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
-      "resolved": "http://r.npm.sankuai.com/v8-to-istanbul/download/v8-to-istanbul-9.3.0.tgz",
-      "integrity": "sha1-uVcqv6Yr1VbBbXX968GkEdX/MXU=",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7543,8 +7085,7 @@
     },
     "node_modules/vite": {
       "version": "4.5.14",
-      "resolved": "http://r.npm.sankuai.com/vite/download/vite-4.5.14.tgz",
-      "integrity": "sha1-LmUrwdiYJl2YfWVDzoZuzWX6QIY=",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7597,10 +7138,18 @@
         }
       }
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
-      "resolved": "http://r.npm.sankuai.com/walker/download/walker-1.0.8.tgz",
-      "integrity": "sha1-vUmNtHev5XPcBBhfAR06uKjXZT8=",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7609,8 +7158,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "http://r.npm.sankuai.com/which/download/which-2.0.2.tgz",
-      "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7625,8 +7173,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "http://r.npm.sankuai.com/word-wrap/download/word-wrap-1.2.5.tgz",
-      "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7635,15 +7182,13 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "resolved": "http://r.npm.sankuai.com/wordwrap/download/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "http://r.npm.sankuai.com/wrap-ansi/download/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7660,15 +7205,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "http://r.npm.sankuai.com/wrappy/download/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "resolved": "http://r.npm.sankuai.com/write-file-atomic/download/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha1-qd8Brlt3hYoCf9LoB2juQzVV/P0=",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7681,8 +7224,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "http://r.npm.sankuai.com/y18n/download/y18n-5.0.8.tgz",
-      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -7691,15 +7233,13 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "http://r.npm.sankuai.com/yallist/download/yallist-3.1.1.tgz",
-      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "http://r.npm.sankuai.com/yargs/download/yargs-17.7.2.tgz",
-      "integrity": "sha1-mR3zmspnWhkrgW4eA2P5110qomk=",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7717,8 +7257,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "http://r.npm.sankuai.com/yargs-parser/download/yargs-parser-21.1.1.tgz",
-      "integrity": "sha1-kJa87r+ZDSG7MfqVFuDt4pSnfTU=",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -7727,8 +7266,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "http://r.npm.sankuai.com/yocto-queue/download/yocto-queue-0.1.0.tgz",
-      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## TASK-025: i18n 中英文切换

### 变更内容

- 安装 `i18next`、`react-i18next`、`i18next-browser-languagedetector`
- 新增 `src/i18n.ts`：LanguageDetector 优先读 localStorage（key: `knife4j-lang`），fallback zh-CN
- 新增 `src/locales/zh-CN.ts` 和 `src/locales/en-US.ts`，覆盖约 130 条 UI 文案
- `main.tsx` 引入 `./i18n`，在 RouterProvider 渲染前初始化
- `App.tsx` Header 右上角新增语言切换按钮（中/EN），调用 `i18n.changeLanguage()` 并持久化到 localStorage
- 所有组件（SidebarSearchMenu、SettingsDrawer、Home、Schema、Authorize、GlobalParam、OfficeDoc、ApiDoc、ApiDebug、useCurrentOperation）接入 `useTranslation()` + `t()`
- Ant Design 列定义移入组件函数体，确保语言切换后响应式更新

### 验证

```
cd knife4j-front/knife4j-ui-react && npm ci && npm run build
✓ tsc 通过，无 TypeScript 错误
✓ vite build 通过
```

### 对标

原版 knife4j 的 zh-CN / en-US 切换能力