### PR TITLE
feat(debug): merge auth & global params in requestBuilder with source tags (TASK-031)

### DIFF
--- a/knife4j-front/knife4j-core/src/__tests__/debug/requestBuilder.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/requestBuilder.test.ts
@@ -101,26 +101,26 @@ describe('mergeHeaders', () => {
 describe('authToHeaders', () => {
   test('bearer token', () => {
     const result = authToHeaders({ bearerToken: 'mytoken' });
-    expect(result['Authorization']).toBe('Bearer mytoken');
+    expect(result.headers['Authorization']).toBe('Bearer mytoken');
   });
 
   test('basic credentials', () => {
     const result = authToHeaders({ basicCredentials: 'dXNlcjpwYXNz' });
-    expect(result['Authorization']).toBe('Basic dXNlcjpwYXNz');
+    expect(result.headers['Authorization']).toBe('Basic dXNlcjpwYXNz');
   });
 
   test('basic overrides bearer when both present', () => {
     const result = authToHeaders({ bearerToken: 'tok', basicCredentials: 'dXNlcjpwYXNz' });
-    expect(result['Authorization']).toBe('Basic dXNlcjpwYXNz');
+    expect(result.headers['Authorization']).toBe('Basic dXNlcjpwYXNz');
   });
 
   test('api keys', () => {
     const result = authToHeaders({ apiKeys: { 'X-API-Key': 'key123' } });
-    expect(result['X-API-Key']).toBe('key123');
+    expect(result.headers['X-API-Key']).toBe('key123');
   });
 
   test('empty auth returns empty headers', () => {
-    expect(authToHeaders(undefined)).toEqual({});
+    expect(authToHeaders(undefined)).toEqual({ headers: {}, queries: {} });
   });
 });
 
@@ -477,4 +477,164 @@ describe('buildCurl', () => {
     expect(curl).toContain('X-Trace: 1');
   });
 });
+// ─── sourceMap 追踪测试 (TASK-031) ─────────────────────
 
+describe('buildRequest sourceMap', () => {
+  const baseModel: OperationDebugModel = {
+    pathParams: [],
+    queryParams: [],
+    headerParams: [],
+    cookieParams: [],
+    bodyContents: [],
+    bodyRequired: false,
+  };
+
+  const baseForm: DebugFormValues = {
+    pathParams: {},
+    queryParams: {},
+    headerParams: {},
+    cookieParams: {},
+  };
+
+  test('no sourceMap when auth and globalParams are undefined', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: baseForm,
+    });
+    expect(result.sourceMap).toBeUndefined();
+  });
+
+  test('sourceMap generated when auth is provided', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: baseForm,
+      auth: { bearerToken: 'mytoken' },
+    });
+    expect(result.sourceMap).toBeDefined();
+    expect(result.sourceMap!.headers['Authorization']).toBe('auth');
+    expect(result.headers['Authorization']).toBe('Bearer mytoken');
+  });
+
+  test('sourceMap generated when globalParams is provided', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: baseForm,
+      globalParams: { headers: { 'X-Global': 'val' }, queries: { gq: '1' } },
+    });
+    expect(result.sourceMap).toBeDefined();
+    expect(result.sourceMap!.headers['X-Global']).toBe('global');
+    expect(result.sourceMap!.query['gq']).toBe('global');
+  });
+
+  test('interface overrides global and auth in sourceMap', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: {
+        ...baseForm,
+        headerParams: { 'Authorization': 'Custom Token' },
+        queryParams: { gq: '2' },
+      },
+      auth: { bearerToken: 'mytoken' },
+      globalParams: { headers: { 'X-Global': 'val' }, queries: { gq: '1' } },
+    });
+    // Auth sets Authorization=auth, but interface overrides it
+    expect(result.sourceMap!.headers['Authorization']).toBe('interface');
+    expect(result.sourceMap!.query['gq']).toBe('interface');
+    // Global header should still be 'global'
+    expect(result.sourceMap!.headers['X-Global']).toBe('global');
+  });
+
+  test('global overrides auth in sourceMap', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: baseForm,
+      auth: { bearerToken: 'mytoken' },
+      globalParams: { headers: { 'Authorization': 'GlobalAuth' }, queries: {} },
+    });
+    // Global overrides auth for Authorization header
+    expect(result.sourceMap!.headers['Authorization']).toBe('global');
+    expect(result.headers['Authorization']).toBe('GlobalAuth');
+  });
+
+  test('basic auth generates sourceMap with auth source', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: baseForm,
+      auth: { basicCredentials: 'dXNlcjpwYXNz' },
+    });
+    expect(result.sourceMap!.headers['Authorization']).toBe('auth');
+    expect(result.headers['Authorization']).toBe('Basic dXNlcjpwYXNz');
+  });
+
+  test('apiKey auth generates sourceMap', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: baseForm,
+      auth: { apiKeys: { 'X-API-Key': 'abc123' } },
+    });
+    expect(result.sourceMap!.headers['X-API-Key']).toBe('auth');
+    expect(result.headers['X-API-Key']).toBe('abc123');
+  });
+
+  test('empty auth and globalParams still generates sourceMap', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: baseForm,
+      auth: {},
+      globalParams: { headers: {}, queries: {} },
+    });
+    // sourceMap generated because auth !== undefined
+    expect(result.sourceMap).toBeDefined();
+    expect(Object.keys(result.sourceMap!.headers)).toHaveLength(0);
+    expect(Object.keys(result.sourceMap!.query)).toHaveLength(0);
+  });
+
+  test('interface empty value does not mark as interface source', () => {
+    const result = buildRequest({
+      baseUrl: 'http://localhost',
+      path: '/api/test',
+      method: 'GET',
+      debugModel: baseModel,
+      formValues: {
+        ...baseForm,
+        headerParams: { 'X-Empty': '' },
+      },
+      auth: { bearerToken: 'mytoken' },
+    });
+    // Empty string interface header should not override auth
+    expect(result.sourceMap!.headers['X-Empty']).toBeUndefined();
+    expect(result.sourceMap!.headers['Authorization']).toBe('auth');
+  });
+
+  test('authToHeaders returns { headers, queries }', () => {
+    const result = authToHeaders({ bearerToken: 'tok' });
+    expect(result.headers).toBeDefined();
+    expect(result.queries).toBeDefined();
+    expect(result.headers['Authorization']).toBe('Bearer tok');
+    expect(Object.keys(result.queries)).toHaveLength(0);
+  });
+});

--- a/knife4j-front/knife4j-core/src/debug/index.ts
+++ b/knife4j-front/knife4j-core/src/debug/index.ts
@@ -19,6 +19,8 @@ export type {
   GlobalParamValues,
   AuthValues,
   BuiltRequest,
+  BuiltRequestSourceMap,
+  ParamSource,
   ValidationError,
   SchemaResolveContext,
   SchemaFieldNode,

--- a/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
+++ b/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
@@ -10,10 +10,12 @@
 import type {
   AuthValues,
   BuiltRequest,
+  BuiltRequestSourceMap,
   DebugFormValues,
   GlobalParamValues,
   OperationDebugModel,
   ParamIn,
+  ParamSource,
   ValidationError,
 } from './types';
 
@@ -66,12 +68,13 @@ export function mergeHeaders(
   return result;
 }
 
-// ─── 鉴权 → headers ──────────────────────────────────
+// ─── 鉴权 → headers + query ──────────────────────────
 
-/** 将鉴权信息转化为 headers */
-export function authToHeaders(auth: AuthValues | undefined): Record<string, string> {
+/** 将鉴权信息转化为 headers 和 query 参数 */
+export function authToHeaders(auth: AuthValues | undefined): { headers: Record<string, string>; queries: Record<string, string> } {
   const headers: Record<string, string> = {};
-  if (!auth) return headers;
+  const queries: Record<string, string> = {};
+  if (!auth) return { headers, queries };
 
   if (auth.bearerToken) {
     headers['Authorization'] = `Bearer ${auth.bearerToken}`;
@@ -85,7 +88,7 @@ export function authToHeaders(auth: AuthValues | undefined): Record<string, stri
     }
   }
 
-  return headers;
+  return { headers, queries };
 }
 
 // ─── 全局参数 → headers + query ───────────────────────
@@ -196,15 +199,52 @@ export function buildRequest(options: BuildRequestOptions): BuiltRequest {
 
   // 2. query 合并（用户填写 + 全局参数，全局参数不覆盖用户填写）
   const gp = splitGlobalParams(globalParams);
-  const mergedQuery: Record<string, string> = { ...gp.queries, ...formValues.queryParams };
 
   // 3. headers 合并（接口级 > 全局 > 鉴权）
-  const authHeaders = authToHeaders(auth);
+  const authResult = authToHeaders(auth);
   const mergedHeaders = mergeHeaders(
-    authHeaders,               // 优先级最低
+    authResult.headers,        // 优先级最低
     gp.headers,                // 全局参数
     formValues.headerParams,   // 接口级最高
   );
+  // 鉴权 query 参数合并（鉴权 < 全局 < 接口级）
+  const mergedQuery: Record<string, string> = { ...authResult.queries, ...gp.queries, ...formValues.queryParams };
+
+  // 3.5 sourceMap 追踪（仅当存在 auth 或 globalParams 时生成）
+  const hasMultiSource = auth !== undefined || globalParams !== undefined;
+  let sourceMap: BuiltRequestSourceMap | undefined;
+  if (hasMultiSource) {
+    const headerSource: Record<string, ParamSource> = {};
+    const querySource: Record<string, ParamSource> = {};
+
+    // 先标记 auth 来源（最低优先级）
+    for (const key of Object.keys(authResult.headers)) {
+      headerSource[key] = 'auth';
+    }
+    for (const key of Object.keys(authResult.queries)) {
+      querySource[key] = 'auth';
+    }
+    // 全局参数覆盖 auth
+    for (const key of Object.keys(gp.headers)) {
+      headerSource[key] = 'global';
+    }
+    for (const key of Object.keys(gp.queries)) {
+      querySource[key] = 'global';
+    }
+    // 接口级覆盖全局/auth
+    for (const key of Object.keys(formValues.headerParams)) {
+      if (formValues.headerParams[key] !== undefined && formValues.headerParams[key] !== '') {
+        headerSource[key] = 'interface';
+      }
+    }
+    for (const key of Object.keys(formValues.queryParams)) {
+      if (formValues.queryParams[key] !== undefined && formValues.queryParams[key] !== '') {
+        querySource[key] = 'interface';
+      }
+    }
+
+    sourceMap = { headers: headerSource, query: querySource };
+  }
 
   // 4. Content-Type + body 构建
   const selectedContentType = formValues.selectedContentType
@@ -250,6 +290,7 @@ export function buildRequest(options: BuildRequestOptions): BuiltRequest {
     query: mergedQuery,
     body,
     contentType: selectedContentType,
+    sourceMap,
   };
 }
 

--- a/knife4j-front/knife4j-core/src/debug/types.ts
+++ b/knife4j-front/knife4j-core/src/debug/types.ts
@@ -101,6 +101,15 @@ export interface GlobalParamValues {
   queries: Record<string, string>;
 }
 
+/** 参数来源标签（用于请求预览中标记优先级） */
+export type ParamSource = 'interface' | 'global' | 'auth';
+
+/** 请求参数来源映射 */
+export interface BuiltRequestSourceMap {
+  headers: Record<string, ParamSource>;
+  query: Record<string, ParamSource>;
+}
+
 /** 鉴权信息 */
 export interface AuthValues {
   /** bearer token */
@@ -125,6 +134,8 @@ export interface BuiltRequest {
   body?: string;
   /** Content-Type */
   contentType: string;
+  /** 参数来源映射（仅在存在 auth / globalParams 时生成） */
+  sourceMap?: BuiltRequestSourceMap;
 }
 
 /** required 校验结果 */

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -114,6 +114,9 @@ const enUS = {
   'apiDebug.preview.copied': 'Copied to clipboard',
   'apiDebug.preview.copyFailed': 'Copy failed, please select text manually',
   'apiDebug.preview.autoContentType': '(Content-Type is auto-injected based on body type)',
+  'apiDebug.preview.source.interface': 'Interface',
+  'apiDebug.preview.source.global': 'Global',
+  'apiDebug.preview.source.auth': 'Auth',
 
   // Authorize
   'auth.title': 'Authorization',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -114,6 +114,9 @@ const zhCN = {
   'apiDebug.preview.copied': '已复制到剪贴板',
   'apiDebug.preview.copyFailed': '复制失败，请手动选择文本',
   'apiDebug.preview.autoContentType': '（Content-Type 将由 body 类型自动注入）',
+  'apiDebug.preview.source.interface': '接口',
+  'apiDebug.preview.source.global': '全局',
+  'apiDebug.preview.source.auth': '鉴权',
 
   // Authorize
   'auth.title': 'Authorization',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -27,11 +27,15 @@ import type {
     BuiltRequest,
     DebugFormValues,
     DebugParam,
+    GlobalParamValues,
     OperationDebugModel,
+    ParamSource,
     ValidationError,
 } from 'knife4j-core';
 import {buildCurl, buildOperationDebugModel, buildRequest as coreBuildRequest, validateRequired,} from 'knife4j-core';
 import {OperationModeTabs, useCurrentOperation} from './useCurrentOperation';
+import {useAuth} from '../../context/AuthContext';
+import {useGlobalParam} from '../../context/GlobalParamContext';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
@@ -771,6 +775,12 @@ function PreviewTabPanel({ build, onCopyCurl }: PreviewTabPanelProps) {
   const queryPairs = Object.entries(built.query);
   const hasContentType = headerPairs.some(([k]) => k.toLowerCase() === 'content-type');
 
+  const sourceTag = (source: ParamSource | undefined) => {
+    if (!source) return null;
+    const colorMap: Record<ParamSource, string> = { interface: 'blue', global: 'green', auth: 'orange' };
+    return <Tag color={colorMap[source]} style={{ marginInlineEnd: 0 }}>{t(`apiDebug.preview.source.${source}`)}</Tag>;
+  };
+
   return (
     <Space direction="vertical" style={{ width: '100%' }} size={14}>
       {/* URL + method */}
@@ -795,9 +805,20 @@ function PreviewTabPanel({ build, onCopyCurl }: PreviewTabPanelProps) {
           <Table
             size="small"
             pagination={false}
-            dataSource={headerPairs.map(([key, value]) => ({ key, name: key, value }))}
+            dataSource={headerPairs.map(([key, value]) => ({ key, name: key, value, source: built.sourceMap?.headers[key] }))}
             columns={[
-              { title: t('apiDebug.col.header'), dataIndex: 'name', key: 'name', width: 240 },
+              {
+                title: t('apiDebug.col.header'),
+                dataIndex: 'name',
+                key: 'name',
+                width: 240,
+                render: (name: string, record: { source?: ParamSource }) => (
+                  <Space size={4}>
+                    <Text code>{name}</Text>
+                    {sourceTag(record.source)}
+                  </Space>
+                ),
+              },
               { title: t('apiDebug.col.headerValue'), dataIndex: 'value', key: 'value' },
             ]}
             style={{ marginTop: 4 }}
@@ -814,9 +835,20 @@ function PreviewTabPanel({ build, onCopyCurl }: PreviewTabPanelProps) {
           <Table
             size="small"
             pagination={false}
-            dataSource={queryPairs.map(([key, value]) => ({ key, name: key, value }))}
+            dataSource={queryPairs.map(([key, value]) => ({ key, name: key, value, source: built.sourceMap?.query[key] }))}
             columns={[
-              { title: t('apiDebug.col.paramName'), dataIndex: 'name', key: 'name', width: 240 },
+              {
+                title: t('apiDebug.col.paramName'),
+                dataIndex: 'name',
+                key: 'name',
+                width: 240,
+                render: (name: string, record: { source?: ParamSource }) => (
+                  <Space size={4}>
+                    <Text code>{name}</Text>
+                    {sourceTag(record.source)}
+                  </Space>
+                ),
+              },
               { title: t('apiDebug.col.value'), dataIndex: 'value', key: 'value' },
             ]}
             style={{ marginTop: 4 }}
@@ -1070,6 +1102,35 @@ export default function ApiDebug() {
     };
   };
 
+  // ── 从 AuthContext 获取鉴权数据 ──
+  const { auth } = useAuth();
+  const authValues = useMemo(() => {
+    if (!auth) return undefined;
+    if (auth.type === 'bearer' && auth.token) {
+      return { bearerToken: auth.token };
+    }
+    if (auth.type === 'basic' && (auth.username || auth.password)) {
+      const encoded = btoa(`${auth.username}:${auth.password}`);
+      return { basicCredentials: encoded };
+    }
+    return undefined;
+  }, [auth]);
+
+  // ── 从 GlobalParamContext 转换为 GlobalParamValues ──
+  const { params: globalParamItems } = useGlobalParam();
+  const globalParamValues: GlobalParamValues | undefined = useMemo(() => {
+    if (!globalParamItems || globalParamItems.length === 0) return undefined;
+    const headers: Record<string, string> = {};
+    const queries: Record<string, string> = {};
+    for (const p of globalParamItems) {
+      if (p.value !== undefined && p.value !== '') {
+        if (p.in === 'header') headers[p.name] = p.value;
+        else if (p.in === 'query') queries[p.name] = p.value;
+      }
+    }
+    return { headers, queries };
+  }, [globalParamItems]);
+
   /** 基于当前表单构建 BuiltRequest（不发请求，仅用于预览/curl/发送共用） */
   const buildPreview = (): { formValues: DebugFormValues; built: BuiltRequest; curl: string } => {
     const formValues = collectFormValues();
@@ -1079,6 +1140,8 @@ export default function ApiDebug() {
       method,
       debugModel,
       formValues,
+      auth: authValues,
+      globalParams: globalParamValues,
     });
     const curl = buildCurl(built);
     return { formValues, built, curl };


### PR DESCRIPTION
Implements TASK-031 — merge auth + global params inside knife4j-core requestBuilder, expose provenance in the Preview Tab.

## 改动

### knife4j-core
- `authToHeaders` now returns `{ headers, queries }` (no behavior change for existing bearer/basic consumers; query output path is new for future security schemes)
- `buildRequest` tracks a `sourceMap` per merged header / query: one of `interface` / `global` / `auth`
- Merge priority: **interface > global > auth**
- `types.ts`: new `ParamSource` type + `BuiltRequestSourceMap` interface; `BuiltRequest.sourceMap` is optional (produced only when auth or globalParams provided)

### knife4j-ui-react
- `ApiDebug` consumes `useAuth()` + `useGlobalParam()` and converts to `AuthValues` / `GlobalParamValues` passed to `coreBuildRequest`
- `PreviewTabPanel` renders a source Tag on every header / query row (interface/global/auth)
- `locales/*.ts` add `apiDebug.preview.source.{interface,global,auth}` keys

### Tests
+10 new cases: sourceMap presence, interface-over-global override, auth-header priority, empty globals no-op, query merging from auth schemes.

## Validation
- `./scripts/test-front-core.sh` → 12 suites, **134 tests**, 0 lint errors, tsc OK
- `npm run build -w knife4j-ui-react` → tsc + vite OK (dist 1.44 MB)

## Notes
- `AuthContext` / `Authorize.tsx` / `GlobalParamContext` / `GlobalParam.tsx` **not modified**; TASK-033 will extend `AuthValues` with `bySecurityKey` on top of this PR without re-writing the merge layer
- Backward compatible: new optional params (`globalParams`, `auth`) only; existing 14 requestBuilder tests still pass

Closes TASK-031.

