### PR TITLE
feat(ui-react): add copy endpoint/markdown/url actions to ApiDoc toolbar (TASK-042)

### DIFF
--- a/knife4j-front/knife4j-core/src/index.ts
+++ b/knife4j-front/knife4j-core/src/index.ts
@@ -2,3 +2,4 @@ export * from './models/SpecParserFactory';
 export * from './models/SpecType';
 export { default as Menu } from './core/menu';
 export * from './debug';
+export * from './markdownExport';

--- a/knife4j-front/knife4j-core/src/markdownExport.ts
+++ b/knife4j-front/knife4j-core/src/markdownExport.ts
@@ -1,0 +1,217 @@
+/**
+ * markdownExport.ts
+ *
+ * Generates a Markdown document for a single OpenAPI operation.
+ * Designed to be reusable from ApiDoc copy-action (TASK-042) and
+ * OfficeDoc export (TASK-043).
+ */
+
+// ── Minimal local type aliases (mirrors knife4j-ui-react swagger types) ──────
+
+export interface MdSchemaObject {
+  type?: string;
+  format?: string;
+  description?: string;
+  properties?: Record<string, MdSchemaObject>;
+  items?: MdSchemaObject;
+  $ref?: string;
+  required?: string[];
+  enum?: unknown[];
+}
+
+export interface MdParameterObject {
+  name: string;
+  in: string;
+  required?: boolean;
+  description?: string;
+  schema?: MdSchemaObject;
+  type?: string;
+  format?: string;
+}
+
+export interface MdRequestBodyObject {
+  description?: string;
+  required?: boolean;
+  content?: Record<string, { schema?: MdSchemaObject }>;
+}
+
+export interface MdResponseObject {
+  description?: string;
+  content?: Record<string, { schema?: MdSchemaObject }>;
+  schema?: MdSchemaObject; // OAS2
+}
+
+export interface MdOperationObject {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: MdParameterObject[];
+  requestBody?: MdRequestBodyObject;
+  responses?: Record<string, MdResponseObject>;
+  deprecated?: boolean;
+}
+
+export interface MdDocContext {
+  components?: { schemas?: Record<string, MdSchemaObject> };
+  definitions?: Record<string, MdSchemaObject>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function resolveRef(ref: string, ctx: MdDocContext): MdSchemaObject | undefined {
+  const m = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
+  if (!m) return undefined;
+  return (ctx.components?.schemas ?? ctx.definitions ?? {})[m[1]];
+}
+
+function schemaName(schema?: MdSchemaObject): string {
+  if (!schema) return '';
+  if (schema.$ref) return schema.$ref.split('/').pop() ?? '$ref';
+  if (schema.type === 'array') return `${schemaName(schema.items) || 'object'}[]`;
+  return [schema.type, schema.format].filter(Boolean).join('/') || 'object';
+}
+
+function paramType(p: MdParameterObject): string {
+  return schemaName(p.schema) || [p.type, p.format].filter(Boolean).join('/') || '-';
+}
+
+function firstRequestSchema(rb: MdRequestBodyObject | undefined): MdSchemaObject | undefined {
+  if (!rb?.content) return undefined;
+  return rb.content['application/json']?.schema ?? Object.values(rb.content)[0]?.schema;
+}
+
+function responseSchemaName(r: MdResponseObject): string {
+  const s = r.content?.['application/json']?.schema ?? r.schema ?? Object.values(r.content ?? {})[0]?.schema;
+  return schemaName(s);
+}
+
+function bodyRows(
+  schema: MdSchemaObject,
+  ctx: MdDocContext,
+): Array<{ name: string; type: string; required: boolean; description: string }> {
+  const resolved = schema.$ref ? resolveRef(schema.$ref, ctx) : schema;
+  if (!resolved?.properties) return [];
+  const req = new Set(resolved.required ?? []);
+  return Object.entries(resolved.properties).map(([name, prop]) => ({
+    name,
+    type: schemaName(prop),
+    required: req.has(name),
+    description: prop.description ?? '',
+  }));
+}
+
+function mdTable(headers: string[], rows: string[][]): string {
+  const sep = headers.map(() => '---');
+  const lines = [`| ${headers.join(' | ')} |`, `| ${sep.join(' | ')} |`, ...rows.map((r) => `| ${r.join(' | ')} |`)];
+  return lines.join('\n');
+}
+
+function escape(s: string): string {
+  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface GenerateApiMarkdownOptions {
+  method: string;
+  path: string;
+  operation: MdOperationObject;
+  docContext: MdDocContext;
+}
+
+/**
+ * Generates a Markdown string for a single API operation.
+ *
+ * Sections:
+ *  - Title (summary or path)
+ *  - Method + path badge
+ *  - Description (if any)
+ *  - Request Parameters table
+ *  - Request Body table
+ *  - Response Structure table
+ */
+export function generateApiMarkdown(opts: GenerateApiMarkdownOptions): string {
+  const { method, path, operation, docContext } = opts;
+  const m = method.toUpperCase();
+  const op = operation;
+
+  const lines: string[] = [];
+
+  // Title
+  lines.push(`# ${op.summary ?? path}`);
+  lines.push('');
+
+  // Method + path
+  lines.push(`**${m}** \`${path}\``);
+  if (op.deprecated) lines.push('');
+  if (op.deprecated) lines.push('> ⚠️ This API is deprecated.');
+  lines.push('');
+
+  // Description
+  if (op.description) {
+    lines.push(op.description);
+    lines.push('');
+  }
+
+  // Request Parameters
+  lines.push('## Request Parameters');
+  lines.push('');
+  const params = op.parameters ?? [];
+  if (params.length === 0) {
+    lines.push('_No request parameters._');
+  } else {
+    lines.push(
+      mdTable(
+        ['Name', 'In', 'Type', 'Required', 'Description'],
+        params.map((p) => [
+          escape(`\`${p.name}\``),
+          escape(p.in),
+          escape(paramType(p)),
+          p.required ? 'Yes' : 'No',
+          escape(p.description ?? ''),
+        ]),
+      ),
+    );
+  }
+  lines.push('');
+
+  // Request Body
+  lines.push('## Request Body');
+  lines.push('');
+  const bodySchema = firstRequestSchema(op.requestBody);
+  if (!bodySchema) {
+    lines.push('_No request body._');
+  } else {
+    const rows = bodyRows(bodySchema, docContext);
+    if (rows.length === 0) {
+      lines.push('_Request body schema cannot be expanded._');
+    } else {
+      lines.push(
+        mdTable(
+          ['Field', 'Type', 'Required', 'Description'],
+          rows.map((r) => [escape(`\`${r.name}\``), escape(r.type), r.required ? 'Yes' : 'No', escape(r.description)]),
+        ),
+      );
+    }
+  }
+  lines.push('');
+
+  // Response Structure
+  lines.push('## Response Structure');
+  lines.push('');
+  const responses = Object.entries(op.responses ?? {});
+  if (responses.length === 0) {
+    lines.push('_No response defined._');
+  } else {
+    lines.push(
+      mdTable(
+        ['Status', 'Description', 'Schema'],
+        responses.map(([code, r]) => [escape(code), escape(r.description ?? ''), escape(responseSchemaName(r))]),
+      ),
+    );
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -50,6 +50,15 @@ const enUS = {
   'apiDoc.col.schema': 'Schema',
   'apiDoc.col.fieldName': 'Field Name',
 
+  // ApiDoc — copy actions (TASK-042)
+  'apiDoc.copy.endpoint': 'Copy Endpoint',
+  'apiDoc.copy.endpoint.success': 'Endpoint copied',
+  'apiDoc.copy.markdown': 'Copy Markdown',
+  'apiDoc.copy.markdown.success': 'Markdown copied',
+  'apiDoc.copy.url': 'Copy URL',
+  'apiDoc.copy.url.success': 'URL copied',
+  'apiDoc.copy.failed': 'Copy failed, please select text manually',
+
   // Operation mode tabs (doc / debug)
   'operation.tab.doc': 'Doc',
   'operation.tab.debug': 'Debug',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -50,6 +50,15 @@ const zhCN = {
   'apiDoc.col.schema': 'Schema',
   'apiDoc.col.fieldName': '字段名',
 
+  // ApiDoc — 复制操作 (TASK-042)
+  'apiDoc.copy.endpoint': '复制接口',
+  'apiDoc.copy.endpoint.success': '接口已复制',
+  'apiDoc.copy.markdown': '复制文档 Markdown',
+  'apiDoc.copy.markdown.success': 'Markdown 已复制',
+  'apiDoc.copy.url': '复制地址',
+  'apiDoc.copy.url.success': '地址已复制',
+  'apiDoc.copy.failed': '复制失败，请手动选择文本',
+
   // Operation mode tabs (doc / debug)
   'operation.tab.doc': '文档',
   'operation.tab.debug': '调试',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -1,9 +1,12 @@
-import { Alert, Badge, Spin, Table, Tag, Typography } from 'antd';
+import { Alert, Badge, Button, Space, Spin, Table, Tag, Typography, message } from 'antd';
+import { CopyOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useTranslation } from 'react-i18next';
 import type { ParameterObject, ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
 import { OperationModeTabs, useCurrentOperation } from './useCurrentOperation';
 import Markdown from '../../components/Markdown';
+import { copyToClipboard } from '../../utils/clipboard';
+import { generateApiMarkdown } from 'knife4j-core';
 
 const { Title, Text } = Typography;
 
@@ -100,9 +103,41 @@ export default function ApiDoc() {
     );
   }
 
+  const method = operation.method.toUpperCase();
+  const op = operation.operation;
+
+  const handleCopyEndpoint = () => {
+    copyToClipboard(
+      `${method} ${operation.path}`,
+      () => message.success(t('apiDoc.copy.endpoint.success')),
+      () => message.error(t('apiDoc.copy.failed')),
+    );
+  };
+
+  const handleCopyMarkdown = () => {
+    const md = generateApiMarkdown({
+      method,
+      path: operation.path,
+      operation: op,
+      docContext: swaggerDoc,
+    });
+    copyToClipboard(
+      md,
+      () => message.success(t('apiDoc.copy.markdown.success')),
+      () => message.error(t('apiDoc.copy.failed')),
+    );
+  };
+
+  const handleCopyUrl = () => {
+    copyToClipboard(
+      window.location.href,
+      () => message.success(t('apiDoc.copy.url.success')),
+      () => message.error(t('apiDoc.copy.failed')),
+    );
+  };
+
   const paramColumns: ColumnsType<ParamRow> = [
     {
-      title: t('apiDoc.col.paramName'),
       dataIndex: 'name',
       width: 180,
       render: (value) => <Text code>{value}</Text>,
@@ -179,8 +214,6 @@ export default function ApiDoc() {
     },
   ];
 
-  const method = operation.method.toUpperCase();
-  const op = operation.operation;
   const parameters: ParamRow[] = (op.parameters ?? []).map((parameter, index) => ({
     key: `${parameter.in}-${parameter.name}-${index}`,
     name: parameter.name,
@@ -201,6 +234,18 @@ export default function ApiDoc() {
   return (
     <div style={{ padding: '0 24px 24px', maxWidth: 1080 }}>
       <OperationModeTabs activeKey="doc" />
+
+      <Space style={{ marginBottom: 8 }}>
+        <Button size="small" icon={<CopyOutlined />} onClick={handleCopyEndpoint}>
+          {t('apiDoc.copy.endpoint')}
+        </Button>
+        <Button size="small" icon={<CopyOutlined />} onClick={handleCopyMarkdown}>
+          {t('apiDoc.copy.markdown')}
+        </Button>
+        <Button size="small" icon={<CopyOutlined />} onClick={handleCopyUrl}>
+          {t('apiDoc.copy.url')}
+        </Button>
+      </Space>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
         <Tag color={METHOD_COLOR[method] ?? 'default'} style={{ fontSize: 14, padding: '2px 10px' }}>

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Space, Table, Tabs, Tag, Typography, message } from 'antd';
 import { CopyOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
+import { copyToClipboard } from '../../utils/clipboard';
 
 const { Text } = Typography;
 
@@ -81,35 +82,6 @@ const preStyle: React.CSSProperties = {
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
 };
-
-/**
- * Copies text via navigator.clipboard, with a hidden-textarea fallback
- * for older browsers / non-secure contexts. Mirrors the copy helper
- * already used by the request preview panel.
- */
-function copyToClipboard(text: string, onDone: () => void, onFail: () => void): void {
-  try {
-    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(text).then(onDone).catch(onFail);
-      return;
-    }
-  } catch {
-    // fall through to textarea fallback
-  }
-  try {
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.style.position = 'fixed';
-    ta.style.opacity = '0';
-    document.body.appendChild(ta);
-    ta.select();
-    document.execCommand('copy');
-    document.body.removeChild(ta);
-    onDone();
-  } catch {
-    onFail();
-  }
-}
 
 export default function ResponsePanel({ response, error }: ResponsePanelProps) {
   const { t } = useTranslation();

--- a/knife4j-front/knife4j-ui-react/src/utils/clipboard.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/clipboard.ts
@@ -1,0 +1,33 @@
+/**
+ * clipboard.ts — shared clipboard utility
+ *
+ * Uses navigator.clipboard.writeText when available,
+ * falls back to a hidden textarea + execCommand for older browsers.
+ */
+export function copyToClipboard(text: string, onDone: () => void, onFail: () => void): void {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(text).then(onDone).catch(onFail);
+      return;
+    }
+  } catch {
+    // fall through to textarea fallback
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    if (ok) {
+      onDone();
+    } else {
+      onFail();
+    }
+  } catch {
+    onFail();
+  }
+}


### PR DESCRIPTION
## TASK-042: ApiDoc 顶部加入复制操作

### 变更内容

- ApiDoc.tsx 顶部工具栏新增三个复制按钮：
  1. **复制接口** — 复制 `METHOD PATH`（如 `GET /api/user/{id}`）
  2. **复制文档 Markdown** — 复制整篇接口的 Markdown（含参数表格、响应结构）
  3. **复制地址** — 复制当前页面 URL
- Markdown 生成逻辑在 `knife4j-core/src/markdownExport.ts` 的 `generateApiMarkdown` 函数
- 复制行为统一走 `knife4j-ui-react/src/utils/clipboard.ts` 的 `copyToClipboard`
- 复制成功/失败均有 antd message 提示
- i18n keys 对齐 vue2：`apiDoc.copy.endpoint` / `apiDoc.copy.markdown` / `apiDoc.copy.url`

### 验证

- `tsc --noEmit`: ✅ 无错误
- `vite build`: ✅ 通过