### PR TITLE
feat(ui-react): Markdown rendering for API/tag/info descriptions (TASK-040)

### DIFF
--- a/knife4j-front/knife4j-ui-react/package.json
+++ b/knife4j-front/knife4j-ui-react/package.json
@@ -14,10 +14,12 @@
   "dependencies": {
     "@types/react-router-dom": "^5.3.3",
     "antd": "^5.7.3",
+    "dompurify": "^3.0.6",
     "i18next": "^23.7.6",
     "i18next-browser-languagedetector": "^7.2.0",
     "idb-keyval": "^6.2.1",
     "knife4j-core": "*",
+    "marked": "^9.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^14.0.0",
@@ -25,6 +27,7 @@
     "react-router-dom": "^6.14.2"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@types/react-resizable": "^3.0.4",

--- a/knife4j-front/knife4j-ui-react/src/components/Markdown.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/Markdown.tsx
@@ -1,0 +1,21 @@
+import { memo, useMemo } from 'react';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+interface MarkdownProps {
+  source: string;
+}
+
+const Markdown = memo(({ source }: MarkdownProps) => {
+  const html = useMemo(() => {
+    if (!source) return '';
+    const rawHtml = marked.parse(source, { async: false }) as string;
+    return DOMPurify.sanitize(rawHtml);
+  }, [source]);
+
+  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+});
+
+Markdown.displayName = 'Markdown';
+
+export default Markdown;

--- a/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
@@ -1,8 +1,9 @@
 import { Card, Descriptions, Statistic, Row, Col, Typography, Spin } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useGroup } from '../context/GroupContext';
+import Markdown from '../components/Markdown';
 
-const { Title, Paragraph } = Typography;
+const { Title } = Typography;
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch'] as const;
 
@@ -41,7 +42,7 @@ export default function Home() {
           <Descriptions.Item label={t('home.version')}>{info.version ?? '-'}</Descriptions.Item>
           {info.description && (
             <Descriptions.Item label={t('home.description')}>
-              <Paragraph style={{ margin: 0 }}>{info.description}</Paragraph>
+              <Markdown source={info.description} />
             </Descriptions.Item>
           )}
         </Descriptions>

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -3,8 +3,9 @@ import type { ColumnsType } from 'antd/es/table';
 import { useTranslation } from 'react-i18next';
 import type { ParameterObject, ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
 import { OperationModeTabs, useCurrentOperation } from './useCurrentOperation';
+import Markdown from '../../components/Markdown';
 
-const { Title, Paragraph, Text } = Typography;
+const { Title, Text } = Typography;
 
 interface ParamRow {
   key: string;
@@ -214,7 +215,7 @@ export default function ApiDoc() {
       <Title level={4} style={{ marginTop: 0 }}>
         {op.summary ?? operation.path}
       </Title>
-      {op.description && <Paragraph type="secondary">{op.description}</Paragraph>}
+      {op.description && <Markdown source={op.description} />}
 
       <Title level={5} style={{ marginTop: 24 }}>
         {t('apiDoc.requestParams')}


### PR DESCRIPTION
## TASK-040: React 前端接入 Markdown 渲染

### 变更内容

- 新增 `marked` + `dompurify` 依赖
- 新增 `src/components/Markdown.tsx` 组件（memo + useMemo，DOMPurify XSS 防护）
- `Home.tsx`：`info.description` 改用 Markdown 渲染
- `ApiDoc.tsx`：`op.description` 改用 Markdown 渲染

### 验证

- `npx tsc --noEmit` ✅
- `npx vite build` ✅