### PR TITLE
docs(agent): sync orchestrator + server playbook with CI-first policy

### DIFF
--- a/.agent/SERVER_PLAYBOOK.md
+++ b/.agent/SERVER_PLAYBOOK.md
@@ -21,14 +21,16 @@
 
 1. 拉取最新仓库状态并检查工作区是否干净。
 2. 如果当前分支对应某个 `in_progress` 任务，先处理该任务。
-3. 如果没有进行中的任务，从 `.agent/TASKS.md` 选择一个 `ready` 任务。
+3. 如果没有进行中的任务，从 GitHub Issues 选择一个 `status:ready` 任务：
+   `gh issue list --repo songxychn/knife4j-next --label agent-task --label status:ready --state open`
 4. 判断任务是否符合 `.agent/AUTONOMY_POLICY.md` 中的安全条件。
 5. 决定直接执行还是委派给 worker。
 6. 完成最小改动后，运行最窄相关验证。
 7. 需要时启动 reviewer。
-8. 更新 `.agent/PROGRESS.md` 与 `.agent/TASKS.md`。
+8. 在对应 GitHub Issue 评论里记录进度、验证结果和下一步（不再写 .agent/TASKS.md 或 .agent/PROGRESS.md，这两个文件已冻结）。
 9. 满足条件时创建或更新 PR。
-10. 停止本次运行，不继续吞下一个新任务。
+10. 等待 PR CI 终态：`gh pr checks <N> --watch`。全绿后给 issue 加 `status:review` label；CI 红时同分支修复再等（单次唤醒最多 2 轮修复尝试）。
+11. 停止本次运行，不继续吞下一个新任务。
 
 ## 任务选择策略
 
@@ -54,7 +56,7 @@
 如果分支已存在：
 
 - 优先继续已有分支
-- 如果分支状态和任务状态不一致，先更新 `.agent/TASKS.md` 和 `.agent/PROGRESS.md`
+- 如果分支状态和任务状态不一致，通过 GitHub Issue label 和评论对齐
 
 ## 什么时候派 Worker
 
@@ -81,10 +83,10 @@
 
 只有满足以下条件时才应创建或更新 PR：
 
-- 任务状态可进入 `review`
-- 至少完成该任务要求的最窄验证
-- `.agent/PROGRESS.md` 已记录摘要、验证和下一步
+- 至少完成该任务要求的最窄验证（含 `./scripts/test-*.sh`，不只用 `tsc` / `vite build` 单步替代）
+- 在对应 GitHub Issue 评论里已记录摘要、验证和下一步
 - 没有未说明的高风险残留
+- 创建 PR 后必须等 CI 全绿，才把 issue 切为 `status:review`（见 .agent/RUNBOOK.md “PR 后 CI 验证”节）
 
 PR 描述应至少包含：
 
@@ -119,8 +121,8 @@ PR 描述应至少包含：
 如果是网络、依赖源、CI 凭据、本地环境损坏等环境问题：
 
 - 不要把环境问题当成代码问题反复重试
-- 在 `.agent/PROGRESS.md` 记录失败命令和环境现象
-- 将任务标记为 `blocked`
+- 在对应 GitHub Issue 评论里记录失败命令和环境现象
+- 给 issue 加 `status:blocked` label
 
 ## 重试规则
 
@@ -139,7 +141,7 @@ PR 描述应至少包含：
 - 已完成一个任务的可审查提交
 - 已记录 blocker，等待人工
 - 已完成一次失败后的合理重试
-- 已创建或更新 PR，且没有新的安全动作可做
+- 已创建或更新 PR，CI 全绿（或 CI 红且已用完重试上限），且没有新的安全动作可做
 - 工作区出现未预期冲突或状态异常
 
 ## 状态写回规则

--- a/.agent/prompts/openclaw-orchestrator.md
+++ b/.agent/prompts/openclaw-orchestrator.md
@@ -41,9 +41,14 @@
     - 追加审查分配字段：Task id / Branch or diff to review / Changed files / Claimed behavior change / Validation already run / Known risks / Reviewer constraints
     - reviewer 返回 findings + recommendation（approve/revise/block）
     - revise 时打回 worker 修复，block 时通知维护者，approve 时继续开 PR
-11. coordinator 根据 worker handoff 结果，更新 issue 状态（label + 评论），不再修改 .agent/TASKS.md 或 .agent/PROGRESS.md。
+11. coordinator 根据 worker handoff 结果，在 issue 评论里记录进度（不再修改 .agent/TASKS.md 或 .agent/PROGRESS.md）。注意此时还不要打 `status:review`，等 CI 结果。
 12. 任务可审查时创建或更新 PR。创建 PR 后，立即通过 Telegram 通知维护者：
     `openclaw message send --account knife4j-next-bot --channel telegram --target 6358501334 --message "[TASK-XXX] PR #N 已创建：<PR 链接>"`
+13. 等待 PR CI 达到终态（见 .agent/RUNBOOK.md “PR 后 CI 验证”节）：
+    - 轮询：`gh pr checks <N> --watch`
+    - 全绿：`gh issue edit <N> --remove-label status:in-progress --add-label status:review`，并在 issue 评论声称实现完成
+    - 任一 check 红：`gh run view <run-id> --log-failed` 定位后在**同一分支**修复，重新等 CI；第二次仍红则按 .agent/SERVER_PLAYBOOK.md 的重试上限执行
+    - 不要在 CI 红的情况下把 issue 标为 `status:review`。CI 未终态前也不要切下一个任务
 
 安全规则：
 - 不要直接 push 到 master。
@@ -58,11 +63,12 @@
 - 任务状态通过 GitHub Issue label 操作，不再写入 .agent/TASKS.md 或 .agent/PROGRESS.md。
 - 状态变更命令：
   - 拾取：`gh issue edit <N> --add-label status:in-progress`
-  - 完成：`gh issue edit <N> --remove-label status:in-progress --add-label status:review`
+  - 完成（**仅在 PR CI 全绿后**）：`gh issue edit <N> --remove-label status:in-progress --add-label status:review`
   - 阻塞：`gh issue edit <N> --remove-label status:in-progress --add-label status:blocked`
   - 关闭：PR 合并后 `gh issue close <N>`
   - 进度评论：`gh issue comment <N> --body "..."`
 - 代码变更仍然走 feature branch → PR → merge 流程。
+- 本地验证 ≠ CI 验证。创建或更新 PR 后必须 `gh pr checks <N> --watch`，CI 红时同分支修复再推，不绕过。
 
 委派规则：
 - 对重文件阅读、有边界实现或独立探索使用 worker。


### PR DESCRIPTION
## 目的

同步 `openclaw-orchestrator.md` 和 `SERVER_PLAYBOOK.md`，使其与 RUNBOOK.md 新增的 CI-first 规则一致。

## 变更

### `.agent/prompts/openclaw-orchestrator.md`

1. **新增步骤 13**：创建 PR 后必须 `gh pr checks <N> --watch` 等到 CI 终态；全绿才切 `status:review`；CI 红则同分支修复再等；不绕过
2. **步骤 11 细化**：worker handoff 后先在 issue 评论记录进度，但不打 `status:review`，等 CI 结果
3. **状态变更规则强调**：`完成` 命令标注"仅在 PR CI 全绿后"；补充"本地验证 ≠ CI 验证"说明

### `.agent/SERVER_PLAYBOOK.md`

1. **消除所有 `.agent/TASKS.md` / `.agent/PROGRESS.md` 写入引用**（6 处），改为读 GitHub Issues + 写 issue comment
2. **新增步骤 10**：等 CI 终态，全绿后加 `status:review`；CI 红时同分支修复再等（单次唤醒最多 2 轮）
3. **停止条件更新**：从"创建 PR 后停止"改为"创建 PR 且 CI 全绿（或 CI 红且用完重试上限）后停止"
4. **PR 触发条件补充**：必须用 `./scripts/test-*.sh`，不能只用 `tsc + vite build` 替代；创建 PR 后必须等 CI 全绿才切 `status:review`

## 背景

之前 TASK-045 PR #69 因为只跑了 `tsc --noEmit + vite build` 就声称完成，CI 的 `prettier --check` 失败了。RUNBOOK.md 已在 PR #70 中更新，但 orchestrator prompt 和 server playbook 还在用旧流程，openclaw 会跳过 CI 验证直接标 `status:review`。

## 验证

纯 `.agent/` 文档变更，不需要 Java/前端构建验证。

