### PR TITLE
feat(knife4j-core): implement buildSchemaExample & buildSchemaFieldTr…

### DIFF
--- a/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
@@ -1,0 +1,461 @@
+import { buildSchemaExample, buildSchemaFieldTree } from '../../debug/schemaExample';
+import type { SchemaResolveContext, SchemaFieldNode } from '../../debug/types';
+
+// ─── 测试文档 ─────────────────────────────────────────
+
+const doc: Record<string, unknown> = {
+  components: {
+    schemas: {
+      User: {
+        type: 'object',
+        required: ['id', 'name'],
+        properties: {
+          id: { type: 'integer', format: 'int64' },
+          name: { type: 'string' },
+          email: { type: 'string', format: 'email' },
+          role: { type: 'string', enum: ['ADMIN', 'USER'] },
+        },
+      },
+      Pet: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', example: 'Buddy' },
+          tag: { type: 'string' },
+        },
+      },
+      Order: {
+        type: 'object',
+        required: ['id', 'user'],
+        properties: {
+          id: { type: 'integer' },
+          user: { $ref: '#/components/schemas/User' },
+          items: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Pet' },
+          },
+        },
+      },
+      SelfRef: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          parent: { $ref: '#/components/schemas/SelfRef' },
+        },
+      },
+      MutualA: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          b: { $ref: '#/components/schemas/MutualB' },
+        },
+      },
+      MutualB: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          a: { $ref: '#/components/schemas/MutualA' },
+        },
+      },
+      AllOfDemo: {
+        allOf: [
+          { $ref: '#/components/schemas/User' },
+          {
+            type: 'object',
+            properties: {
+              avatar: { type: 'string', format: 'url' },
+            },
+          },
+        ],
+      },
+      OneOfDemo: {
+        oneOf: [
+          { $ref: '#/components/schemas/User' },
+          { $ref: '#/components/schemas/Pet' },
+        ],
+      },
+      AnyOfDemo: {
+        anyOf: [
+          { $ref: '#/components/schemas/Pet' },
+          { type: 'string' },
+        ],
+      },
+      FreeFormMap: {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+      },
+      ArrayOfPrimitives: {
+        type: 'array',
+        items: { type: 'string' },
+      },
+    },
+  },
+  definitions: {
+    LegacyCar: {
+      type: 'object',
+      properties: {
+        brand: { type: 'string' },
+        model: { type: 'string' },
+      },
+    },
+  },
+};
+
+function ctx(overrides?: Partial<SchemaResolveContext>): SchemaResolveContext {
+  return { doc, ...overrides };
+}
+
+// ─── buildSchemaExample 测试 ──────────────────────────
+
+describe('buildSchemaExample', () => {
+  // 1. primitive 类型
+  test('generates example for string type', () => {
+    const result = buildSchemaExample({ type: 'string' }, ctx());
+    expect(result).toBe('string');
+  });
+
+  test('generates example for string format date-time', () => {
+    const result = buildSchemaExample({ type: 'string', format: 'date-time' }, ctx());
+    expect(result).toBe('2024-01-01T00:00:00Z');
+  });
+
+  test('generates example for integer type', () => {
+    const result = buildSchemaExample({ type: 'integer' }, ctx());
+    expect(result).toBe(0);
+  });
+
+  test('generates example for boolean type', () => {
+    const result = buildSchemaExample({ type: 'boolean' }, ctx());
+    expect(result).toBe(true);
+  });
+
+  // 2. enum
+  test('uses first enum value as example', () => {
+    const result = buildSchemaExample({ type: 'string', enum: ['cat', 'dog'] }, ctx());
+    expect(result).toBe('cat');
+  });
+
+  // 3. example/default 优先级
+  test('explicit example takes highest priority', () => {
+    const result = buildSchemaExample(
+      { type: 'string', enum: ['a', 'b'], default: 'default', example: 'explicit' },
+      ctx(),
+    );
+    expect(result).toBe('explicit');
+  });
+
+  test('default takes priority over enum and type inference', () => {
+    const result = buildSchemaExample(
+      { type: 'string', enum: ['a'], default: 'my-default' },
+      ctx(),
+    );
+    expect(result).toBe('my-default');
+  });
+
+  // 4. $ref 解析
+  test('resolves $ref to OAS3 components.schemas', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/User' }, ctx());
+    expect(result).toEqual({
+      id: 0,
+      name: 'string',
+      email: 'user@example.com',
+      role: 'ADMIN',
+    });
+  });
+
+  test('resolves $ref to OAS2 definitions', () => {
+    const result = buildSchemaExample({ $ref: '#/definitions/LegacyCar' }, ctx());
+    expect(result).toEqual({
+      brand: 'string',
+      model: 'string',
+    });
+  });
+
+  // 5. object
+  test('generates example for inline object with properties', () => {
+    const result = buildSchemaExample(
+      {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+      },
+      ctx(),
+    );
+    expect(result).toEqual({ name: 'string', age: 0 });
+  });
+
+  // 6. array
+  test('generates example for array of primitives', () => {
+    const result = buildSchemaExample({ type: 'array', items: { type: 'string' } }, ctx());
+    expect(result).toEqual(['string']);
+  });
+
+  test('generates example for array of $ref items', () => {
+    const result = buildSchemaExample(
+      { type: 'array', items: { $ref: '#/components/schemas/Pet' } },
+      ctx(),
+    );
+    expect(result).toEqual([{ name: 'Buddy', tag: 'string' }]);
+  });
+
+  // 7. 循环引用
+  test('handles self-referencing schema without infinite loop', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/SelfRef' }, ctx());
+    expect(result).toEqual({ id: 0, parent: null });
+  });
+
+  test('handles mutual circular references', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/MutualA' }, ctx());
+    // MutualA.id=0, MutualA.b → MutualB (展开), MutualB.a → MutualA (截断为null)
+    expect(result).toEqual({
+      id: 0,
+      b: { id: 0, a: null },
+    });
+  });
+
+  // 8. allOf
+  test('merges allOf schemas', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/AllOfDemo' }, ctx());
+    expect(result).toEqual({
+      id: 0,
+      name: 'string',
+      email: 'user@example.com',
+      role: 'ADMIN',
+      avatar: 'https://example.com',
+    });
+  });
+
+  // 9. oneOf
+  test('uses first resolvable branch of oneOf', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/OneOfDemo' }, ctx());
+    // First branch is User
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('name');
+  });
+
+  // 10. anyOf
+  test('uses first resolvable branch of anyOf', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/AnyOfDemo' }, ctx());
+    expect(result).toHaveProperty('name');
+    expect(result).toHaveProperty('tag');
+  });
+
+  // 11. additionalProperties (map)
+  test('generates example for additionalProperties map', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/FreeFormMap' }, ctx());
+    expect(result).toEqual({ additionalProp1: 'string' });
+  });
+
+  // 12. maxDepth 保护
+  test('respects maxDepth and returns null beyond it', () => {
+    const result = buildSchemaExample(
+      { $ref: '#/components/schemas/User' },
+      ctx({ maxDepth: 0 }),
+    );
+    expect(result).toBeNull();
+  });
+
+  // 13. 空输入
+  test('returns null for undefined schema', () => {
+    const result = buildSchemaExample(undefined, ctx());
+    expect(result).toBeNull();
+  });
+
+  // 14. 不存在的 $ref
+  test('returns null for non-existent $ref', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/NotExist' }, ctx());
+    expect(result).toBeNull();
+  });
+
+  // 15. object with nested $ref
+  test('generates example for object containing $ref properties', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/Order' }, ctx());
+    expect(result).toEqual({
+      id: 0,
+      user: { id: 0, name: 'string', email: 'user@example.com', role: 'ADMIN' },
+      items: [{ name: 'Buddy', tag: 'string' }],
+    });
+  });
+
+  // 16. array with no items
+  test('returns empty array when items is missing', () => {
+    const result = buildSchemaExample({ type: 'array' }, ctx());
+    expect(result).toEqual([]);
+  });
+
+  // 17. format-specific examples
+  test('generates uuid format example', () => {
+    const result = buildSchemaExample({ type: 'string', format: 'uuid' }, ctx());
+    expect(result).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+  });
+});
+
+// ─── buildSchemaFieldTree 测试 ────────────────────────
+
+describe('buildSchemaFieldTree', () => {
+  // 1. object 展开
+  test('expands object properties into field nodes', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/User' }, ctx());
+    expect(nodes).toHaveLength(4);
+    const idNode = nodes.find((n) => n.name === 'id')!;
+    expect(idNode.type).toBe('integer');
+    expect(idNode.format).toBe('int64');
+    expect(idNode.required).toBe(true);
+    const emailNode = nodes.find((n) => n.name === 'email')!;
+    expect(emailNode.required).toBe(false);
+  });
+
+  // 2. $ref refName
+  test('sets refName for $ref properties', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/Order' }, ctx());
+    const userNode = nodes.find((n) => n.name === 'user')!;
+    expect(userNode.refName).toBe('User');
+    expect(userNode.type).toBe('object');
+    // 应该有 children（User 的字段）
+    expect(userNode.children).toBeDefined();
+    expect(userNode.children!.length).toBeGreaterThan(0);
+  });
+
+  // 3. array items
+  test('represents array as node with items child', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/Order' }, ctx());
+    const itemsNode = nodes.find((n) => n.name === 'items')!;
+    expect(itemsNode.type).toBe('array');
+    expect(itemsNode.children).toBeDefined();
+    expect(itemsNode.children![0].name).toBe('items');
+    expect(itemsNode.children![0].refName).toBe('Pet');
+  });
+
+  // 4. enum
+  test('includes enum values in field node', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/User' }, ctx());
+    const roleNode = nodes.find((n) => n.name === 'role')!;
+    expect(roleNode.enum).toEqual(['ADMIN', 'USER']);
+  });
+
+  // 5. 循环引用截断
+  test('marks circular ref fields as truncated', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/SelfRef' }, ctx());
+    const parentNode = nodes.find((n) => n.name === 'parent')!;
+    expect(parentNode.truncated).toBe(true);
+    expect(parentNode.refName).toBe('SelfRef');
+  });
+
+  // 6. maxDepth
+  test('marks object/array as truncated when hitting maxDepth', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/User' }, ctx({ maxDepth: 1 }));
+    // depth=0: User 本身 → 展开 properties → depth=1 到达 User 的各字段
+    // 但 User 的字段不会再递归了，因为 depth=1 >= maxDepth=1
+    // email 是 string，不截断；其他也是 primitive，不截断
+    // 只有 array / object 子字段会被截断
+    const orderNodes = buildSchemaFieldTree({ $ref: '#/components/schemas/Order' }, ctx({ maxDepth: 1 }));
+    const userNode = orderNodes.find((n) => n.name === 'user')!;
+    expect(userNode.truncated).toBe(true);
+  });
+
+  // 7. allOf
+  test('merges allOf in field tree', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/AllOfDemo' }, ctx());
+    const names = nodes.map((n) => n.name);
+    expect(names).toContain('id');
+    expect(names).toContain('name');
+    expect(names).toContain('email');
+    expect(names).toContain('role');
+    expect(names).toContain('avatar');
+  });
+
+  // 8. oneOf / anyOf
+  test('uses first resolvable branch in oneOf field tree', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/OneOfDemo' }, ctx());
+    const names = nodes.map((n) => n.name);
+    expect(names).toContain('id');
+    expect(names).toContain('name');
+  });
+
+  // 9. 空输入
+  test('returns empty array for undefined schema', () => {
+    const result = buildSchemaFieldTree(undefined, ctx());
+    expect(result).toEqual([]);
+  });
+
+  // 10. primitive 顶层
+  test('returns single node for top-level primitive schema', () => {
+    const result = buildSchemaFieldTree({ type: 'string', format: 'email' }, ctx());
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('string');
+    expect(result[0].format).toBe('email');
+    expect(result[0].name).toBe('');
+  });
+
+  // 11. array 顶层
+  test('returns items node for top-level array schema', () => {
+    const result = buildSchemaFieldTree({ type: 'array', items: { type: 'integer' } }, ctx());
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('array');
+    expect(result[0].children).toBeDefined();
+    expect(result[0].children![0].name).toBe('items');
+    expect(result[0].children![0].type).toBe('integer');
+  });
+
+  // 12. example / default / description 透传
+  test('passes through example, default, and description to field nodes', () => {
+    const nodes = buildSchemaFieldTree(
+      {
+        type: 'object',
+        properties: {
+          status: { type: 'string', example: 'active', default: 'pending', description: 'Current status' },
+        },
+      },
+      ctx(),
+    );
+    const statusNode = nodes[0];
+    expect(statusNode.example).toBe('active');
+    expect(statusNode.default).toBe('pending');
+    expect(statusNode.description).toBe('Current status');
+  });
+
+  // 13. readOnly / writeOnly / deprecated
+  test('passes through readOnly, writeOnly, and deprecated', () => {
+    const nodes = buildSchemaFieldTree(
+      {
+        type: 'object',
+        properties: {
+          createdAt: { type: 'string', readOnly: true },
+          password: { type: 'string', writeOnly: true },
+          oldField: { type: 'string', deprecated: true },
+        },
+      },
+      ctx(),
+    );
+    const createdNode = nodes.find((n) => n.name === 'createdAt')!;
+    expect(createdNode.readOnly).toBe(true);
+    const passwordNode = nodes.find((n) => n.name === 'password')!;
+    expect(passwordNode.writeOnly).toBe(true);
+    const oldNode = nodes.find((n) => n.name === 'oldField')!;
+    expect(oldNode.deprecated).toBe(true);
+  });
+
+  // 14. mutual circular reference
+  test('handles mutual circular reference in field tree', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/MutualA' }, ctx());
+    const bNode = nodes.find((n) => n.name === 'b')!;
+    expect(bNode.refName).toBe('MutualB');
+    // b 的 children 应包含 MutualB 的字段，其中 a 应被截断
+    if (bNode.children) {
+      const aInB = bNode.children.find((n) => n.name === 'a');
+      if (aInB) {
+        expect(aInB.truncated).toBe(true);
+      }
+    }
+  });
+
+  // 15. additionalProperties map
+  test('represents additionalProperties map as * field', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/FreeFormMap' }, ctx());
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('*');
+    expect(nodes[0].type).toBe('string');
+  });
+});
+

--- a/knife4j-front/knife4j-core/src/debug/index.ts
+++ b/knife4j-front/knife4j-core/src/debug/index.ts
@@ -21,6 +21,7 @@ export type {
   BuiltRequest,
   ValidationError,
   SchemaResolveContext,
+  SchemaFieldNode,
   BuildSchemaExampleFn,
   BuildSchemaFieldTreeFn,
 } from './types';
@@ -45,6 +46,6 @@ export {
 } from './requestBuilder';
 export type { BuildRequestOptions } from './requestBuilder';
 
-// schemaExample (占位，TASK-030 完整实现)
+// schemaExample
 export { buildSchemaExample, buildSchemaFieldTree } from './schemaExample';
 

--- a/knife4j-front/knife4j-core/src/debug/schemaExample.ts
+++ b/knife4j-front/knife4j-core/src/debug/schemaExample.ts
@@ -1,97 +1,478 @@
 /**
- * Schema 示例生成与字段树递归 — 占位实现
+ * Schema 示例值生成与字段树递归（TASK-030 完整实现）
  *
- * 完整递归逻辑在 TASK-030 实现。
- * 当前版本只处理基本类型和一层 object/array，不递归展开 $ref。
- * 目的：让 requestBuilder 和 OperationDebugModel 在 TASK-032 就能生成初始值。
+ * 同时兼容 OAS2（definitions）与 OAS3（components.schemas），通过 resolveRef 统一引用解析。
+ *
+ * 规则：
+ * - 优先级：example > default > enum[0] > 按 type/format 推断
+ * - 递归处理 $ref / object.properties / array.items
+ * - allOf：浅合并子 schema 的 properties / required
+ * - oneOf / anyOf：取第一个可解析分支
+ * - 循环引用：按引用链数组截断，重复命中同一 $ref 时返回占位值（example）或 null + truncated 标记（fieldTree）
+ * - maxDepth：默认 8，超过后截断
+ *
+ * 不依赖浏览器 API、不依赖框架。
  */
 
-import type { BuildSchemaExampleFn, BuildSchemaFieldTreeFn } from './types';
+import type {
+  BuildSchemaExampleFn,
+  BuildSchemaFieldTreeFn,
+  SchemaFieldNode,
+  SchemaResolveContext,
+} from './types';
+import { resolveRef } from './resolveRef';
 
-/**
- * 基本类型 → 示例值的映射
- */
-function primitiveExample(type?: string, format?: string, enumValues?: unknown[], example?: unknown, defaultValue?: unknown): unknown {
-  // 优先使用显式 example
-  if (example !== undefined) return example;
-  // 其次 default
-  if (defaultValue !== undefined) return defaultValue;
-  // enum 取第一个
-  if (enumValues && enumValues.length > 0) return enumValues[0];
+// ─── 常量 ─────────────────────────────────────────────
 
-  // 按 type + format 推断
+const DEFAULT_MAX_DEPTH = 8;
+
+/** 按 type + format 推断的 primitive 默认值 */
+function primitiveExample(
+  type: string | undefined,
+  format: string | undefined,
+): unknown {
   switch (type) {
     case 'string':
       switch (format) {
         case 'date': return '2024-01-01';
         case 'date-time': return '2024-01-01T00:00:00Z';
+        case 'time': return '00:00:00';
         case 'email': return 'user@example.com';
         case 'uri':
         case 'url': return 'https://example.com';
         case 'uuid': return '3fa85f64-5717-4562-b3fc-2c963f66afa6';
-        case 'binary': return '(binary)';
+        case 'hostname': return 'example.com';
+        case 'ipv4': return '127.0.0.1';
+        case 'ipv6': return '::1';
+        case 'binary': return '';
         case 'byte': return 'dGVzdA==';
-        default: return '';
+        case 'password': return 'password';
+        default: return 'string';
       }
     case 'integer':
+      switch (format) {
+        case 'int64': return 0;
+        case 'int32':
+        default: return 0;
+      }
     case 'number':
-      return 0;
+      switch (format) {
+        case 'float': return 0.0;
+        case 'double': return 0.0;
+        default: return 0;
+      }
     case 'boolean':
       return true;
     case 'file':
-      return '(file)';
-    default:
       return '';
+    case 'null':
+      return null;
+    default:
+      return null;
   }
 }
 
+/** type 归一化（null / undefined → 'unknown'） */
+function normalizeType(type: unknown): string {
+  if (Array.isArray(type)) {
+    // OAS 3.1 允许 type: ['string', 'null']
+    for (const t of type as unknown[]) {
+      if (typeof t === 'string' && t !== 'null') return t;
+    }
+    return 'unknown';
+  }
+  return typeof type === 'string' ? type : 'unknown';
+}
+
+// ─── 内部递归上下文 ───────────────────────────────────
+
 /**
- * 简易 schema → 示例值生成（不递归展开 $ref，仅处理基本类型和一层嵌套）
- *
- * TASK-030 会替换为完整实现（递归 $ref、allOf/oneOf/anyOf、循环引用检测、maxDepth）
+ * 递归上下文：在外部的 SchemaResolveContext 基础上追加引用链和深度
  */
-export const buildSchemaExample: BuildSchemaExampleFn = (
-  schema,
-  _ctx,
-): unknown => {
-  if (!schema) return undefined;
+interface InternalCtx {
+  doc: Record<string, unknown>;
+  maxDepth: number;
+  /** 当前递归深度（从 0 起） */
+  depth: number;
+  /** 当前引用链（用于检测循环），记录已访问的 $ref 字符串 */
+  refChain: string[];
+}
 
-  // $ref: 不递归，返回空对象占位
-  if (schema.$ref) return {};
+function toInternalCtx(ctx: SchemaResolveContext): InternalCtx {
+  return {
+    doc: ctx.doc,
+    maxDepth: ctx.maxDepth ?? DEFAULT_MAX_DEPTH,
+    depth: 0,
+    refChain: [],
+  };
+}
 
-  const type = schema.type as string | undefined;
-  const format = schema.format as string | undefined;
-  const enumVal = schema.enum as unknown[] | undefined;
-  const example = schema.example;
-  const defaultVal = schema.default;
+function childCtx(ctx: InternalCtx, pushedRef?: string): InternalCtx {
+  return {
+    doc: ctx.doc,
+    maxDepth: ctx.maxDepth,
+    depth: ctx.depth + 1,
+    refChain: pushedRef ? [...ctx.refChain, pushedRef] : ctx.refChain,
+  };
+}
 
-  if (type === 'array') {
-    const items = schema.items as Record<string, unknown> | undefined;
-    const itemExample = buildSchemaExample(items, _ctx);
-    return [itemExample ?? {}];
+// ─── allOf / oneOf / anyOf 合并 ───────────────────────
+
+/**
+ * 合并 allOf 所有子项：
+ * - type / format / enum / example / default 取第一个非 undefined
+ * - properties 浅合并
+ * - required 拼接去重
+ */
+function mergeAllOf(
+  parts: Record<string, unknown>[],
+  ctx: InternalCtx,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  const mergedProps: Record<string, Record<string, unknown>> = {};
+  const mergedRequired = new Set<string>();
+  let hasProps = false;
+  let hasRequired = false;
+
+  for (const part of parts) {
+    const resolved = deref(part, ctx);
+    if (!resolved) continue;
+    for (const [key, value] of Object.entries(resolved)) {
+      if (key === 'properties') {
+        hasProps = true;
+        if (value && typeof value === 'object') {
+          for (const [pname, pschema] of Object.entries(value as Record<string, unknown>)) {
+            mergedProps[pname] = pschema as Record<string, unknown>;
+          }
+        }
+      } else if (key === 'required') {
+        hasRequired = true;
+        if (Array.isArray(value)) {
+          for (const r of value) {
+            if (typeof r === 'string') mergedRequired.add(r);
+          }
+        }
+      } else if (merged[key] === undefined) {
+        merged[key] = value;
+      }
+    }
   }
 
-  if (type === 'object' || (!type && schema.properties)) {
-    const props = schema.properties as Record<string, Record<string, unknown>> | undefined;
-    if (!props) return {};
+  if (hasProps) merged.properties = mergedProps;
+  if (hasRequired) merged.required = Array.from(mergedRequired);
+  if (!merged.type && hasProps) merged.type = 'object';
+  return merged;
+}
+
+/** 解析 schema 的显式分支（$ref / allOf / oneOf / anyOf），返回归一化后的 schema */
+function resolveSchema(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): { schema: Record<string, unknown> | undefined; ref?: string; truncated: boolean } {
+  if (!schema) return { schema: undefined, truncated: false };
+
+  // 1. $ref
+  if (typeof schema.$ref === 'string') {
+    const ref = schema.$ref;
+    if (ctx.refChain.includes(ref)) {
+      return { schema: undefined, ref, truncated: true };
+    }
+    const resolved = resolveRef(ref, ctx.doc);
+    if (!resolved) return { schema: undefined, ref, truncated: false };
+    // 递归解析（解析后可能仍是 $ref / allOf 等）
+    const deeper = resolveSchema(resolved, {
+      ...ctx,
+      refChain: [...ctx.refChain, ref],
+    });
+    return { ...deeper, ref };
+  }
+
+  // 2. allOf：浅合并
+  if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
+    const merged = mergeAllOf(schema.allOf as Record<string, unknown>[], ctx);
+    // 若 allOf 外层还带 properties/required/type，进一步合并
+    const outer: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(schema)) {
+      if (k === 'allOf') continue;
+      outer[k] = v;
+    }
+    const combined = mergeAllOf([merged, outer], ctx);
+    return { schema: combined, truncated: false };
+  }
+
+  // 3. oneOf / anyOf：取第一个可解析分支
+  const union = (schema.oneOf ?? schema.anyOf) as Record<string, unknown>[] | undefined;
+  if (Array.isArray(union) && union.length > 0) {
+    for (const branch of union) {
+      const branchResolved = resolveSchema(branch, ctx);
+      if (branchResolved.schema) return branchResolved;
+    }
+    return { schema: undefined, truncated: false };
+  }
+
+  return { schema, truncated: false };
+}
+
+/** dereference：$ref → 解析后 schema（循环或失败时原样返回） */
+function deref(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): Record<string, unknown> | undefined {
+  if (!schema) return schema;
+  if (typeof schema.$ref !== 'string') return schema;
+  if (ctx.refChain.includes(schema.$ref)) return undefined;
+  const r = resolveRef(schema.$ref, ctx.doc);
+  return r;
+}
+
+/** 从 $ref 字符串中提取类型名（最后一段） */
+function refToName(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  const idx = ref.lastIndexOf('/');
+  return idx >= 0 ? ref.slice(idx + 1) : ref;
+}
+
+// ─── buildSchemaExample 实现 ──────────────────────────
+
+export const buildSchemaExample: BuildSchemaExampleFn = (schema, ctx) => {
+  return buildExampleInternal(schema, toInternalCtx(ctx));
+};
+
+function buildExampleInternal(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): unknown {
+  if (!schema) return null;
+
+  // maxDepth 保护
+  if (ctx.depth >= ctx.maxDepth) {
+    return null;
+  }
+
+  const { schema: resolved, truncated, ref } = resolveSchema(schema, ctx);
+  if (!resolved || truncated) {
+    // 循环引用或解析失败：给一个占位值（保持类型尽量合理）
+    if (schema.example !== undefined) return schema.example;
+    return null;
+  }
+
+  // 如果 resolveSchema 解析了 $ref，将 ref 加入后续递归的上下文
+  // 这样子属性递归时能检测到祖先 $ref，避免循环引用
+  const ctxWithRef = ref ? pushRefIfAny(ctx, ref) : ctx;
+
+  // 显式 example 覆盖一切（OpenAPI 官方约定）
+  if (resolved.example !== undefined) {
+    return resolved.example;
+  }
+  // default 次优
+  if (resolved.default !== undefined) {
+    return resolved.default;
+  }
+  // enum 第一个
+  if (Array.isArray(resolved.enum) && resolved.enum.length > 0) {
+    return resolved.enum[0];
+  }
+
+  const type = normalizeType(resolved.type);
+  const format = typeof resolved.format === 'string' ? resolved.format : undefined;
+
+  // array
+  if (type === 'array') {
+    const items = resolved.items as Record<string, unknown> | undefined;
+    if (!items) return [];
+    const child = buildExampleInternal(items, childCtx(ctxWithRef));
+    return child === null && type === 'array' ? [] : [child];
+  }
+
+  // object（type=object 或未声明但有 properties）
+  if (type === 'object' || (type === 'unknown' && (resolved.properties || resolved.additionalProperties))) {
+    const props = resolved.properties as Record<string, Record<string, unknown>> | undefined;
     const result: Record<string, unknown> = {};
-    for (const [key, propSchema] of Object.entries(props)) {
-      result[key] = buildSchemaExample(propSchema, _ctx);
+    if (props) {
+      for (const [key, propSchema] of Object.entries(props)) {
+        result[key] = buildExampleInternal(propSchema, childCtx(ctxWithRef));
+      }
+    } else if (resolved.additionalProperties && typeof resolved.additionalProperties === 'object') {
+      const addSchema = resolved.additionalProperties as Record<string, unknown>;
+      result['additionalProp1'] = buildExampleInternal(addSchema, childCtx(ctxWithRef));
     }
     return result;
   }
 
-  return primitiveExample(type, format, enumVal, example, defaultVal);
+  // primitive
+  return primitiveExample(type, format);
+}
+
+// ─── buildSchemaFieldTree 实现 ────────────────────────
+
+export const buildSchemaFieldTree: BuildSchemaFieldTreeFn = (schema, ctx) => {
+  return buildFieldTreeInternal(schema, toInternalCtx(ctx));
 };
 
-/**
- * 简易字段树生成（占位） — TASK-030 实现
- */
-export const buildSchemaFieldTree: BuildSchemaFieldTreeFn = (
-  _schema,
-  _ctx,
-): unknown => {
-  // 占位：返回空数组
-  return [];
-};
+function buildFieldTreeInternal(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): SchemaFieldNode[] {
+  if (!schema) return [];
+  if (ctx.depth >= ctx.maxDepth) return [];
+
+  const { schema: resolved, ref, truncated } = resolveSchema(schema, ctx);
+  if (!resolved) return [];
+  if (truncated) return [];
+
+  const type = normalizeType(resolved.type);
+
+  // 顶层 object → 展开 properties
+  if (type === 'object' || (type === 'unknown' && resolved.properties)) {
+    return objectToFieldNodes(resolved, ctx, ref);
+  }
+
+  // 顶层 array → 返回 array 节点 + items 子节点
+  if (type === 'array') {
+    const items = resolved.items as Record<string, unknown> | undefined;
+    const arrayNode: SchemaFieldNode = {
+      name: '',
+      type: 'array',
+      format: typeof resolved.format === 'string' ? resolved.format : undefined,
+      required: false,
+      description: typeof resolved.description === 'string' ? resolved.description : undefined,
+      refName: refToName(ref),
+    };
+    if (items && ctx.depth + 1 < ctx.maxDepth) {
+      const itemNode = buildSingleFieldNode('items', items, false, childCtx(pushRefIfAny(ctx, ref)));
+      arrayNode.children = [itemNode];
+    }
+    return [arrayNode];
+  }
+
+  // 顶层 primitive → 返回单节点
+  return [
+    {
+      name: '',
+      type,
+      format: typeof resolved.format === 'string' ? resolved.format : undefined,
+      required: false,
+      description: typeof resolved.description === 'string' ? resolved.description : undefined,
+      default: resolved.default,
+      example: resolved.example,
+      enum: Array.isArray(resolved.enum) ? resolved.enum : undefined,
+      refName: refToName(ref),
+    },
+  ];
+}
+
+function objectToFieldNodes(
+  resolved: Record<string, unknown>,
+  ctx: InternalCtx,
+  parentRef?: string,
+): SchemaFieldNode[] {
+  const props = (resolved.properties as Record<string, Record<string, unknown>> | undefined) ?? {};
+  const requiredSet = new Set<string>(Array.isArray(resolved.required) ? (resolved.required as string[]) : []);
+
+  const nodes: SchemaFieldNode[] = [];
+  for (const [name, propSchema] of Object.entries(props)) {
+    nodes.push(buildSingleFieldNode(name, propSchema, requiredSet.has(name), pushRefIfAny(ctx, parentRef)));
+  }
+  // additionalProperties 作为伪字段（只有在没有 properties 时展示）
+  if (Object.keys(props).length === 0 && resolved.additionalProperties && typeof resolved.additionalProperties === 'object') {
+    nodes.push(buildSingleFieldNode('*', resolved.additionalProperties as Record<string, unknown>, false, ctx));
+  }
+  return nodes;
+}
+
+function pushRefIfAny(ctx: InternalCtx, ref: string | undefined): InternalCtx {
+  if (!ref) return ctx;
+  if (ctx.refChain.includes(ref)) return ctx;
+  return { ...ctx, refChain: [...ctx.refChain, ref] };
+}
+
+function buildSingleFieldNode(
+  name: string,
+  rawSchema: Record<string, unknown> | undefined,
+  required: boolean,
+  ctx: InternalCtx,
+): SchemaFieldNode {
+  if (!rawSchema) {
+    return { name, type: 'unknown', required };
+  }
+
+  // 循环检测：$ref 重复命中 → truncated
+  if (typeof rawSchema.$ref === 'string' && ctx.refChain.includes(rawSchema.$ref)) {
+    return {
+      name,
+      type: 'object',
+      refName: refToName(rawSchema.$ref),
+      required,
+      truncated: true,
+    };
+  }
+
+  const { schema: resolved, ref, truncated } = resolveSchema(rawSchema, ctx);
+  if (!resolved) {
+    return {
+      name,
+      type: 'unknown',
+      refName: refToName(ref),
+      required,
+      truncated,
+    };
+  }
+
+  const type = normalizeType(resolved.type);
+  const format = typeof resolved.format === 'string' ? resolved.format : undefined;
+  const description = typeof resolved.description === 'string' ? resolved.description : undefined;
+
+  const node: SchemaFieldNode = {
+    name,
+    type: type === 'unknown' && resolved.properties ? 'object' : type,
+    format,
+    required,
+    description,
+    default: resolved.default,
+    example: resolved.example,
+    enum: Array.isArray(resolved.enum) ? resolved.enum : undefined,
+    readOnly: typeof resolved.readOnly === 'boolean' ? resolved.readOnly : undefined,
+    writeOnly: typeof resolved.writeOnly === 'boolean' ? resolved.writeOnly : undefined,
+    deprecated: typeof resolved.deprecated === 'boolean' ? resolved.deprecated : undefined,
+    refName: refToName(ref),
+  };
+
+  // 子字段展开
+  // 达到 maxDepth 时只保留当前层，不再递归
+  if (ctx.depth + 1 >= ctx.maxDepth) {
+    if (type === 'object' || type === 'array') {
+      node.truncated = true;
+    }
+    return node;
+  }
+
+  const nextCtx = ref ? pushRefIfAny(ctx, ref) : ctx;
+  const deeperCtx = childCtx(nextCtx);
+
+  if (node.type === 'object') {
+    const children = objectToFieldNodes(resolved, deeperCtx, ref);
+    if (children.length > 0) node.children = children;
+  } else if (node.type === 'array') {
+    const items = resolved.items as Record<string, unknown> | undefined;
+    if (items) {
+      // 循环检测
+      if (typeof items.$ref === 'string' && deeperCtx.refChain.includes(items.$ref)) {
+        node.children = [
+          {
+            name: 'items',
+            type: 'object',
+            refName: refToName(items.$ref),
+            required: false,
+            truncated: true,
+          },
+        ];
+      } else {
+        const itemNode = buildSingleFieldNode('items', items, false, deeperCtx);
+        node.children = [itemNode];
+      }
+    }
+  }
+
+  return node;
+}
 

--- a/knife4j-front/knife4j-core/src/debug/types.ts
+++ b/knife4j-front/knife4j-core/src/debug/types.ts
@@ -135,7 +135,7 @@ export interface ValidationError {
   message: string;
 }
 
-// ─── Schema 示例/字段树 占位签名（TASK-030 实现） ──────
+// ─── Schema 示例/字段树 ───────────────────────────────
 
 /** schema 递归展开上下文 */
 export interface SchemaResolveContext {
@@ -145,9 +145,43 @@ export interface SchemaResolveContext {
   maxDepth?: number;
 }
 
+/** 字段树节点（用于文档展示） */
+export interface SchemaFieldNode {
+  /** 字段名；根节点或 array 元素可能为空字符串 */
+  name: string;
+  /** 归一化后的类型：string / integer / number / boolean / array / object / unknown */
+  type: string;
+  /** 格式修饰（如 int64 / date-time / binary） */
+  format?: string;
+  /** 是否必填（由父 schema 的 required 列表决定） */
+  required: boolean;
+  /** 描述 */
+  description?: string;
+  /** 默认值 */
+  default?: unknown;
+  /** 显式 example */
+  example?: unknown;
+  /** 枚举值 */
+  enum?: unknown[];
+  /** 是否只读 */
+  readOnly?: boolean;
+  /** 是否只写 */
+  writeOnly?: boolean;
+  /** 是否已废弃 */
+  deprecated?: boolean;
+  /** 当 type 为 $ref 指向的具名类型时，保留类型名便于 UI 提示 */
+  refName?: string;
+  /** 因循环引用或达到最大深度被截断时标记 */
+  truncated?: boolean;
+  /** 子字段（object.properties 或 array.items） */
+  children?: SchemaFieldNode[];
+}
+
 /**
- * 根据 schema 生成 JSON 示例值。
- * TASK-030 实现完整逻辑；当前为占位，只处理基本类型。
+ * 根据 schema 生成 JSON 示例值（纯数据）。
+ *
+ * 支持：$ref / object / array / enum / example / default / allOf（浅合并） /
+ * oneOf / anyOf（取第一个可解析分支） / 循环引用截断 / maxDepth 保护。
  */
 export type BuildSchemaExampleFn = (
   schema: Record<string, unknown> | undefined,
@@ -156,10 +190,12 @@ export type BuildSchemaExampleFn = (
 
 /**
  * 根据 schema 生成字段树（用于文档展示）。
- * TASK-030 实现；当前占位。
+ *
+ * 返回值为 SchemaFieldNode 数组：object 展开 properties，array 以伪节点暴露 items。
+ * 循环引用以 `truncated=true` 截断，不会死循环。
  */
 export type BuildSchemaFieldTreeFn = (
   schema: Record<string, unknown> | undefined,
   ctx: SchemaResolveContext,
-) => unknown;
+) => SchemaFieldNode[];
 


### PR DESCRIPTION
…ee (TASK-030)

Complete recursive schema example generation and field tree building: buildSchemaExample with $ref/object/array/allOf/oneOf/anyOf/circular-ref/maxDepth, buildSchemaFieldTree with SchemaFieldNode output, 39 unit tests. Validation: 121 tests passed, lint clean, build OK.