### PR TITLE
fix(ci): scrub private registry URL from package-lock and pin public …

### DIFF
--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -722,3 +722,78 @@ next:
 - 等待新任务规划（阶段 2 或维护者指定下一优先级）
 blockers:
 - none
+
+## 2026-04-26 01:09 CST
+task: TASK-036
+agent: coordinator (direct)
+branch: agent/TASK-036-repo-format-baseline
+status: review
+summary:
+- 背景：维护者反映「AI 提交完文件之后经常出现格式化变更」，排查结论是 IDE 保存时自动格式化 + 缺少仓库级 EOL/风格约束共同作用。
+- 在仓库根目录新增 `.gitattributes`（178 行）：
+  - `* text=auto eol=lf`：默认所有文本统一存 LF，解决 CRLF↔LF 抖动
+  - `.sh` 强制 LF；`.bat` / `.cmd` / `.ps1` / `mvnw.cmd` 强制 CRLF
+  - 显式声明常见二进制（png/jpg/gif/ico/webp/woff/woff2/ttf/jar/war/class/zip/pdf 等）
+  - `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` 设 `merge=ours`，减少 lockfile 手工解冲突
+  - linguist 分类：`knife4j-vue/**` + `knife4j-front/knife4j-ui/**` → vendored；webjars 产物 → generated；`docs-site/` + `knife4j-doc/` → documentation
+  - `export-ignore`：`.agent/` `.github/` `.gitee/` `docs-site/` `knife4j-doc/` `scripts/` `backup/` `static/` 等，打 `git archive` 时排除
+- 在仓库根目录新增 `.editorconfig`（113 行）：
+  - 全局默认：charset=utf-8、eol=lf、insert_final_newline、trim_trailing_whitespace、2 空格
+  - Java/Kotlin/Groovy/Scala → 4 空格（Java 社区惯例）
+  - Python → 4 空格；Go / Makefile → tab
+  - `.bat` / `.cmd` / `.ps1` → CRLF
+  - Markdown → 不 trim 末尾空白（保留「两空格换行」语义）
+  - 未设 `root = true`，保持 `knife4j-vue/` 和 `knife4j-front/knife4j-ui/` 子项目 editorconfig 自治（两者均已有独立 .editorconfig）
+- **未触发 `git add --renormalize`**：本次只让规则对今后的改动生效，不回溯历史，避免一次性产生几百文件的 EOL diff。
+- 未改动任何源代码，未触发构建，零源文件风险。
+validation:
+- `git check-attr -a scripts/test-java.sh` → `text: set`, `eol: lf` ✅
+- `git check-attr -a knife4j/knife4j-demo/.../UserVO.java` → `text: set`, `eol: lf` ✅
+- `git check-attr -a knife4j-front/package-lock.json` → `merge: ours`, `text: set`, `eol: lf` ✅
+- `git check-attr -a README.md` → `diff: markdown`, `text: set`, `eol: lf` ✅
+- `git check-attr -a knife4j-vue/src/core/logger.js` → `linguist-vendored: set` ✅
+- `git check-attr -a AGENTS.md` → `export-ignore: set`, `diff: markdown` ✅
+- `git check-attr -a knife4j/changeVersion.bat` → `text: set`, `eol: crlf` ✅
+- `git check-attr -a docs-site/public/assets/*.png` → `binary: set`, `text: unset`, `linguist-documentation: set` ✅
+- 工作区 diff 仅 3 个文件变化：.agent/TASKS.md (+24)、新增 .editorconfig (+113)、新增 .gitattributes (+178)
+next:
+- 提交本分支并推送，等待维护者 review（或根据 .agent/COORDINATION.md 继续协调发 PR）
+- 推送前恢复本地 TASK-033 的脏改动（git stash pop）
+followup 候选:
+- 后续如果想彻底清洗历史 EOL，可独立做一个 `git add --renormalize .` 的 commit，并把该 commit 写入 `.git-blame-ignore-revs`，但本任务不做
+- IDEA 端还需要用户手动关 Settings → Tools → Actions on Save 的 Reformat / Optimize imports，`.editorconfig` 只能约束缩进和换行，不能阻止 IDEA 重排代码
+blockers:
+- none
+
+## 2026-04-26 17:30 CST
+task: TASK-038
+agent: coordinator (direct)
+branch: agent/TASK-038-fix-ci-npm-registry
+status: review
+summary:
+- 背景：master@7e2b52d 触发的 GitHub Actions run 24936006761 两个 job 失败（`java-build-test` / `front-core-test`），第三个 `docs-build` 因路径过滤未跑到 npm ci 故幸免。
+- 失败日志关键行：`npm error network request to <private-registry-host>/idb-keyval/download/idb-keyval-6.2.2.tgz failed, reason: getaddrinfo ENOTFOUND <private-registry-host>`（`<private-registry-host>` 是贡献者本地配置的私有 npm 镜像域名，公共 runner 无法解析）
+- 根因定位：
+  - 贡献者本地 `~/.npmrc` 配置了一个私有 npm registry（只在贡献者自己的网络里能解析）。
+  - PR #48 合并版的 `knife4j-front/package-lock.json` 中 `idb-keyval@6.2.2` 的 `resolved` 字段被写成了那个私有 URL（其它包恰好已被其他 PR 写成 `registry.npmjs.org`，仅此一处漏网）。
+  - GitHub Actions 公共 runner 无法解析该域名，`npm ci` 按 lock 下载 tarball 时直接失败。
+- 修复动作（只动 3 个文件，刻意最小 diff）：
+  - `knife4j-front/package-lock.json`：用 `sed` 精确替换 `idb-keyval` 那一行 `resolved` URL，从私有 registry 的下载路径 → `https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz`；**不重新生成 lock**、**不升级任何依赖**、**不改其他包的 integrity**。最终 diff 就是 1 行 `-` / 1 行 `+`。
+  - `knife4j-front/.npmrc`（新增）：`registry=https://registry.npmjs.org/`，强制本仓库 npm workspace 使用公共 registry，覆盖 user-level `~/.npmrc`。
+  - `knife4j-doc/.npmrc`（新增）：同上，给 VitePress 站点加同样护栏（该项目当前 lock 干净，但容易被同一台机器后续的 `npm install` 污染）。
+- 未动源代码、未改 CI workflow、未升级任何依赖版本。
+validation:
+- `jq -r '.. | .resolved? // empty' knife4j-front/package-lock.json | grep -v '^https://registry.npmjs.org/'` → 无输出（所有 resolved 都指向公共 registry）✅
+- `cd knife4j-front && rm -rf node_modules && npm ci` → 成功完成（513 packages installed）✅
+- `./scripts/test-front-core.sh` → `Test Suites: 12 passed, 12 total / Tests: 147 passed` + `eslint src --ext .js,.ts` 0 error + `tsc` 0 error ✅
+next:
+- 推送分支 `agent/TASK-038-fix-ci-npm-registry` → 开 PR → 人工 review → merge master
+- 合并后验证下一次 push 到 master 的 `Build` workflow 三个 job 全绿
+followup 候选:
+- 可在 `scripts/` 下加一条预防性检查，如 `jq -r '.. | .resolved? // empty' knife4j-front/package-lock.json | grep -v '^https://registry.npmjs.org/' && exit 1`，一旦 lock 出现非公共 registry URL 就 fail fast；但此属 TASK-037 的 CI 强化范畴，本任务不扩散
+- 贡献者如果继续在配置了私有 registry 的机器上开发，建议临时把 `~/.npmrc` 的 registry 改成 `https://registry.npmjs.org/`，或直接依赖本次加的项目级 `.npmrc` 的覆盖行为
+blockers:
+- none
+lessons:
+- npm lock 文件的 `resolved` 字段是「谁生成 lock 就写谁」，private registry 会无声地污染公共仓库的 lock 文件，跨团队贡献代码时必须用 project-level `.npmrc` 兜底
+- CI 报 `ENOTFOUND` 而不是 `ETIMEDOUT` 说明 runner 连 DNS 都解析不了，基本 100% 是某个只在私有网络内可解析的域名泄漏到公共 lock 文件

--- a/.agent/TASKS.md
+++ b/.agent/TASKS.md
@@ -639,3 +639,73 @@ notes:
 - 不引入 Node 22 新特性到业务代码（如内建 test runner、watch mode）；保持现有 jest/vite 工具链
 - 不动 `knife4j-ui/`（pnpm）和 `knife4j-vue/`（Vue2 历史代码）的 engines，避免无关改动
 - 回滚路径：`.nvmrc` 回 20、CI workflow 还原两处、删除 `knife4j-front/package.json` 的 engines 字段
+
+### TASK-036
+status: review
+area: repo
+title: 加根级 .gitattributes 与 .editorconfig，统一行尾符与编辑器风格
+branch: agent/TASK-036-repo-format-baseline
+depends_on:
+validation:
+- `git check-attr -a scripts/test-java.sh` 命中 `text eol=lf`
+- `git check-attr -a knife4j/knife4j-demo/src/main/java` 下任意 .java 命中 `text=auto eol=lf`
+- `git check-attr -a knife4j-openapi3-ui/src/main/resources/webjars` 下任意 .png/.woff 命中 `binary`
+- 现有已 tracked 文件不做 `git add --renormalize`，避免一次性巨量 diff
+done_when:
+- 仓库根目录新增 `.gitattributes`，覆盖 EOL（默认 LF，.bat/.cmd 保持 CRLF）、常见二进制标注、`package-lock.json merge=ours`、linguist 分类、`export-ignore`
+- 仓库根目录新增 `.editorconfig`，覆盖 Java / TS / JS / Vue / JSON / YAML / Markdown / Shell 的缩进、charset、换行、trim_trailing_whitespace、insert_final_newline
+- 不回溯历史文件行尾符（本任务不跑 renormalize），只让规则对「今后的改动」生效
+- 不改动任何源代码文件，不触发构建
+- .agent/PROGRESS.md 记录本次结果
+notes:
+- 目的：解决「AI 改完文件后 IDE 自动格式化 / CRLF↔LF 漂移 / GitHub 语言统计不准」三类噪声
+- 子项目已有的 `.editorconfig`（knife4j-vue、knife4j-front/knife4j-ui）保持不动；`.editorconfig` 支持层叠，子项目规则会覆盖根
+- 子项目已有的 `.prettierrc`（knife4j-front/knife4j-core、knife4j-front/knife4j-ui）保持不动
+- 不碰 IDEA 的 code style（`.idea/codeStyles/`），由开发者自行在 IDE 里关 Actions on Save
+- 回滚路径：删除两份新增文件即可
+
+### TASK-037
+status: in_progress
+area: repo
+title: 补齐格式化规则与 CI 强制检查（Prettier / IDEA code style / spotless:check）
+branch: agent/TASK-037-format-rules-enforcement
+depends_on: TASK-036
+validation:
+- cd knife4j-front/knife4j-ui-react && npx prettier --check "src/**/*.{ts,tsx}"
+- cd knife4j-front/knife4j-core && npx prettier --check "src/**/*.ts"
+- .idea/codeStyles/Project.xml 存在且能被 IDEA 识别
+- CI workflow 包含 `spotless:check` 步骤
+done_when:
+- knife4j-ui-react 有 .prettierrc + format 脚本，且现有代码 prettier --check 通过
+- knife4j-front 根级共享 .prettierrc（子项目不再各自维护重复配置）
+- .idea/codeStyles/Project.xml 从 spotless_knife4j_formatter.xml 导出，IDEA 用户开箱即用
+- CI build.yml 新增 spotless:check 步骤（Java）和 npm run lint 步骤（前端）
+notes:
+- 目的：让所有编辑者（AI / IDEA / VS Code）产出一致的格式化结果，消除"改一行 diff 全红"
+- knife4j-ui-react 当前没有 Prettier，是格式化噪声的最大来源
+- Java 侧已有 spotless + Eclipse formatter，但 IDEA 不知道它的存在，导致两套规则打架
+- CI 目前只跑 spotless:apply（静默修复），不跑 spotless:check（检查不合规就 fail），需要补上
+- 不引入 husky / lint-staged（pre-commit hook），保持轻量
+- 回滚路径：删除新增 .prettierrc + .idea/codeStyles/ + 还原 CI workflow
+
+### TASK-038
+status: review
+area: repo
+title: 修复 CI npm ci 失败：清理 package-lock.json 中指向私有 registry 的 URL
+branch: agent/TASK-038-fix-ci-npm-registry
+depends_on:
+validation:
+- `jq -r '.. | .resolved? // empty' knife4j-front/package-lock.json | grep -v '^https://registry.npmjs.org/'` → 无输出
+- `cd knife4j-front && rm -rf node_modules && npm ci` → 成功
+- `./scripts/test-front-core.sh` → 147 tests / 12 suites pass + lint + build ok
+done_when:
+- `knife4j-front/package-lock.json` 中所有 `resolved` 字段只指向公共 `registry.npmjs.org`，不再出现任何私有 registry URL
+- `knife4j-front/.npmrc` 与 `knife4j-doc/.npmrc` 强制使用公共 `registry.npmjs.org`，防止未来 lock 文件再被本地配置的私有 registry 污染
+- GitHub Actions `Build` workflow 的 `java-build-test` 与 `front-core-test` 不再因 `npm ci` 走不通 `getaddrinfo ENOTFOUND` 的私有域名而失败
+notes:
+- 触发：GitHub Actions run 24936006761（master@7e2b52d）两个 job 因 `npm ci` 尝试从一个公共 runner 无法解析的私有域名下载 `idb-keyval-6.2.2.tgz` 而被 ENOTFOUND
+- 根因：贡献者本地 `~/.npmrc` 配置了私有 npm registry，PR #48 合并时 `idb-keyval` 的 `resolved` 字段被写入了那个私有 URL
+- 修复范围刻意最小化：`package-lock.json` 只改动 `idb-keyval` 的一行 `resolved` URL，不重新生成 lock、不升降任何依赖版本，避免把其他噪声混进来
+- 子项目级 `.npmrc` 会覆盖 user-level `.npmrc`，保证任何人在任何环境 `npm install` 写出的 lock 都走公共 registry
+- 不引入 `ignore-scripts` 等额外策略；只加一行 `registry=...`
+- 回滚路径：删除两份 `.npmrc`、还原 `knife4j-front/package-lock.json` 即可

--- a/knife4j-doc/.npmrc
+++ b/knife4j-doc/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+

--- a/knife4j-front/.npmrc
+++ b/knife4j-front/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+

--- a/knife4j-front/package-lock.json
+++ b/knife4j-front/package-lock.json
@@ -4207,7 +4207,7 @@
     },
     "node_modules/idb-keyval": {
       "version": "6.2.2",
-      "resolved": "http://r.npm.sankuai.com/idb-keyval/download/idb-keyval-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha1-sBcbX3OUSFSjKRpc26jhJ2jEhUo=",
       "license": "Apache-2.0"
     },


### PR DESCRIPTION
…registry (TASK-038)

CI run 24936006761 failed on both java-build-test and front-core-test with 'getaddrinfo ENOTFOUND' while npm ci tried to fetch idb-keyval-6.2.2.tgz from a private registry hostname. The private registry was leaked into package-lock.json via a user-level ~/.npmrc during PR #48 merge.

- knife4j-front/package-lock.json: replace the single leaked resolved URL for idb-keyval@6.2.2 with its canonical registry.npmjs.org path (1-line diff).
- knife4j-front/.npmrc (new): pin registry to https://registry.npmjs.org/ so project-level config overrides any user-level private registry.
- knife4j-doc/.npmrc  (new): same guard for the VitePress workspace.

Validation:
- all resolved URLs in knife4j-front/package-lock.json point to registry.npmjs.org
- cd knife4j-front && rm -rf node_modules && npm ci -> success
- ./scripts/test-front-core.sh -> 12 suites / 147 tests pass + lint + build