### PR TITLE
TASK-027: React 调试页补全 requestBody 多内容类型表单

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -515,3 +515,25 @@ summary:
 - TASK-034（npm workspaces）：代码已在 master@6572a458，状态更新为 done
 - TASK-035（Node 22 升级）：代码已在 master@2617c72f，状态更新为 done
 - 解锁 TASK-027（requestBody 多内容类型表单）和 TASK-030（schema 示例生成）为 ready
+
+## 2026-07-04 CST
+task: TASK-030
+agent: coordinator (direct)
+branch: codex/TASK-030-schema-example-builder
+status: review
+summary:
+- 完整实现 buildSchemaExample(schema, ctx) 和 buildSchemaFieldTree(schema, ctx)
+- 支持 $ref、object、array、enum、example、default、allOf、oneOf、anyOf（后两者取第一个可解析分支）
+- 循环引用通过引用链数组截断，重复引用以占位值兜底
+- maxDepth 保护（默认 8），超过截断并附 truncated 标记
+- OAS2 definitions 与 OAS3 components.schemas 统一抽象
+- 新增 SchemaFieldNode 类型定义
+- 新增 schemaExample.test.ts（39 个用例覆盖各种分支）
+validation:
+- 12 test suites, 121 tests pass
+- lint 0 errors, tsc build OK
+- 分支已推送，等待创建 PR
+next:
+- 等待维护者 review PR
+blockers:
+- gh CLI 未安装，PR 需通过 GitHub 网页创建

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -561,6 +561,6 @@ validation:
 - knife4j-ui-react: npm run build 通过 (tsc + vite build, dist 1.44MB)
 next:
 - 等待维护者 review
-- PR: https://github.com/songxychn/knife4j-next/pull/new/codex/TASK-027-react-debug-request-body
+- PR: https://github.com/songxychn/knife4j-next/pull/44
 blockers:
 - none

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -537,3 +537,30 @@ next:
 - 等待维护者 review PR
 blockers:
 - gh CLI 未安装，PR 需通过 GitHub 网页创建
+
+## 2026-07-04 CST
+task: TASK-027
+agent: coordinator (direct)
+branch: codex/TASK-027-react-debug-request-body
+status: review
+summary:
+- 重写 ApiDebug.tsx 的 Body Tab，实现 requestBody 多内容类型表单
+- 新增 BodyTab 组件：根据 content-type 分类渲染不同表单
+  - JSON 模式：可编辑 TextArea + Beautify 按钮（接入 buildSchemaExample 生成的 exampleValue）
+  - urlencoded 模式：从 schema.properties 提取字段行，渲染参数表格（SchemaFieldInput 调度器）
+  - multipart 模式：普通字段表单 + 文件字段使用 antd Upload 组件（支持多文件）
+  - raw 模式：Text/JSON/JavaScript/XML/HTML 五种子模式切换 + Beautify
+- Radio.Group 切换 content-type（多 content-type 时显示）
+- 新增 selectedContentType / formFields / fileFields 状态管理
+- collectFormValues 传递 selectedContentType / formFields / fileFields 给 requestBuilder
+- handleSend 对 multipart 场景手动构建 FormData（浏览器自动设 boundary）
+- 新增辅助函数：extractSchemaFields, initialFieldValue, SchemaFieldRow 类型
+- i18n 补全 7 个新文案（中英文）
+validation:
+- knife4j-core: 12 suites, 121 tests pass
+- knife4j-ui-react: npm run build 通过 (tsc + vite build, dist 1.44MB)
+next:
+- 等待维护者 review
+- PR: https://github.com/songxychn/knife4j-next/pull/new/codex/TASK-027-react-debug-request-body
+blockers:
+- none

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -485,7 +485,7 @@ notes:
 - Vue2 的 Base64Img Tab 若实现成本低可一并做，否则延后
 
 ### TASK-030
-status: ready
+status: review
 area: front-core
 title: schema 示例生成与字段树递归（knife4j-core）
 branch: codex/TASK-030-schema-example-builder

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -430,7 +430,7 @@ notes:
 - blocked 原因：等 TASK-032 的参数解析 API 稳定后再落实现
 
 ### TASK-027
-status: ready
+status: review
 area: ui-react
 title: React 调试页补全 requestBody 多内容类型表单
 branch: codex/TASK-027-react-debug-request-body

--- a/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
@@ -1,0 +1,461 @@
+import { buildSchemaExample, buildSchemaFieldTree } from '../../debug/schemaExample';
+import type { SchemaResolveContext, SchemaFieldNode } from '../../debug/types';
+
+// ─── 测试文档 ─────────────────────────────────────────
+
+const doc: Record<string, unknown> = {
+  components: {
+    schemas: {
+      User: {
+        type: 'object',
+        required: ['id', 'name'],
+        properties: {
+          id: { type: 'integer', format: 'int64' },
+          name: { type: 'string' },
+          email: { type: 'string', format: 'email' },
+          role: { type: 'string', enum: ['ADMIN', 'USER'] },
+        },
+      },
+      Pet: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', example: 'Buddy' },
+          tag: { type: 'string' },
+        },
+      },
+      Order: {
+        type: 'object',
+        required: ['id', 'user'],
+        properties: {
+          id: { type: 'integer' },
+          user: { $ref: '#/components/schemas/User' },
+          items: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Pet' },
+          },
+        },
+      },
+      SelfRef: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          parent: { $ref: '#/components/schemas/SelfRef' },
+        },
+      },
+      MutualA: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          b: { $ref: '#/components/schemas/MutualB' },
+        },
+      },
+      MutualB: {
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+          a: { $ref: '#/components/schemas/MutualA' },
+        },
+      },
+      AllOfDemo: {
+        allOf: [
+          { $ref: '#/components/schemas/User' },
+          {
+            type: 'object',
+            properties: {
+              avatar: { type: 'string', format: 'url' },
+            },
+          },
+        ],
+      },
+      OneOfDemo: {
+        oneOf: [
+          { $ref: '#/components/schemas/User' },
+          { $ref: '#/components/schemas/Pet' },
+        ],
+      },
+      AnyOfDemo: {
+        anyOf: [
+          { $ref: '#/components/schemas/Pet' },
+          { type: 'string' },
+        ],
+      },
+      FreeFormMap: {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+      },
+      ArrayOfPrimitives: {
+        type: 'array',
+        items: { type: 'string' },
+      },
+    },
+  },
+  definitions: {
+    LegacyCar: {
+      type: 'object',
+      properties: {
+        brand: { type: 'string' },
+        model: { type: 'string' },
+      },
+    },
+  },
+};
+
+function ctx(overrides?: Partial<SchemaResolveContext>): SchemaResolveContext {
+  return { doc, ...overrides };
+}
+
+// ─── buildSchemaExample 测试 ──────────────────────────
+
+describe('buildSchemaExample', () => {
+  // 1. primitive 类型
+  test('generates example for string type', () => {
+    const result = buildSchemaExample({ type: 'string' }, ctx());
+    expect(result).toBe('string');
+  });
+
+  test('generates example for string format date-time', () => {
+    const result = buildSchemaExample({ type: 'string', format: 'date-time' }, ctx());
+    expect(result).toBe('2024-01-01T00:00:00Z');
+  });
+
+  test('generates example for integer type', () => {
+    const result = buildSchemaExample({ type: 'integer' }, ctx());
+    expect(result).toBe(0);
+  });
+
+  test('generates example for boolean type', () => {
+    const result = buildSchemaExample({ type: 'boolean' }, ctx());
+    expect(result).toBe(true);
+  });
+
+  // 2. enum
+  test('uses first enum value as example', () => {
+    const result = buildSchemaExample({ type: 'string', enum: ['cat', 'dog'] }, ctx());
+    expect(result).toBe('cat');
+  });
+
+  // 3. example/default 优先级
+  test('explicit example takes highest priority', () => {
+    const result = buildSchemaExample(
+      { type: 'string', enum: ['a', 'b'], default: 'default', example: 'explicit' },
+      ctx(),
+    );
+    expect(result).toBe('explicit');
+  });
+
+  test('default takes priority over enum and type inference', () => {
+    const result = buildSchemaExample(
+      { type: 'string', enum: ['a'], default: 'my-default' },
+      ctx(),
+    );
+    expect(result).toBe('my-default');
+  });
+
+  // 4. $ref 解析
+  test('resolves $ref to OAS3 components.schemas', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/User' }, ctx());
+    expect(result).toEqual({
+      id: 0,
+      name: 'string',
+      email: 'user@example.com',
+      role: 'ADMIN',
+    });
+  });
+
+  test('resolves $ref to OAS2 definitions', () => {
+    const result = buildSchemaExample({ $ref: '#/definitions/LegacyCar' }, ctx());
+    expect(result).toEqual({
+      brand: 'string',
+      model: 'string',
+    });
+  });
+
+  // 5. object
+  test('generates example for inline object with properties', () => {
+    const result = buildSchemaExample(
+      {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+      },
+      ctx(),
+    );
+    expect(result).toEqual({ name: 'string', age: 0 });
+  });
+
+  // 6. array
+  test('generates example for array of primitives', () => {
+    const result = buildSchemaExample({ type: 'array', items: { type: 'string' } }, ctx());
+    expect(result).toEqual(['string']);
+  });
+
+  test('generates example for array of $ref items', () => {
+    const result = buildSchemaExample(
+      { type: 'array', items: { $ref: '#/components/schemas/Pet' } },
+      ctx(),
+    );
+    expect(result).toEqual([{ name: 'Buddy', tag: 'string' }]);
+  });
+
+  // 7. 循环引用
+  test('handles self-referencing schema without infinite loop', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/SelfRef' }, ctx());
+    expect(result).toEqual({ id: 0, parent: null });
+  });
+
+  test('handles mutual circular references', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/MutualA' }, ctx());
+    // MutualA.id=0, MutualA.b → MutualB (展开), MutualB.a → MutualA (截断为null)
+    expect(result).toEqual({
+      id: 0,
+      b: { id: 0, a: null },
+    });
+  });
+
+  // 8. allOf
+  test('merges allOf schemas', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/AllOfDemo' }, ctx());
+    expect(result).toEqual({
+      id: 0,
+      name: 'string',
+      email: 'user@example.com',
+      role: 'ADMIN',
+      avatar: 'https://example.com',
+    });
+  });
+
+  // 9. oneOf
+  test('uses first resolvable branch of oneOf', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/OneOfDemo' }, ctx());
+    // First branch is User
+    expect(result).toHaveProperty('id');
+    expect(result).toHaveProperty('name');
+  });
+
+  // 10. anyOf
+  test('uses first resolvable branch of anyOf', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/AnyOfDemo' }, ctx());
+    expect(result).toHaveProperty('name');
+    expect(result).toHaveProperty('tag');
+  });
+
+  // 11. additionalProperties (map)
+  test('generates example for additionalProperties map', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/FreeFormMap' }, ctx());
+    expect(result).toEqual({ additionalProp1: 'string' });
+  });
+
+  // 12. maxDepth 保护
+  test('respects maxDepth and returns null beyond it', () => {
+    const result = buildSchemaExample(
+      { $ref: '#/components/schemas/User' },
+      ctx({ maxDepth: 0 }),
+    );
+    expect(result).toBeNull();
+  });
+
+  // 13. 空输入
+  test('returns null for undefined schema', () => {
+    const result = buildSchemaExample(undefined, ctx());
+    expect(result).toBeNull();
+  });
+
+  // 14. 不存在的 $ref
+  test('returns null for non-existent $ref', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/NotExist' }, ctx());
+    expect(result).toBeNull();
+  });
+
+  // 15. object with nested $ref
+  test('generates example for object containing $ref properties', () => {
+    const result = buildSchemaExample({ $ref: '#/components/schemas/Order' }, ctx());
+    expect(result).toEqual({
+      id: 0,
+      user: { id: 0, name: 'string', email: 'user@example.com', role: 'ADMIN' },
+      items: [{ name: 'Buddy', tag: 'string' }],
+    });
+  });
+
+  // 16. array with no items
+  test('returns empty array when items is missing', () => {
+    const result = buildSchemaExample({ type: 'array' }, ctx());
+    expect(result).toEqual([]);
+  });
+
+  // 17. format-specific examples
+  test('generates uuid format example', () => {
+    const result = buildSchemaExample({ type: 'string', format: 'uuid' }, ctx());
+    expect(result).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+  });
+});
+
+// ─── buildSchemaFieldTree 测试 ────────────────────────
+
+describe('buildSchemaFieldTree', () => {
+  // 1. object 展开
+  test('expands object properties into field nodes', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/User' }, ctx());
+    expect(nodes).toHaveLength(4);
+    const idNode = nodes.find((n) => n.name === 'id')!;
+    expect(idNode.type).toBe('integer');
+    expect(idNode.format).toBe('int64');
+    expect(idNode.required).toBe(true);
+    const emailNode = nodes.find((n) => n.name === 'email')!;
+    expect(emailNode.required).toBe(false);
+  });
+
+  // 2. $ref refName
+  test('sets refName for $ref properties', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/Order' }, ctx());
+    const userNode = nodes.find((n) => n.name === 'user')!;
+    expect(userNode.refName).toBe('User');
+    expect(userNode.type).toBe('object');
+    // 应该有 children（User 的字段）
+    expect(userNode.children).toBeDefined();
+    expect(userNode.children!.length).toBeGreaterThan(0);
+  });
+
+  // 3. array items
+  test('represents array as node with items child', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/Order' }, ctx());
+    const itemsNode = nodes.find((n) => n.name === 'items')!;
+    expect(itemsNode.type).toBe('array');
+    expect(itemsNode.children).toBeDefined();
+    expect(itemsNode.children![0].name).toBe('items');
+    expect(itemsNode.children![0].refName).toBe('Pet');
+  });
+
+  // 4. enum
+  test('includes enum values in field node', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/User' }, ctx());
+    const roleNode = nodes.find((n) => n.name === 'role')!;
+    expect(roleNode.enum).toEqual(['ADMIN', 'USER']);
+  });
+
+  // 5. 循环引用截断
+  test('marks circular ref fields as truncated', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/SelfRef' }, ctx());
+    const parentNode = nodes.find((n) => n.name === 'parent')!;
+    expect(parentNode.truncated).toBe(true);
+    expect(parentNode.refName).toBe('SelfRef');
+  });
+
+  // 6. maxDepth
+  test('marks object/array as truncated when hitting maxDepth', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/User' }, ctx({ maxDepth: 1 }));
+    // depth=0: User 本身 → 展开 properties → depth=1 到达 User 的各字段
+    // 但 User 的字段不会再递归了，因为 depth=1 >= maxDepth=1
+    // email 是 string，不截断；其他也是 primitive，不截断
+    // 只有 array / object 子字段会被截断
+    const orderNodes = buildSchemaFieldTree({ $ref: '#/components/schemas/Order' }, ctx({ maxDepth: 1 }));
+    const userNode = orderNodes.find((n) => n.name === 'user')!;
+    expect(userNode.truncated).toBe(true);
+  });
+
+  // 7. allOf
+  test('merges allOf in field tree', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/AllOfDemo' }, ctx());
+    const names = nodes.map((n) => n.name);
+    expect(names).toContain('id');
+    expect(names).toContain('name');
+    expect(names).toContain('email');
+    expect(names).toContain('role');
+    expect(names).toContain('avatar');
+  });
+
+  // 8. oneOf / anyOf
+  test('uses first resolvable branch in oneOf field tree', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/OneOfDemo' }, ctx());
+    const names = nodes.map((n) => n.name);
+    expect(names).toContain('id');
+    expect(names).toContain('name');
+  });
+
+  // 9. 空输入
+  test('returns empty array for undefined schema', () => {
+    const result = buildSchemaFieldTree(undefined, ctx());
+    expect(result).toEqual([]);
+  });
+
+  // 10. primitive 顶层
+  test('returns single node for top-level primitive schema', () => {
+    const result = buildSchemaFieldTree({ type: 'string', format: 'email' }, ctx());
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('string');
+    expect(result[0].format).toBe('email');
+    expect(result[0].name).toBe('');
+  });
+
+  // 11. array 顶层
+  test('returns items node for top-level array schema', () => {
+    const result = buildSchemaFieldTree({ type: 'array', items: { type: 'integer' } }, ctx());
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('array');
+    expect(result[0].children).toBeDefined();
+    expect(result[0].children![0].name).toBe('items');
+    expect(result[0].children![0].type).toBe('integer');
+  });
+
+  // 12. example / default / description 透传
+  test('passes through example, default, and description to field nodes', () => {
+    const nodes = buildSchemaFieldTree(
+      {
+        type: 'object',
+        properties: {
+          status: { type: 'string', example: 'active', default: 'pending', description: 'Current status' },
+        },
+      },
+      ctx(),
+    );
+    const statusNode = nodes[0];
+    expect(statusNode.example).toBe('active');
+    expect(statusNode.default).toBe('pending');
+    expect(statusNode.description).toBe('Current status');
+  });
+
+  // 13. readOnly / writeOnly / deprecated
+  test('passes through readOnly, writeOnly, and deprecated', () => {
+    const nodes = buildSchemaFieldTree(
+      {
+        type: 'object',
+        properties: {
+          createdAt: { type: 'string', readOnly: true },
+          password: { type: 'string', writeOnly: true },
+          oldField: { type: 'string', deprecated: true },
+        },
+      },
+      ctx(),
+    );
+    const createdNode = nodes.find((n) => n.name === 'createdAt')!;
+    expect(createdNode.readOnly).toBe(true);
+    const passwordNode = nodes.find((n) => n.name === 'password')!;
+    expect(passwordNode.writeOnly).toBe(true);
+    const oldNode = nodes.find((n) => n.name === 'oldField')!;
+    expect(oldNode.deprecated).toBe(true);
+  });
+
+  // 14. mutual circular reference
+  test('handles mutual circular reference in field tree', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/MutualA' }, ctx());
+    const bNode = nodes.find((n) => n.name === 'b')!;
+    expect(bNode.refName).toBe('MutualB');
+    // b 的 children 应包含 MutualB 的字段，其中 a 应被截断
+    if (bNode.children) {
+      const aInB = bNode.children.find((n) => n.name === 'a');
+      if (aInB) {
+        expect(aInB.truncated).toBe(true);
+      }
+    }
+  });
+
+  // 15. additionalProperties map
+  test('represents additionalProperties map as * field', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/FreeFormMap' }, ctx());
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe('*');
+    expect(nodes[0].type).toBe('string');
+  });
+});
+

--- a/knife4j-front/knife4j-core/src/debug/index.ts
+++ b/knife4j-front/knife4j-core/src/debug/index.ts
@@ -43,6 +43,7 @@ export {
   validateRequired,
   buildRequest,
   buildCurl,
+  buildUrlencodedBody,
 } from './requestBuilder';
 export type { BuildRequestOptions } from './requestBuilder';
 

--- a/knife4j-front/knife4j-core/src/debug/index.ts
+++ b/knife4j-front/knife4j-core/src/debug/index.ts
@@ -21,6 +21,7 @@ export type {
   BuiltRequest,
   ValidationError,
   SchemaResolveContext,
+  SchemaFieldNode,
   BuildSchemaExampleFn,
   BuildSchemaFieldTreeFn,
 } from './types';
@@ -45,6 +46,6 @@ export {
 } from './requestBuilder';
 export type { BuildRequestOptions } from './requestBuilder';
 
-// schemaExample (占位，TASK-030 完整实现)
+// schemaExample
 export { buildSchemaExample, buildSchemaFieldTree } from './schemaExample';
 

--- a/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
+++ b/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
@@ -8,13 +8,13 @@
  */
 
 import type {
-  OperationDebugModel,
-  DebugFormValues,
-  GlobalParamValues,
   AuthValues,
   BuiltRequest,
-  ValidationError,
+  DebugFormValues,
+  GlobalParamValues,
+  OperationDebugModel,
   ParamIn,
+  ValidationError,
 } from './types';
 
 // ─── URL 构建 ─────────────────────────────────────────
@@ -180,18 +180,40 @@ export function buildRequest(options: BuildRequestOptions): BuiltRequest {
     formValues.headerParams,   // 接口级最高
   );
 
-  // 4. Content-Type
+  // 4. Content-Type + body 构建
   const selectedContentType = formValues.selectedContentType
     ?? (debugModel.bodyContents.length > 0 ? debugModel.bodyContents[0].mediaType : '');
-  if (selectedContentType && !mergedHeaders['Content-Type']) {
-    mergedHeaders['Content-Type'] = selectedContentType;
+
+  const hasBody = !['GET', 'HEAD'].includes(method.toUpperCase());
+  let body: string | undefined = undefined;
+
+  if (hasBody) {
+    const category = debugModel.bodyContents.find(
+      (b) => b.mediaType === selectedContentType,
+    )?.category ?? 'raw';
+
+    if (category === 'urlencoded' && formValues.formFields) {
+      // application/x-www-form-urlencoded: 从 formFields 序列化
+      body = buildUrlencodedBody(formValues.formFields);
+      if (!mergedHeaders['Content-Type']) {
+        mergedHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
+      }
+    } else if (category === 'multipart') {
+      // multipart/form-data: 纯函数只拼文本字段；
+      // UI 层需要用 fileFields 构建 FormData 后替换 body
+      // 这里输出 JSON 占位（文本字段序列化），UI 层自行组装 FormData
+      body = JSON.stringify(formValues.formFields ?? {});
+      // multipart 不设 Content-Type（浏览器自动设 boundary）
+    } else {
+      // json / raw: 直接用 body 文本
+      body = formValues.body;
+      if (selectedContentType && !mergedHeaders['Content-Type']) {
+        mergedHeaders['Content-Type'] = selectedContentType;
+      }
+    }
   }
 
-  // 5. body
-  const hasBody = !['GET', 'HEAD'].includes(method.toUpperCase());
-  const body = hasBody ? formValues.body : undefined;
-
-  // 6. URL
+  // 5. URL
   const queryString = buildQueryString(mergedQuery);
   const url = `${baseUrl}${resolvedPath}${queryString ? `?${queryString}` : ''}`;
 
@@ -232,6 +254,20 @@ export function buildCurl(req: BuiltRequest): string {
   parts.push(`'${req.url}'`);
 
   return parts.join(' \\\n  ');
+}
+
+// ─── Urlencoded 序列化 ────────────────────────────────
+
+/**
+ * 将 formFields 序列化为 application/x-www-form-urlencoded 格式
+ */
+export function buildUrlencodedBody(fields: Record<string, string>): string {
+  const pairs: string[] = [];
+  for (const [name, value] of Object.entries(fields)) {
+    if (value === undefined || value === '') continue;
+    pairs.push(`${encodeURIComponent(name)}=${encodeURIComponent(value)}`);
+  }
+  return pairs.join('&');
 }
 
 // ─── 工具 ─────────────────────────────────────────────

--- a/knife4j-front/knife4j-core/src/debug/schemaExample.ts
+++ b/knife4j-front/knife4j-core/src/debug/schemaExample.ts
@@ -1,97 +1,478 @@
 /**
- * Schema 示例生成与字段树递归 — 占位实现
+ * Schema 示例值生成与字段树递归（TASK-030 完整实现）
  *
- * 完整递归逻辑在 TASK-030 实现。
- * 当前版本只处理基本类型和一层 object/array，不递归展开 $ref。
- * 目的：让 requestBuilder 和 OperationDebugModel 在 TASK-032 就能生成初始值。
+ * 同时兼容 OAS2（definitions）与 OAS3（components.schemas），通过 resolveRef 统一引用解析。
+ *
+ * 规则：
+ * - 优先级：example > default > enum[0] > 按 type/format 推断
+ * - 递归处理 $ref / object.properties / array.items
+ * - allOf：浅合并子 schema 的 properties / required
+ * - oneOf / anyOf：取第一个可解析分支
+ * - 循环引用：按引用链数组截断，重复命中同一 $ref 时返回占位值（example）或 null + truncated 标记（fieldTree）
+ * - maxDepth：默认 8，超过后截断
+ *
+ * 不依赖浏览器 API、不依赖框架。
  */
 
-import type { BuildSchemaExampleFn, BuildSchemaFieldTreeFn } from './types';
+import type {
+  BuildSchemaExampleFn,
+  BuildSchemaFieldTreeFn,
+  SchemaFieldNode,
+  SchemaResolveContext,
+} from './types';
+import { resolveRef } from './resolveRef';
 
-/**
- * 基本类型 → 示例值的映射
- */
-function primitiveExample(type?: string, format?: string, enumValues?: unknown[], example?: unknown, defaultValue?: unknown): unknown {
-  // 优先使用显式 example
-  if (example !== undefined) return example;
-  // 其次 default
-  if (defaultValue !== undefined) return defaultValue;
-  // enum 取第一个
-  if (enumValues && enumValues.length > 0) return enumValues[0];
+// ─── 常量 ─────────────────────────────────────────────
 
-  // 按 type + format 推断
+const DEFAULT_MAX_DEPTH = 8;
+
+/** 按 type + format 推断的 primitive 默认值 */
+function primitiveExample(
+  type: string | undefined,
+  format: string | undefined,
+): unknown {
   switch (type) {
     case 'string':
       switch (format) {
         case 'date': return '2024-01-01';
         case 'date-time': return '2024-01-01T00:00:00Z';
+        case 'time': return '00:00:00';
         case 'email': return 'user@example.com';
         case 'uri':
         case 'url': return 'https://example.com';
         case 'uuid': return '3fa85f64-5717-4562-b3fc-2c963f66afa6';
-        case 'binary': return '(binary)';
+        case 'hostname': return 'example.com';
+        case 'ipv4': return '127.0.0.1';
+        case 'ipv6': return '::1';
+        case 'binary': return '';
         case 'byte': return 'dGVzdA==';
-        default: return '';
+        case 'password': return 'password';
+        default: return 'string';
       }
     case 'integer':
+      switch (format) {
+        case 'int64': return 0;
+        case 'int32':
+        default: return 0;
+      }
     case 'number':
-      return 0;
+      switch (format) {
+        case 'float': return 0.0;
+        case 'double': return 0.0;
+        default: return 0;
+      }
     case 'boolean':
       return true;
     case 'file':
-      return '(file)';
-    default:
       return '';
+    case 'null':
+      return null;
+    default:
+      return null;
   }
 }
 
+/** type 归一化（null / undefined → 'unknown'） */
+function normalizeType(type: unknown): string {
+  if (Array.isArray(type)) {
+    // OAS 3.1 允许 type: ['string', 'null']
+    for (const t of type as unknown[]) {
+      if (typeof t === 'string' && t !== 'null') return t;
+    }
+    return 'unknown';
+  }
+  return typeof type === 'string' ? type : 'unknown';
+}
+
+// ─── 内部递归上下文 ───────────────────────────────────
+
 /**
- * 简易 schema → 示例值生成（不递归展开 $ref，仅处理基本类型和一层嵌套）
- *
- * TASK-030 会替换为完整实现（递归 $ref、allOf/oneOf/anyOf、循环引用检测、maxDepth）
+ * 递归上下文：在外部的 SchemaResolveContext 基础上追加引用链和深度
  */
-export const buildSchemaExample: BuildSchemaExampleFn = (
-  schema,
-  _ctx,
-): unknown => {
-  if (!schema) return undefined;
+interface InternalCtx {
+  doc: Record<string, unknown>;
+  maxDepth: number;
+  /** 当前递归深度（从 0 起） */
+  depth: number;
+  /** 当前引用链（用于检测循环），记录已访问的 $ref 字符串 */
+  refChain: string[];
+}
 
-  // $ref: 不递归，返回空对象占位
-  if (schema.$ref) return {};
+function toInternalCtx(ctx: SchemaResolveContext): InternalCtx {
+  return {
+    doc: ctx.doc,
+    maxDepth: ctx.maxDepth ?? DEFAULT_MAX_DEPTH,
+    depth: 0,
+    refChain: [],
+  };
+}
 
-  const type = schema.type as string | undefined;
-  const format = schema.format as string | undefined;
-  const enumVal = schema.enum as unknown[] | undefined;
-  const example = schema.example;
-  const defaultVal = schema.default;
+function childCtx(ctx: InternalCtx, pushedRef?: string): InternalCtx {
+  return {
+    doc: ctx.doc,
+    maxDepth: ctx.maxDepth,
+    depth: ctx.depth + 1,
+    refChain: pushedRef ? [...ctx.refChain, pushedRef] : ctx.refChain,
+  };
+}
 
-  if (type === 'array') {
-    const items = schema.items as Record<string, unknown> | undefined;
-    const itemExample = buildSchemaExample(items, _ctx);
-    return [itemExample ?? {}];
+// ─── allOf / oneOf / anyOf 合并 ───────────────────────
+
+/**
+ * 合并 allOf 所有子项：
+ * - type / format / enum / example / default 取第一个非 undefined
+ * - properties 浅合并
+ * - required 拼接去重
+ */
+function mergeAllOf(
+  parts: Record<string, unknown>[],
+  ctx: InternalCtx,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  const mergedProps: Record<string, Record<string, unknown>> = {};
+  const mergedRequired = new Set<string>();
+  let hasProps = false;
+  let hasRequired = false;
+
+  for (const part of parts) {
+    const resolved = deref(part, ctx);
+    if (!resolved) continue;
+    for (const [key, value] of Object.entries(resolved)) {
+      if (key === 'properties') {
+        hasProps = true;
+        if (value && typeof value === 'object') {
+          for (const [pname, pschema] of Object.entries(value as Record<string, unknown>)) {
+            mergedProps[pname] = pschema as Record<string, unknown>;
+          }
+        }
+      } else if (key === 'required') {
+        hasRequired = true;
+        if (Array.isArray(value)) {
+          for (const r of value) {
+            if (typeof r === 'string') mergedRequired.add(r);
+          }
+        }
+      } else if (merged[key] === undefined) {
+        merged[key] = value;
+      }
+    }
   }
 
-  if (type === 'object' || (!type && schema.properties)) {
-    const props = schema.properties as Record<string, Record<string, unknown>> | undefined;
-    if (!props) return {};
+  if (hasProps) merged.properties = mergedProps;
+  if (hasRequired) merged.required = Array.from(mergedRequired);
+  if (!merged.type && hasProps) merged.type = 'object';
+  return merged;
+}
+
+/** 解析 schema 的显式分支（$ref / allOf / oneOf / anyOf），返回归一化后的 schema */
+function resolveSchema(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): { schema: Record<string, unknown> | undefined; ref?: string; truncated: boolean } {
+  if (!schema) return { schema: undefined, truncated: false };
+
+  // 1. $ref
+  if (typeof schema.$ref === 'string') {
+    const ref = schema.$ref;
+    if (ctx.refChain.includes(ref)) {
+      return { schema: undefined, ref, truncated: true };
+    }
+    const resolved = resolveRef(ref, ctx.doc);
+    if (!resolved) return { schema: undefined, ref, truncated: false };
+    // 递归解析（解析后可能仍是 $ref / allOf 等）
+    const deeper = resolveSchema(resolved, {
+      ...ctx,
+      refChain: [...ctx.refChain, ref],
+    });
+    return { ...deeper, ref };
+  }
+
+  // 2. allOf：浅合并
+  if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
+    const merged = mergeAllOf(schema.allOf as Record<string, unknown>[], ctx);
+    // 若 allOf 外层还带 properties/required/type，进一步合并
+    const outer: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(schema)) {
+      if (k === 'allOf') continue;
+      outer[k] = v;
+    }
+    const combined = mergeAllOf([merged, outer], ctx);
+    return { schema: combined, truncated: false };
+  }
+
+  // 3. oneOf / anyOf：取第一个可解析分支
+  const union = (schema.oneOf ?? schema.anyOf) as Record<string, unknown>[] | undefined;
+  if (Array.isArray(union) && union.length > 0) {
+    for (const branch of union) {
+      const branchResolved = resolveSchema(branch, ctx);
+      if (branchResolved.schema) return branchResolved;
+    }
+    return { schema: undefined, truncated: false };
+  }
+
+  return { schema, truncated: false };
+}
+
+/** dereference：$ref → 解析后 schema（循环或失败时原样返回） */
+function deref(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): Record<string, unknown> | undefined {
+  if (!schema) return schema;
+  if (typeof schema.$ref !== 'string') return schema;
+  if (ctx.refChain.includes(schema.$ref)) return undefined;
+  const r = resolveRef(schema.$ref, ctx.doc);
+  return r;
+}
+
+/** 从 $ref 字符串中提取类型名（最后一段） */
+function refToName(ref: string | undefined): string | undefined {
+  if (!ref) return undefined;
+  const idx = ref.lastIndexOf('/');
+  return idx >= 0 ? ref.slice(idx + 1) : ref;
+}
+
+// ─── buildSchemaExample 实现 ──────────────────────────
+
+export const buildSchemaExample: BuildSchemaExampleFn = (schema, ctx) => {
+  return buildExampleInternal(schema, toInternalCtx(ctx));
+};
+
+function buildExampleInternal(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): unknown {
+  if (!schema) return null;
+
+  // maxDepth 保护
+  if (ctx.depth >= ctx.maxDepth) {
+    return null;
+  }
+
+  const { schema: resolved, truncated, ref } = resolveSchema(schema, ctx);
+  if (!resolved || truncated) {
+    // 循环引用或解析失败：给一个占位值（保持类型尽量合理）
+    if (schema.example !== undefined) return schema.example;
+    return null;
+  }
+
+  // 如果 resolveSchema 解析了 $ref，将 ref 加入后续递归的上下文
+  // 这样子属性递归时能检测到祖先 $ref，避免循环引用
+  const ctxWithRef = ref ? pushRefIfAny(ctx, ref) : ctx;
+
+  // 显式 example 覆盖一切（OpenAPI 官方约定）
+  if (resolved.example !== undefined) {
+    return resolved.example;
+  }
+  // default 次优
+  if (resolved.default !== undefined) {
+    return resolved.default;
+  }
+  // enum 第一个
+  if (Array.isArray(resolved.enum) && resolved.enum.length > 0) {
+    return resolved.enum[0];
+  }
+
+  const type = normalizeType(resolved.type);
+  const format = typeof resolved.format === 'string' ? resolved.format : undefined;
+
+  // array
+  if (type === 'array') {
+    const items = resolved.items as Record<string, unknown> | undefined;
+    if (!items) return [];
+    const child = buildExampleInternal(items, childCtx(ctxWithRef));
+    return child === null && type === 'array' ? [] : [child];
+  }
+
+  // object（type=object 或未声明但有 properties）
+  if (type === 'object' || (type === 'unknown' && (resolved.properties || resolved.additionalProperties))) {
+    const props = resolved.properties as Record<string, Record<string, unknown>> | undefined;
     const result: Record<string, unknown> = {};
-    for (const [key, propSchema] of Object.entries(props)) {
-      result[key] = buildSchemaExample(propSchema, _ctx);
+    if (props) {
+      for (const [key, propSchema] of Object.entries(props)) {
+        result[key] = buildExampleInternal(propSchema, childCtx(ctxWithRef));
+      }
+    } else if (resolved.additionalProperties && typeof resolved.additionalProperties === 'object') {
+      const addSchema = resolved.additionalProperties as Record<string, unknown>;
+      result['additionalProp1'] = buildExampleInternal(addSchema, childCtx(ctxWithRef));
     }
     return result;
   }
 
-  return primitiveExample(type, format, enumVal, example, defaultVal);
+  // primitive
+  return primitiveExample(type, format);
+}
+
+// ─── buildSchemaFieldTree 实现 ────────────────────────
+
+export const buildSchemaFieldTree: BuildSchemaFieldTreeFn = (schema, ctx) => {
+  return buildFieldTreeInternal(schema, toInternalCtx(ctx));
 };
 
-/**
- * 简易字段树生成（占位） — TASK-030 实现
- */
-export const buildSchemaFieldTree: BuildSchemaFieldTreeFn = (
-  _schema,
-  _ctx,
-): unknown => {
-  // 占位：返回空数组
-  return [];
-};
+function buildFieldTreeInternal(
+  schema: Record<string, unknown> | undefined,
+  ctx: InternalCtx,
+): SchemaFieldNode[] {
+  if (!schema) return [];
+  if (ctx.depth >= ctx.maxDepth) return [];
+
+  const { schema: resolved, ref, truncated } = resolveSchema(schema, ctx);
+  if (!resolved) return [];
+  if (truncated) return [];
+
+  const type = normalizeType(resolved.type);
+
+  // 顶层 object → 展开 properties
+  if (type === 'object' || (type === 'unknown' && resolved.properties)) {
+    return objectToFieldNodes(resolved, ctx, ref);
+  }
+
+  // 顶层 array → 返回 array 节点 + items 子节点
+  if (type === 'array') {
+    const items = resolved.items as Record<string, unknown> | undefined;
+    const arrayNode: SchemaFieldNode = {
+      name: '',
+      type: 'array',
+      format: typeof resolved.format === 'string' ? resolved.format : undefined,
+      required: false,
+      description: typeof resolved.description === 'string' ? resolved.description : undefined,
+      refName: refToName(ref),
+    };
+    if (items && ctx.depth + 1 < ctx.maxDepth) {
+      const itemNode = buildSingleFieldNode('items', items, false, childCtx(pushRefIfAny(ctx, ref)));
+      arrayNode.children = [itemNode];
+    }
+    return [arrayNode];
+  }
+
+  // 顶层 primitive → 返回单节点
+  return [
+    {
+      name: '',
+      type,
+      format: typeof resolved.format === 'string' ? resolved.format : undefined,
+      required: false,
+      description: typeof resolved.description === 'string' ? resolved.description : undefined,
+      default: resolved.default,
+      example: resolved.example,
+      enum: Array.isArray(resolved.enum) ? resolved.enum : undefined,
+      refName: refToName(ref),
+    },
+  ];
+}
+
+function objectToFieldNodes(
+  resolved: Record<string, unknown>,
+  ctx: InternalCtx,
+  parentRef?: string,
+): SchemaFieldNode[] {
+  const props = (resolved.properties as Record<string, Record<string, unknown>> | undefined) ?? {};
+  const requiredSet = new Set<string>(Array.isArray(resolved.required) ? (resolved.required as string[]) : []);
+
+  const nodes: SchemaFieldNode[] = [];
+  for (const [name, propSchema] of Object.entries(props)) {
+    nodes.push(buildSingleFieldNode(name, propSchema, requiredSet.has(name), pushRefIfAny(ctx, parentRef)));
+  }
+  // additionalProperties 作为伪字段（只有在没有 properties 时展示）
+  if (Object.keys(props).length === 0 && resolved.additionalProperties && typeof resolved.additionalProperties === 'object') {
+    nodes.push(buildSingleFieldNode('*', resolved.additionalProperties as Record<string, unknown>, false, ctx));
+  }
+  return nodes;
+}
+
+function pushRefIfAny(ctx: InternalCtx, ref: string | undefined): InternalCtx {
+  if (!ref) return ctx;
+  if (ctx.refChain.includes(ref)) return ctx;
+  return { ...ctx, refChain: [...ctx.refChain, ref] };
+}
+
+function buildSingleFieldNode(
+  name: string,
+  rawSchema: Record<string, unknown> | undefined,
+  required: boolean,
+  ctx: InternalCtx,
+): SchemaFieldNode {
+  if (!rawSchema) {
+    return { name, type: 'unknown', required };
+  }
+
+  // 循环检测：$ref 重复命中 → truncated
+  if (typeof rawSchema.$ref === 'string' && ctx.refChain.includes(rawSchema.$ref)) {
+    return {
+      name,
+      type: 'object',
+      refName: refToName(rawSchema.$ref),
+      required,
+      truncated: true,
+    };
+  }
+
+  const { schema: resolved, ref, truncated } = resolveSchema(rawSchema, ctx);
+  if (!resolved) {
+    return {
+      name,
+      type: 'unknown',
+      refName: refToName(ref),
+      required,
+      truncated,
+    };
+  }
+
+  const type = normalizeType(resolved.type);
+  const format = typeof resolved.format === 'string' ? resolved.format : undefined;
+  const description = typeof resolved.description === 'string' ? resolved.description : undefined;
+
+  const node: SchemaFieldNode = {
+    name,
+    type: type === 'unknown' && resolved.properties ? 'object' : type,
+    format,
+    required,
+    description,
+    default: resolved.default,
+    example: resolved.example,
+    enum: Array.isArray(resolved.enum) ? resolved.enum : undefined,
+    readOnly: typeof resolved.readOnly === 'boolean' ? resolved.readOnly : undefined,
+    writeOnly: typeof resolved.writeOnly === 'boolean' ? resolved.writeOnly : undefined,
+    deprecated: typeof resolved.deprecated === 'boolean' ? resolved.deprecated : undefined,
+    refName: refToName(ref),
+  };
+
+  // 子字段展开
+  // 达到 maxDepth 时只保留当前层，不再递归
+  if (ctx.depth + 1 >= ctx.maxDepth) {
+    if (type === 'object' || type === 'array') {
+      node.truncated = true;
+    }
+    return node;
+  }
+
+  const nextCtx = ref ? pushRefIfAny(ctx, ref) : ctx;
+  const deeperCtx = childCtx(nextCtx);
+
+  if (node.type === 'object') {
+    const children = objectToFieldNodes(resolved, deeperCtx, ref);
+    if (children.length > 0) node.children = children;
+  } else if (node.type === 'array') {
+    const items = resolved.items as Record<string, unknown> | undefined;
+    if (items) {
+      // 循环检测
+      if (typeof items.$ref === 'string' && deeperCtx.refChain.includes(items.$ref)) {
+        node.children = [
+          {
+            name: 'items',
+            type: 'object',
+            refName: refToName(items.$ref),
+            required: false,
+            truncated: true,
+          },
+        ];
+      } else {
+        const itemNode = buildSingleFieldNode('items', items, false, deeperCtx);
+        node.children = [itemNode];
+      }
+    }
+  }
+
+  return node;
+}
 

--- a/knife4j-front/knife4j-core/src/debug/types.ts
+++ b/knife4j-front/knife4j-core/src/debug/types.ts
@@ -135,7 +135,7 @@ export interface ValidationError {
   message: string;
 }
 
-// ─── Schema 示例/字段树 占位签名（TASK-030 实现） ──────
+// ─── Schema 示例/字段树 ───────────────────────────────
 
 /** schema 递归展开上下文 */
 export interface SchemaResolveContext {
@@ -145,9 +145,43 @@ export interface SchemaResolveContext {
   maxDepth?: number;
 }
 
+/** 字段树节点（用于文档展示） */
+export interface SchemaFieldNode {
+  /** 字段名；根节点或 array 元素可能为空字符串 */
+  name: string;
+  /** 归一化后的类型：string / integer / number / boolean / array / object / unknown */
+  type: string;
+  /** 格式修饰（如 int64 / date-time / binary） */
+  format?: string;
+  /** 是否必填（由父 schema 的 required 列表决定） */
+  required: boolean;
+  /** 描述 */
+  description?: string;
+  /** 默认值 */
+  default?: unknown;
+  /** 显式 example */
+  example?: unknown;
+  /** 枚举值 */
+  enum?: unknown[];
+  /** 是否只读 */
+  readOnly?: boolean;
+  /** 是否只写 */
+  writeOnly?: boolean;
+  /** 是否已废弃 */
+  deprecated?: boolean;
+  /** 当 type 为 $ref 指向的具名类型时，保留类型名便于 UI 提示 */
+  refName?: string;
+  /** 因循环引用或达到最大深度被截断时标记 */
+  truncated?: boolean;
+  /** 子字段（object.properties 或 array.items） */
+  children?: SchemaFieldNode[];
+}
+
 /**
- * 根据 schema 生成 JSON 示例值。
- * TASK-030 实现完整逻辑；当前为占位，只处理基本类型。
+ * 根据 schema 生成 JSON 示例值（纯数据）。
+ *
+ * 支持：$ref / object / array / enum / example / default / allOf（浅合并） /
+ * oneOf / anyOf（取第一个可解析分支） / 循环引用截断 / maxDepth 保护。
  */
 export type BuildSchemaExampleFn = (
   schema: Record<string, unknown> | undefined,
@@ -156,10 +190,12 @@ export type BuildSchemaExampleFn = (
 
 /**
  * 根据 schema 生成字段树（用于文档展示）。
- * TASK-030 实现；当前占位。
+ *
+ * 返回值为 SchemaFieldNode 数组：object 展开 properties，array 以伪节点暴露 items。
+ * 循环引用以 `truncated=true` 截断，不会死循环。
  */
 export type BuildSchemaFieldTreeFn = (
   schema: Record<string, unknown> | undefined,
   ctx: SchemaResolveContext,
-) => unknown;
+) => SchemaFieldNode[];
 

--- a/knife4j-front/knife4j-core/src/debug/types.ts
+++ b/knife4j-front/knife4j-core/src/debug/types.ts
@@ -87,9 +87,11 @@ export interface DebugFormValues {
   cookieParams: Record<string, string>;
   /** 当前选中的 content-type */
   selectedContentType?: string;
-  /** body 文本（已序列化） */
+  /** body 文本（已序列化，用于 json/raw 模式） */
   body?: string;
-  /** multipart 文件字段 { fieldName: File } — 由 UI 层处理，不进入纯函数 */
+  /** urlencoded / multipart 字段表单值 { fieldName: value }（纯字符串值） */
+  formFields?: Record<string, string>;
+  /** multipart 文件字段 { fieldName: File[] } — 由 UI 层处理，不序列化进纯函数 */
   fileFields?: Record<string, unknown>;
 }
 

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -92,6 +92,14 @@ const enUS = {
   'apiDebug.json.array': 'array',
   'apiDebug.json.object': 'object',
 
+  // ApiDebug — Body Tab
+  'apiDebug.body.beautify': 'Beautify',
+  'apiDebug.body.file': 'File',
+  'apiDebug.body.selectFile': 'Select File',
+  'apiDebug.body.file.placeholder': 'File path or leave empty to select file',
+  'apiDebug.body.raw': 'Raw',
+  'apiDebug.body.contentType': 'Content-Type',
+
   // Authorize
   'auth.title': 'Authorization',
   'auth.tab.bearer': 'Bearer Token',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -92,6 +92,14 @@ const zhCN = {
   'apiDebug.json.array': '数组',
   'apiDebug.json.object': '对象',
 
+  // ApiDebug — Body Tab
+  'apiDebug.body.beautify': '格式化',
+  'apiDebug.body.file': '文件',
+  'apiDebug.body.selectFile': '选择文件',
+  'apiDebug.body.file.placeholder': '文件路径或留空后选择文件',
+  'apiDebug.body.raw': '原始文本',
+  'apiDebug.body.contentType': 'Content-Type',
+
   // Authorize
   'auth.title': 'Authorization',
   'auth.tab.bearer': 'Bearer Token',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -1,18 +1,29 @@
-import { useEffect, useMemo, useState } from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {
-  Alert, Button, Divider, Input, InputNumber, Select, Space, Spin, Switch, Table, Tabs, Tag, Tooltip, Typography,
+    Alert,
+    Button,
+    Divider,
+    Input,
+    InputNumber,
+    Radio,
+    Select,
+    Space,
+    Spin,
+    Switch,
+    Table,
+    Tabs,
+    Tag,
+    Tooltip,
+    Typography,
+    Upload,
 } from 'antd';
-import { SendOutlined } from '@ant-design/icons';
-import type { ColumnsType } from 'antd/es/table';
-import { useTranslation } from 'react-i18next';
-import {
-  buildOperationDebugModel,
-  buildRequest as coreBuildRequest,
-  buildCurl,
-  validateRequired,
-} from 'knife4j-core';
-import type { DebugParam, OperationDebugModel, DebugFormValues, BuiltRequest } from 'knife4j-core';
-import { OperationModeTabs, useCurrentOperation } from './useCurrentOperation';
+import {SendOutlined, UploadOutlined} from '@ant-design/icons';
+import type {ColumnsType} from 'antd/es/table';
+import type {UploadFile} from 'antd/es/upload/interface';
+import {useTranslation} from 'react-i18next';
+import type {BodyContent, BuiltRequest, DebugFormValues, DebugParam, OperationDebugModel} from 'knife4j-core';
+import {buildCurl, buildOperationDebugModel, buildRequest as coreBuildRequest, validateRequired,} from 'knife4j-core';
+import {OperationModeTabs, useCurrentOperation} from './useCurrentOperation';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
@@ -89,6 +100,84 @@ function stringify(value: unknown, type: string): string {
   }
   return String(value);
 }
+
+// ─── Schema property → field row for urlencoded / multipart ──────
+
+interface SchemaFieldRow {
+  name: string;
+  type: string;
+  format?: string;
+  required: boolean;
+  description?: string;
+  default?: unknown;
+  example?: unknown;
+  enum?: unknown[];
+  isFile: boolean;
+}
+
+/**
+ * 从 BodyContent 的 schema.properties 提取字段行
+ */
+function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
+  const schema = bodyContent.schema;
+  if (!schema || schema.type !== 'object' || !schema.properties) return [];
+
+  const props = schema.properties as Record<string, Record<string, unknown>>;
+  const requiredSet = new Set<string>(Array.isArray(schema.required) ? schema.required as string[] : []);
+  const fileFields = new Set(bodyContent.fileFields ?? []);
+
+  return Object.entries(props).map(([name, prop]) => {
+    const t = (prop.type as string) ?? 'string';
+    const isFile = fileFields.has(name)
+      || t === 'file'
+      || (t === 'string' && prop.format === 'binary')
+      || (t === 'string' && prop.format === 'base64');
+
+    return {
+      name,
+      type: isFile ? 'file' : t,
+      format: typeof prop.format === 'string' ? prop.format : undefined,
+      required: requiredSet.has(name),
+      description: typeof prop.description === 'string' ? prop.description : undefined,
+      default: prop.default,
+      example: prop.example,
+      enum: Array.isArray(prop.enum) ? prop.enum : undefined,
+      isFile,
+    };
+  });
+}
+
+/** 根据 SchemaFieldRow 的类型推断初始值 */
+function initialFieldValue(field: SchemaFieldRow): string {
+  if (field.isFile) return '';
+  if (field.example !== undefined && field.example !== null) return String(field.example);
+  if (field.default !== undefined && field.default !== null) return String(field.default);
+  if (field.enum && field.enum.length > 0) return String(field.enum[0]);
+  if (field.type === 'boolean') return 'true';
+  if (field.type === 'integer' || field.type === 'number') return '0';
+  return '';
+}
+
+// ─── Raw mode types ───────────────────────────────────
+
+const RAW_MODES = [
+  { value: 'text', label: 'Text' },
+  { value: 'json', label: 'JSON' },
+  { value: 'javascript', label: 'JavaScript' },
+  { value: 'xml', label: 'XML' },
+  { value: 'html', label: 'HTML' },
+] as const;
+
+type RawMode = typeof RAW_MODES[number]['value'];
+
+/** raw mode → Content-Type 映射 */
+const RAW_CONTENT_TYPES: Record<RawMode, string> = {
+  text: 'text/plain',
+  json: 'application/json',
+  javascript: 'application/javascript',
+  xml: 'application/xml',
+  html: 'text/html',
+};
 
 // ─── Param input dispatcher ───────────────────────────
 
@@ -171,6 +260,79 @@ function ParamInput({ param, value, onChange }: ParamInputProps) {
   );
 }
 
+// ─── Schema field input (for urlencoded / multipart) ──
+
+interface SchemaFieldInputProps {
+  field: SchemaFieldRow;
+  value: string;
+  onChange: (next: string) => void;
+}
+
+function SchemaFieldInput({ field, value, onChange }: SchemaFieldInputProps) {
+  const { t } = useTranslation();
+
+  // file → Upload
+  if (field.isFile) {
+    return (
+      <Input
+        size="small"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={t('apiDebug.body.file.placeholder')}
+      />
+    );
+  }
+
+  // enum → Select
+  if (field.enum && field.enum.length > 0) {
+    return (
+      <Select
+        size="small"
+        value={value || undefined}
+        onChange={onChange}
+        allowClear
+        options={field.enum.map((item) => ({ value: String(item), label: String(item) }))}
+        style={{ width: '100%' }}
+      />
+    );
+  }
+
+  // boolean → Switch
+  if (field.type === 'boolean') {
+    const checked = value === 'true';
+    return (
+      <Space size="small">
+        <Switch size="small" checked={checked} onChange={(next) => onChange(next ? 'true' : 'false')} />
+        <Text type="secondary" style={{ fontSize: 12 }}>{checked ? 'true' : 'false'}</Text>
+      </Space>
+    );
+  }
+
+  // integer / number
+  if (field.type === 'integer' || field.type === 'number') {
+    const numValue = value === '' ? undefined : Number(value);
+    return (
+      <InputNumber
+        size="small"
+        value={Number.isFinite(numValue) ? numValue : undefined}
+        onChange={(next) => onChange(next === null || next === undefined ? '' : String(next))}
+        style={{ width: '100%' }}
+        step={field.type === 'integer' ? 1 : undefined}
+      />
+    );
+  }
+
+  // default: Input
+  return (
+    <Input
+      size="small"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={field.description ?? ''}
+    />
+  );
+}
+
 // ─── Name cell（附带 deprecated/readOnly 标记）────────
 
 function ParamNameCell({ param }: { param: DebugParam }) {
@@ -203,6 +365,372 @@ function ParamNameCell({ param }: { param: DebugParam }) {
   );
 }
 
+// ─── Body Tab 组件 ────────────────────────────────────
+
+interface BodyTabProps {
+  debugModel: OperationDebugModel;
+  body: string;
+  setBody: (v: string) => void;
+  selectedContentType: string;
+  setSelectedContentType: (v: string) => void;
+  formFields: Record<string, string>;
+  setFormFields: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  fileFieldsRef: React.MutableRefObject<Record<string, File[]>>;
+  rawMode: RawMode;
+  setRawMode: (v: RawMode) => void;
+}
+
+function BodyTab({
+  debugModel,
+  body,
+  setBody,
+  selectedContentType,
+  setSelectedContentType,
+  formFields,
+  setFormFields,
+  fileFieldsRef,
+  rawMode,
+  setRawMode,
+}: BodyTabProps) {
+  const { t } = useTranslation();
+  const bodyContents = debugModel.bodyContents;
+
+  if (bodyContents.length === 0) {
+    return <Alert type="info" message={t('apiDebug.noBody')} showIcon />;
+  }
+
+  // 当前选中的 BodyContent
+  const currentBody = bodyContents.find((b) => b.mediaType === selectedContentType) ?? bodyContents[0];
+  const category = currentBody.category;
+
+  // ── 切换 content-type 时重置 formFields ──
+  const handleContentTypeChange = (mediaType: string) => {
+    setSelectedContentType(mediaType);
+    const target = bodyContents.find((b) => b.mediaType === mediaType);
+    if (target) {
+      // 初始化 formFields
+      const fields = extractSchemaFields(target);
+      const initial: Record<string, string> = {};
+      for (const f of fields) {
+        initial[f.name] = initialFieldValue(f);
+      }
+      setFormFields(initial);
+      // 重置 fileFields
+      fileFieldsRef.current = {};
+
+      // 更新 body 文本
+      if (target.category === 'json') {
+        setBody(target.exampleValue ?? '');
+      } else if (target.category === 'raw') {
+        setBody(target.exampleValue ?? '');
+      }
+    }
+  };
+
+  // ── JSON Beautify ──
+  const handleBeautify = () => {
+    try {
+      const parsed = JSON.parse(body);
+      setBody(JSON.stringify(parsed, null, 2));
+    } catch {
+      // 无效 JSON，不处理
+    }
+  };
+
+  return (
+    <div>
+      {/* Content-Type 选择 */}
+      {bodyContents.length > 1 && (
+        <div style={{ marginBottom: 12 }}>
+          <Radio.Group
+            value={selectedContentType}
+            onChange={(e) => handleContentTypeChange(e.target.value)}
+            size="small"
+          >
+            {bodyContents.map((bc) => (
+              <Radio.Button key={bc.mediaType} value={bc.mediaType}>
+                {bc.category === 'json' ? 'JSON' :
+                 bc.category === 'urlencoded' ? 'x-www-form-urlencoded' :
+                 bc.category === 'multipart' ? 'multipart/form-data' :
+                 'raw'}
+              </Radio.Button>
+            ))}
+          </Radio.Group>
+        </div>
+      )}
+
+      {/* 根据分类渲染不同的表单 */}
+      {category === 'json' && (
+        <div>
+          <div style={{ marginBottom: 4, textAlign: 'right' }}>
+            <Button size="small" onClick={handleBeautify}>{t('apiDebug.body.beautify')}</Button>
+          </div>
+          <TextArea
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            rows={10}
+            style={{ fontFamily: 'monospace', fontSize: 13 }}
+            placeholder={`${currentBody.mediaType} request body`}
+          />
+        </div>
+      )}
+
+      {category === 'urlencoded' && (
+        <UrlencodedForm
+          bodyContent={currentBody}
+          formFields={formFields}
+          setFormFields={setFormFields}
+        />
+      )}
+
+      {category === 'multipart' && (
+        <MultipartForm
+          bodyContent={currentBody}
+          formFields={formFields}
+          setFormFields={setFormFields}
+          fileFieldsRef={fileFieldsRef}
+        />
+      )}
+
+      {category === 'raw' && (
+        <RawEditor
+          body={body}
+          setBody={setBody}
+          rawMode={rawMode}
+          setRawMode={setRawMode}
+          onBeautify={handleBeautify}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Urlencoded Form ──────────────────────────────────
+
+interface UrlencodedFormProps {
+  bodyContent: BodyContent;
+  formFields: Record<string, string>;
+  setFormFields: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+}
+
+function UrlencodedForm({ bodyContent, formFields, setFormFields }: UrlencodedFormProps) {
+  const { t } = useTranslation();
+  const fields = useMemo(() => extractSchemaFields(bodyContent), [bodyContent]);
+
+  const updateField = (name: string, value: string) => {
+    setFormFields((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const columns: ColumnsType<SchemaFieldRow> = [
+    {
+      title: t('apiDebug.col.paramName'),
+      dataIndex: 'name',
+      key: 'name',
+      width: 200,
+      render: (_value: string, record: SchemaFieldRow) => (
+        <Space size={4}>
+          <Text code>{record.name}</Text>
+          {record.required && <Tag color="red" style={{ marginInlineEnd: 0 }}>{t('apiDebug.tag.required')}</Tag>}
+        </Space>
+      ),
+    },
+    {
+      title: t('apiDebug.col.type'),
+      dataIndex: 'type',
+      key: 'type',
+      width: 100,
+      render: (_value: string, record: SchemaFieldRow) => (
+        <Space size={2} direction="vertical" style={{ lineHeight: 1.3 }}>
+          <Text code style={{ fontSize: 12 }}>{record.type}</Text>
+          {record.format && <Text type="secondary" style={{ fontSize: 11 }}>{record.format}</Text>}
+        </Space>
+      ),
+    },
+    {
+      title: t('apiDebug.col.value'),
+      key: 'value',
+      render: (_value, record: SchemaFieldRow) => (
+        <SchemaFieldInput
+          field={record}
+          value={formFields[record.name] ?? ''}
+          onChange={(next) => updateField(record.name, next)}
+        />
+      ),
+    },
+    {
+      title: t('apiDebug.col.description'),
+      key: 'description',
+      width: 240,
+      render: (_value, record: SchemaFieldRow) => (
+        <Space size={2} direction="vertical" style={{ lineHeight: 1.35, fontSize: 12 }}>
+          {record.description && <Text style={{ fontSize: 12 }}>{record.description}</Text>}
+          {record.default !== undefined && (
+            <Text type="secondary" style={{ fontSize: 11 }}>
+              {t('apiDebug.desc.default')}<Text code style={{ fontSize: 11 }}>{String(record.default)}</Text>
+            </Text>
+          )}
+          {record.example !== undefined && (
+            <Text type="secondary" style={{ fontSize: 11 }}>
+              {t('apiDebug.desc.example')}<Text code style={{ fontSize: 11 }}>{String(record.example)}</Text>
+            </Text>
+          )}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      size="small"
+      dataSource={fields}
+      columns={columns}
+      pagination={false}
+      rowKey="name"
+    />
+  );
+}
+
+// ─── Multipart Form ───────────────────────────────────
+
+interface MultipartFormProps {
+  bodyContent: BodyContent;
+  formFields: Record<string, string>;
+  setFormFields: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  fileFieldsRef: React.MutableRefObject<Record<string, File[]>>;
+}
+
+function MultipartForm({ bodyContent, formFields, setFormFields, fileFieldsRef }: MultipartFormProps) {
+  const { t } = useTranslation();
+  const [fileListMap, setFileListMap] = useState<Record<string, UploadFile[]>>({});
+  const fields = useMemo(() => extractSchemaFields(bodyContent), [bodyContent]);
+
+  const updateField = (name: string, value: string) => {
+    setFormFields((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleFileChange = (name: string, info: { fileList: UploadFile[] }) => {
+    setFileListMap((prev) => ({ ...prev, [name]: info.fileList }));
+    // 提取原始 File 对象存入 ref（originFileObj 是 RcFile，extends File）
+    const files: File[] = [];
+    for (const f of info.fileList) {
+      if (f.originFileObj) files.push(f.originFileObj);
+    }
+    fileFieldsRef.current[name] = files;
+  };
+
+  const columns: ColumnsType<SchemaFieldRow> = [
+    {
+      title: t('apiDebug.col.paramName'),
+      dataIndex: 'name',
+      key: 'name',
+      width: 200,
+      render: (_value: string, record: SchemaFieldRow) => (
+        <Space size={4}>
+          <Text code>{record.name}</Text>
+          {record.required && <Tag color="red" style={{ marginInlineEnd: 0 }}>{t('apiDebug.tag.required')}</Tag>}
+          {record.isFile && <Tag color="blue" style={{ marginInlineEnd: 0 }}>{t('apiDebug.body.file')}</Tag>}
+        </Space>
+      ),
+    },
+    {
+      title: t('apiDebug.col.type'),
+      dataIndex: 'type',
+      key: 'type',
+      width: 80,
+      render: (_value: string, record: SchemaFieldRow) => (
+        <Text code style={{ fontSize: 12 }}>{record.isFile ? 'file' : record.type}</Text>
+      ),
+    },
+    {
+      title: t('apiDebug.col.value'),
+      key: 'value',
+      render: (_value, record: SchemaFieldRow) => {
+        if (record.isFile) {
+          return (
+            <Upload
+              beforeUpload={() => false} // 阻止自动上传
+              multiple
+              fileList={fileListMap[record.name] ?? []}
+              onChange={(info) => handleFileChange(record.name, info)}
+            >
+              <Button size="small" icon={<UploadOutlined />}>{t('apiDebug.body.selectFile')}</Button>
+            </Upload>
+          );
+        }
+        return (
+          <SchemaFieldInput
+            field={record}
+            value={formFields[record.name] ?? ''}
+            onChange={(next) => updateField(record.name, next)}
+          />
+        );
+      },
+    },
+    {
+      title: t('apiDebug.col.description'),
+      key: 'description',
+      width: 240,
+      render: (_value, record: SchemaFieldRow) => (
+        <Space size={2} direction="vertical" style={{ lineHeight: 1.35, fontSize: 12 }}>
+          {record.description && <Text style={{ fontSize: 12 }}>{record.description}</Text>}
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      size="small"
+      dataSource={fields}
+      columns={columns}
+      pagination={false}
+      rowKey="name"
+    />
+  );
+}
+
+// ─── Raw Editor ───────────────────────────────────────
+
+interface RawEditorProps {
+  body: string;
+  setBody: (v: string) => void;
+  rawMode: RawMode;
+  setRawMode: (v: RawMode) => void;
+  onBeautify: () => void;
+}
+
+function RawEditor({ body, setBody, rawMode, setRawMode, onBeautify }: RawEditorProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Radio.Group
+          value={rawMode}
+          onChange={(e) => setRawMode(e.target.value)}
+          size="small"
+          optionType="button"
+          buttonStyle="solid"
+        >
+          {RAW_MODES.map((m) => (
+            <Radio.Button key={m.value} value={m.value}>{m.label}</Radio.Button>
+          ))}
+        </Radio.Group>
+        {rawMode === 'json' && (
+          <Button size="small" onClick={onBeautify}>{t('apiDebug.body.beautify')}</Button>
+        )}
+      </div>
+      <TextArea
+        value={body}
+        onChange={(event) => setBody(event.target.value)}
+        rows={10}
+        style={{ fontFamily: 'monospace', fontSize: 13 }}
+        placeholder={`${RAW_CONTENT_TYPES[rawMode]} request body`}
+      />
+    </div>
+  );
+}
+
 // ─── 主组件 ────────────────────────────────────────────
 
 export default function ApiDebug() {
@@ -218,6 +746,12 @@ export default function ApiDebug() {
   const [response, setResponse] = useState<DebugResponse | null>(null);
   const [curlCommand, setCurlCommand] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // ── requestBody 多内容类型状态 ──
+  const [selectedContentType, setSelectedContentType] = useState('');
+  const [formFields, setFormFields] = useState<Record<string, string>>({});
+  const fileFieldsRef = useRef<Record<string, File[]>>({});
+  const [rawMode, setRawMode] = useState<RawMode>('text');
 
   useEffect(() => {
     if (!operation || !swaggerDoc) return;
@@ -241,9 +775,38 @@ export default function ApiDebug() {
     }
     setParamValues(initial);
 
-    // body 初始值：取第一个 bodyContent 的示例
+    // body 初始值
     const firstBody = model.bodyContents[0];
+    const firstMediaType = firstBody?.mediaType ?? '';
+    setSelectedContentType(firstMediaType);
     setBody(firstBody?.exampleValue ?? '');
+
+    // 初始化 formFields
+    if (firstBody && (firstBody.category === 'urlencoded' || firstBody.category === 'multipart')) {
+      const fields = extractSchemaFields(firstBody);
+      const initialForm: Record<string, string> = {};
+      for (const f of fields) {
+        initialForm[f.name] = initialFieldValue(f);
+      }
+      setFormFields(initialForm);
+    } else {
+      setFormFields({});
+    }
+
+    // 重置文件字段
+    fileFieldsRef.current = {};
+
+    // raw mode 初始推断
+    if (firstBody?.category === 'raw') {
+      if (firstMediaType.includes('json')) setRawMode('json');
+      else if (firstMediaType.includes('xml')) setRawMode('xml');
+      else if (firstMediaType.includes('html')) setRawMode('html');
+      else if (firstMediaType.includes('javascript')) setRawMode('javascript');
+      else setRawMode('text');
+    } else {
+      setRawMode('text');
+    }
+
     setResponse(null);
     setError(null);
     setCurlCommand(null);
@@ -331,13 +894,33 @@ export default function ApiDebug() {
     return result;
   };
 
-  const collectFormValues = (): DebugFormValues => ({
-    pathParams: collectForIn(debugModel.pathParams),
-    queryParams: collectForIn(debugModel.queryParams),
-    headerParams: collectForIn(debugModel.headerParams),
-    cookieParams: collectForIn(debugModel.cookieParams),
-    body,
-  });
+  /** 获取当前选中的 body content 分类 */
+  const getCurrentCategory = (): string => {
+    const bc = debugModel.bodyContents.find((b) => b.mediaType === selectedContentType);
+    return bc?.category ?? 'raw';
+  };
+
+  /** 获取最终 effective content-type */
+  const getEffectiveContentType = (): string => {
+    if (selectedContentType) return selectedContentType;
+    // raw mode fallback
+    if (getCurrentCategory() === 'raw') return RAW_CONTENT_TYPES[rawMode];
+    return debugModel.bodyContents[0]?.mediaType ?? '';
+  };
+
+  const collectFormValues = (): DebugFormValues => {
+    const category = getCurrentCategory();
+    return {
+      pathParams: collectForIn(debugModel.pathParams),
+      queryParams: collectForIn(debugModel.queryParams),
+      headerParams: collectForIn(debugModel.headerParams),
+      cookieParams: collectForIn(debugModel.cookieParams),
+      selectedContentType: getEffectiveContentType(),
+      body: (category === 'json' || category === 'raw') ? body : undefined,
+      formFields: (category === 'urlencoded' || category === 'multipart') ? formFields : undefined,
+      fileFields: category === 'multipart' ? fileFieldsRef.current : undefined,
+    };
+  };
 
   const handleSend = async () => {
     if (!debugModel) return;
@@ -360,16 +943,49 @@ export default function ApiDebug() {
       debugModel,
       formValues,
     });
-    setCurlCommand(buildCurl(built));
+
+    // multipart 场景：需要手动构建 FormData（requestBuilder 只处理文本字段）
+    const category = getCurrentCategory();
+    const isMultipart = category === 'multipart';
+
+    // curl 命令（multipart 不含文件内容，给提示即可）
+    if (!isMultipart) {
+      setCurlCommand(buildCurl(built));
+    } else {
+      setCurlCommand(null);
+    }
 
     setLoading(true);
     setResponse(null);
     const start = Date.now();
     try {
       const init: RequestInit = { method: built.method, headers: built.headers };
-      if (built.body !== undefined && built.body !== '') {
-        init.body = built.body;
+
+      if (isMultipart) {
+        // 构建 FormData
+        const fd = new FormData();
+        // 添加普通字段
+        for (const [name, value] of Object.entries(formFields)) {
+          if (value !== undefined && value !== '') {
+            fd.append(name, value);
+          }
+        }
+        // 添加文件字段
+        const files = fileFieldsRef.current;
+        for (const [name, fileList] of Object.entries(files)) {
+          for (const file of fileList) {
+            fd.append(name, file);
+          }
+        }
+        init.body = fd;
+        // 不设 Content-Type，让浏览器自动设 boundary
+        delete (init.headers as Record<string, string>)['Content-Type'];
+      } else {
+        if (built.body !== undefined && built.body !== '') {
+          init.body = built.body;
+        }
       }
+
       const res = await fetch(built.url, init);
       const responseHeaders: Record<string, string> = {};
       res.headers.forEach((value, key) => { responseHeaders[key] = value; });
@@ -390,6 +1006,11 @@ export default function ApiDebug() {
       return response.body;
     }
   };
+
+  // body tab 的标签含当前 content-type
+  const bodyLabel = debugModel.bodyContents.length > 0
+    ? `${t('apiDebug.tab.body')} (${selectedContentType || debugModel.bodyContents[0].mediaType})`
+    : t('apiDebug.tab.body');
 
   const tabItems = [
     {
@@ -437,20 +1058,20 @@ export default function ApiDebug() {
     },
     {
       key: 'body',
-      label: `${t('apiDebug.tab.body')}${debugModel.bodyContents.length > 0 ? ` (${debugModel.bodyContents[0].mediaType})` : ''}`,
+      label: bodyLabel,
       disabled: debugModel.bodyContents.length === 0,
       children: (
-        <TextArea
-          value={body}
-          onChange={(event) => setBody(event.target.value)}
-          rows={10}
-          style={{ fontFamily: 'monospace', fontSize: 13 }}
-          placeholder={
-            debugModel.bodyContents.length > 0
-              ? `${debugModel.bodyContents[0].mediaType} request body`
-              : t('apiDebug.noBody')
-          }
-          disabled={debugModel.bodyContents.length === 0}
+        <BodyTab
+          debugModel={debugModel}
+          body={body}
+          setBody={setBody}
+          selectedContentType={selectedContentType}
+          setSelectedContentType={setSelectedContentType}
+          formFields={formFields}
+          setFormFields={setFormFields}
+          fileFieldsRef={fileFieldsRef}
+          rawMode={rawMode}
+          setRawMode={setRawMode}
         />
       ),
     },


### PR DESCRIPTION
## TASK-027 实现：requestBody 多内容类型表单

对标 Vue2 的 `initBodyParameter` / `debugSendFormRequest` / `debugSendRawRequest`，在 React 调试页支持 4 种 Content-Type。

### 变更内容

**`ApiDebug.tsx` — 重写 Body Tab**
- 新增 `BodyTab` 组件，根据 `BodyContent.category` 分类渲染
- `Radio.Group` 切换 mediaType（多 content-type 时显示）
- 新增 `selectedContentType` / `formFields` / `fileFieldsRef` / `rawMode` 状态

**四种内容类型**
1. **JSON** — 可编辑 TextArea + Beautify 按钮（复用 `buildSchemaExample` 生成的 `exampleValue`）
2. **x-www-form-urlencoded** — 从 `schema.properties` 提取字段，参数表格渲染（`UrlencodedForm` + `SchemaFieldInput`）
3. **multipart/form-data** — 普通字段表单 + antd `Upload` 文件上传（支持多文件，文件字段以 `fileFieldsRef` 保存 `File[]`）
4. **raw** — Text / JSON / JavaScript / XML / HTML 五种子模式切换 + Beautify

**发送逻辑**
- `collectFormValues` 透传 `selectedContentType` / `formFields` / `fileFields` 给 requestBuilder
- `handleSend` 对 multipart 场景手动构建 `FormData`（浏览器自动设置 boundary）
- 非 multipart 沿用 `buildCurl` 输出 cURL 命令

**`knife4j-core` 配套**
- `DebugFormValues` 新增 `formFields` / `fileFields`
- `requestBuilder` 支持 urlencoded 序列化（新增 `buildUrlencodedBody`）
- multipart 时由 UI 层接管 body，纯函数不设 Content-Type
- `index.ts` 导出 `buildUrlencodedBody`

**i18n**
- 中英文各补全 7 个新文案（`body.beautify` / `body.file` / `body.selectFile` / `body.contentType` 等）

### 验证

- `knife4j-core`: 12 test suites, 121 tests pass
- `knife4j-ui-react`: `npm run build` 通过（tsc + vite build, dist ~1.44MB）

### 相关任务

- 依赖：TASK-026（调试参数表单）、TASK-030（schema 示例生成）已合并
- 解锁：TASK-028（请求预览 + curl 复制）可继续推进

