### PR TITLE
fix(build): enable -parameters in parent POM so Springdoc detects @PathVariable

### DIFF
--- a/docs-site/guide/faq.md
+++ b/docs-site/guide/faq.md
@@ -217,6 +217,49 @@ public class CommonWebMvcConfig implements WebMvcConfigurer {
 
 这是 springdoc 默认行为。`@ParameterObject` 会把对象内每个字段展开成独立 query 参数。这是**设计如此**，不是 bug。如果你希望作为整体 JSON 传入，用 `@RequestBody`。
 
+### `GET /foo/{id}` 在调试页上所有 tab 都灰掉，无法编辑 path 参数 {#missing-path-variable}
+
+**症状**：形如 `@GetMapping("/{id}") public Xxx get(@PathVariable Long id)` 的接口，调试页 Path / Query / Header / Body 全部 tab 都是灰的，点不开。查看 `/v3/api-docs` 发现该操作的 `parameters` 是 `[]`。
+
+**根因**：编译时没开 `-parameters`，导致 class 文件里没有 `MethodParameters` 属性。Spring / Springdoc 无法通过反射拿到参数名 `id`，在参数没显式写 `name` 的情况下会**丢弃整个参数**。`@PathVariable` 不写 `value` / `@Parameter` 不写 `name` 时尤其明显。
+
+**诊断**（任选其一）：
+
+```bash
+# 1. 看 OpenAPI 文档
+curl -s http://localhost:8080/v3/api-docs | jq '.paths."/your/path/{id}".get.parameters'
+# 输出 [] 就是这个问题
+
+# 2. 看 class 字节码
+javap -v target/classes/com/your/YourController.class | grep MethodParameters
+# 没有任何输出就是没开 -parameters
+```
+
+**修复（推荐）**：在 Maven `maven-compiler-plugin` 里开启 `-parameters`：
+
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <configuration>
+    <parameters>true</parameters>
+  </configuration>
+</plugin>
+```
+
+继承 `spring-boot-starter-parent` 的项目默认已经带 `-parameters`，无需额外配置。如果你没继承、或者用的是 Gradle，自行在各自构建工具中开启即可（Gradle：`tasks.withType(JavaCompile) { options.compilerArgs << '-parameters' }`）。
+
+**替代方案**：在注解里显式写参数名。适合不方便改构建配置的场景，但侵入代码：
+
+```java
+@GetMapping("/{id}")
+public UserVO getById(
+    @Parameter(name = "id", description = "用户 ID")
+    @PathVariable("id") Long id) { ... }
+```
+
+**降级兜底**：Knife4j UI（自 `4.6.0.3` 后续版本起）会在 OpenAPI 文档里 `parameters: []` 但 URL 模板含 `{xxx}` 时，自动把占位符补成 `string` 类型的 path 参数输入框——因此**即便后端 OpenAPI 文档不完整，调试页也不会再整页灰掉**。但补出来的参数丢失了原始 `description` / `type` / `example`，仍建议按上面两种方式从源头修复。
+
 ### Spring Boot 3.4 / 3.5 启动报错
 
 如果你用的是 upstream `4.5.0` 或更早版本，在 Boot 3.4+ 上会遇到 `NoSuchMethodError` 或 `ClassNotFoundException`。本 fork `4.6.0.3` 已将 springdoc-openapi 升级到 `2.8.9`，解决了此问题。

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -267,6 +267,16 @@
                         <target>${knife4j-java.version}</target>
                         <encoding>UTF-8</encoding>
                         <compilerArgument>-Xlint:unchecked</compilerArgument>
+                        <!--
+                          Enable -parameters so frameworks that rely on reflection
+                          (Spring MVC / Springdoc-OpenAPI / Jackson) can derive
+                          method parameter names without requiring @PathVariable("id"),
+                          @RequestParam("foo") or @Parameter(name="...") everywhere.
+                          Spring Boot's own starter-parent enables this by default;
+                          knife4j does NOT inherit spring-boot-starter-parent, so we
+                          opt in explicitly here.
+                        -->
+                        <parameters>true</parameters>
                         <annotationProcessorPaths>
                             <path>
                                 <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## 问题

当 `maven-compiler-plugin` 未开启 `-parameters` 时，编译后的 class 文件不包含 `MethodParameters` 属性。Spring / Springdoc 无法通过反射获取方法参数名，导致 `@PathVariable Long id` 这类不显式写 `name` 的参数在 OpenAPI 文档中被**整个丢弃**（`parameters: []`）。

表现：调试页所有 Tab（Path / Query / Header / Body）全部灰掉，无法操作。

## 改动

### 1. 父 POM 统一开启 `-parameters`（`knife4j/pom.xml`）

在 `pluginManagement.maven-compiler-plugin` 中添加 `<parameters>true</parameters>`，所有子模块自动继承。

- `knife4j-demo`：不再需要单独覆盖，已移除之前 PR 中的 demo-only 配置。
- 其他 knife4j 模块（如 `knife4j-openapi3-jakarta-spring-boot-starter`）：附带受益，class 文件现在也包含参数名元数据。

### 2. FAQ 文档（`docs-site/guide/faq.md`）

新增条目 [GET /foo/{id} 在调试页上所有 tab 都灰掉](../../blob/aea88f7f/docs-site/guide/faq.md)，包含：
- 症状描述
- 根因解释（`-parameters` 缺失）
- 诊断命令（`curl` + `javap`）
- 推荐修复（Maven / Gradle 开 `-parameters`）
- 替代方案（注解显式写 name）
- 降级兜底说明（UI 自动补充占位符参数）

## 为什么大多数用户不会遇到此问题

继承 `spring-boot-starter-parent` 的项目默认已开 `-parameters`。knife4j 自身因为不继承该 parent，所以需要手动开启。

## 验证

```bash
# 编译后检查 MethodParameters
javap -v target/classes/com/baizhukui/knife4j/demo/UserController.class | grep MethodParameters
# 6 个方法均有输出

# 启动后检查 OpenAPI 文档
curl -s http://localhost:8080/v3/api-docs | jq '.paths."/api/user/{id}".get.parameters'
# 输出包含 id:path 参数
```

## 关联

- 前端兜底：PR #56（从 URL 模板自动提取 Path 参数）

