### PR TITLE
fix(ui-react): TASK-048 dev proxy forwards /api to demo backend

### DIFF
--- a/knife4j-front/knife4j-ui-react/vite.config.ts
+++ b/knife4j-front/knife4j-ui-react/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
       '/swagger-resources': { target: BACKEND, changeOrigin: true },
       '/swagger-ui': { target: BACKEND, changeOrigin: true },
       '/doc.html': { target: BACKEND, changeOrigin: true },
+      // Demo 后端业务接口（UserController 的 /api/user/**），
+      // 供「接口文档调试」在 dev 下直接命中后端。
+      '/api': { target: BACKEND, changeOrigin: true },
     },
   },
   build: {


### PR DESCRIPTION
## Task

- Issue: #71
- Branch: `agent/TASK-048-dev-proxy-api`
- Area: `ui-react`（仅 dev-server 配置）

## Scope

`knife4j-front/knife4j-ui-react/vite.config.ts`：在 `server.proxy` 中补充 `/api` 前缀，转发到 `VITE_BACKEND`（默认 `http://localhost:8080`）。

## Why

`ApiDebug` 将 `baseUrl` 默认为 `window.location.origin`（dev 下即 `http://localhost:5173`），调试 `knife4j-demo` 的 `UserController`（`/api/user/**`）时请求直接落到 Vite dev server，报：

```
PUT http://localhost:5173/api/user/123 404 (Not Found)
```

此前 proxy 只转发了 `/v3/api-docs`、`/swagger-resources`、`/swagger-ui`、`/doc.html`，未覆盖业务前缀。

## Change

```ts
server: {
  proxy: {
    '/v3/api-docs': { target: BACKEND, changeOrigin: true },
    '/swagger-resources': { target: BACKEND, changeOrigin: true },
    '/swagger-ui': { target: BACKEND, changeOrigin: true },
    '/doc.html': { target: BACKEND, changeOrigin: true },
    // Demo 后端业务接口（UserController 的 /api/user/**），
    // 供「接口文档调试」在 dev 下直接命中后端。
    '/api': { target: BACKEND, changeOrigin: true },
  },
},
```

## Validation

- `./scripts/test-front-core.sh` ✅
  - `knife4j-core`：147 tests passed、lint、build
  - `knife4j-ui-react`：`format:check`、`tsc`、`vite build`、`lint` 全部通过

## Risks

- 仅影响 Vite dev server 的请求代理，**不影响生产 build 行为**。
- 如果用户自己的后端把 Swagger 挂在非 `/api` 的业务前缀下，仍可在调试面板里手动改 `baseUrl` 指向真实后端；这个 proxy 仅是让自带 `knife4j-demo` 开箱即用。

## Follow-up

- 无。

Closes #71