### PR TITLE
feat(ui-react): 离线文档补齐响应、新增.docx导出、修复全局参数布局

### DIFF
--- a/knife4j-front/knife4j-ui-react/package.json
+++ b/knife4j-front/knife4j-ui-react/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@types/react-router-dom": "^5.3.3",
     "antd": "^5.7.3",
+    "docx": "^9.6.1",
     "dompurify": "^3.0.6",
     "i18next": "^23.7.6",
     "i18next-browser-languagedetector": "^7.2.0",

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -234,9 +234,10 @@ const enUS = {
   // OfficeDoc
   'officeDoc.title': 'Offline Document Export',
   'officeDoc.desc':
-    'Export the current API documentation as a downloadable offline file. Supports HTML and Word (.doc) formats.',
+    'Export the current API documentation as a downloadable offline file. Supports HTML, Word (.docx), and Word (.doc) formats.',
   'officeDoc.alert.mockData': 'Mock data or unloaded document detected; exported content may be incomplete.',
   'officeDoc.btn.html': 'Download HTML',
+  'officeDoc.btn.docx': 'Download Word (.docx)',
   'officeDoc.btn.word': 'Download Word (.doc)',
 
   // Tab context menu

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -233,9 +233,10 @@ const zhCN = {
 
   // OfficeDoc
   'officeDoc.title': '离线文档导出',
-  'officeDoc.desc': '将当前接口文档导出为可下载的离线文件，支持 HTML 和 Word（.doc）格式。',
+  'officeDoc.desc': '将当前接口文档导出为可下载的离线文件，支持 HTML、Word（.docx）和 Word（.doc）格式。',
   'officeDoc.alert.mockData': '当前使用 Mock 数据或文档未加载，导出内容可能不完整。',
   'officeDoc.btn.html': '下载 HTML',
+  'officeDoc.btn.docx': '下载 Word (.docx)',
   'officeDoc.btn.word': '下载 Word (.doc)',
 
   // Tab context menu

--- a/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Form, Input, Select, Space, Table } from 'antd';
+import { Button, Form, Input, Select, Table } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { GlobalParamItem, useGlobalParam } from '../../context/GlobalParamContext';
@@ -43,10 +43,10 @@ function GlobalParamInner() {
         style={{ marginBottom: 16 }}
       >
         <Form.Item name="name" rules={[{ required: true, message: t('globalParam.validation.name') }]}>
-          <Input placeholder={t('globalParam.placeholder.name')} />
+          <Input placeholder={t('globalParam.placeholder.name')} style={{ width: 160 }} />
         </Form.Item>
         <Form.Item name="value" rules={[{ required: true, message: t('globalParam.validation.value') }]}>
-          <Input placeholder={t('globalParam.placeholder.value')} />
+          <Input placeholder={t('globalParam.placeholder.value')} style={{ width: 160 }} />
         </Form.Item>
         <Form.Item name="in">
           <Select style={{ width: 100 }}>
@@ -55,11 +55,9 @@ function GlobalParamInner() {
           </Select>
         </Form.Item>
         <Form.Item>
-          <Space>
-            <Button type="primary" htmlType="submit" loading={loading}>
-              {t('globalParam.btn.add')}
-            </Button>
-          </Space>
+          <Button type="primary" htmlType="submit" loading={loading}>
+            {t('globalParam.btn.add')}
+          </Button>
         </Form.Item>
       </Form>
 

--- a/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx
@@ -35,30 +35,38 @@ function GlobalParamInner() {
 
   return (
     <div id="knife4j-global-param-page" style={{ padding: 16 }}>
-      <Form
-        form={form}
-        layout="inline"
-        onFinish={onFinish}
-        initialValues={{ in: 'header' }}
-        style={{ marginBottom: 16 }}
-      >
-        <Form.Item name="name" rules={[{ required: true, message: t('globalParam.validation.name') }]}>
-          <Input placeholder={t('globalParam.placeholder.name')} style={{ width: 160 }} />
-        </Form.Item>
-        <Form.Item name="value" rules={[{ required: true, message: t('globalParam.validation.value') }]}>
-          <Input placeholder={t('globalParam.placeholder.value')} style={{ width: 160 }} />
-        </Form.Item>
-        <Form.Item name="in">
-          <Select style={{ width: 100 }}>
-            <Select.Option value="header">header</Select.Option>
-            <Select.Option value="query">query</Select.Option>
-          </Select>
-        </Form.Item>
-        <Form.Item>
-          <Button type="primary" htmlType="submit" loading={loading}>
-            {t('globalParam.btn.add')}
-          </Button>
-        </Form.Item>
+      <Form form={form} onFinish={onFinish} initialValues={{ in: 'header' }} style={{ marginBottom: 16 }}>
+        {/*
+         * 使用 flex 布局（而非 Form layout="inline"），让三个输入控件在一行内
+         * 按剩余空间自适应收缩，按钮始终贴在最右侧，避免在 Drawer (600px) 等狭窄容器里被挤到下一行。
+         */}
+        <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', flexWrap: 'nowrap' }}>
+          <Form.Item
+            name="name"
+            rules={[{ required: true, message: t('globalParam.validation.name') }]}
+            style={{ flex: 1, minWidth: 0, marginBottom: 0 }}
+          >
+            <Input placeholder={t('globalParam.placeholder.name')} />
+          </Form.Item>
+          <Form.Item
+            name="value"
+            rules={[{ required: true, message: t('globalParam.validation.value') }]}
+            style={{ flex: 1, minWidth: 0, marginBottom: 0 }}
+          >
+            <Input placeholder={t('globalParam.placeholder.value')} />
+          </Form.Item>
+          <Form.Item name="in" style={{ flex: '0 0 96px', marginBottom: 0 }}>
+            <Select style={{ width: '100%' }}>
+              <Select.Option value="header">header</Select.Option>
+              <Select.Option value="query">query</Select.Option>
+            </Select>
+          </Form.Item>
+          <Form.Item style={{ flex: '0 0 auto', marginBottom: 0 }}>
+            <Button type="primary" htmlType="submit" loading={loading}>
+              {t('globalParam.btn.add')}
+            </Button>
+          </Form.Item>
+        </div>
       </Form>
 
       <Table dataSource={params} columns={columns} rowKey="id" pagination={false} size="small" />

--- a/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
@@ -1,8 +1,29 @@
 import { Button, Space, Typography, Alert } from 'antd';
 import { FileTextOutlined, FileWordOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
+import {
+  Document,
+  Packer,
+  Paragraph as DocxParagraph,
+  TextRun,
+  Table as DocxTable,
+  TableRow as DocxTableRow,
+  TableCell as DocxTableCell,
+  WidthType,
+  AlignmentType,
+  BorderStyle,
+  HeadingLevel,
+  ShadingType,
+} from 'docx';
 import { useGroup } from '../../context/GroupContext';
-import type { SwaggerDoc, MenuTag, OperationObject, ParameterObject, SchemaObject } from '../../types/swagger';
+import type {
+  SwaggerDoc,
+  MenuTag,
+  OperationObject,
+  ParameterObject,
+  ResponseObject,
+  SchemaObject,
+} from '../../types/swagger';
 
 const { Title, Paragraph } = Typography;
 
@@ -109,6 +130,96 @@ function renderRequestBodyTable(op: OperationObject, doc: SwaggerDoc, borderStyl
     </table>`;
 }
 
+/** Render a schema's properties as table rows, resolving $ref recursively. */
+function renderSchemaRows(
+  schema: SchemaObject,
+  doc: SwaggerDoc,
+  borderStyle: string,
+  requiredSet: Set<string>,
+  prefix = '',
+): string {
+  if (schema.$ref) {
+    const resolved = resolveRef(schema.$ref, doc);
+    if (!resolved) return '';
+    return renderSchemaRows(
+      resolved,
+      doc,
+      borderStyle,
+      resolved.required ? new Set(resolved.required) : new Set<string>(),
+      prefix,
+    );
+  }
+  if (!schema.properties) return '';
+  return Object.entries(schema.properties)
+    .map(([name, prop]) => {
+      const fieldPath = prefix ? `${prefix}.${name}` : name;
+      const type = prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object');
+      const nested = prop.properties || (prop.$ref ? resolveRef(prop.$ref, doc) : undefined)?.properties;
+      let rows = `
+    <tr>
+      <td style="${borderStyle}">${escapeHtml(fieldPath)}</td>
+      <td style="${borderStyle}">${escapeHtml(type)}${prop.items?.type ? `&lt;${escapeHtml(prop.items.type)}&gt;` : ''}</td>
+      <td style="${borderStyle}">${requiredSet.has(name) ? 'Yes' : 'No'}</td>
+      <td style="${borderStyle}">${escapeHtml(prop.description)}</td>
+    </tr>`;
+      if (nested || (prop.$ref && resolveRef(prop.$ref, doc)?.properties)) {
+        const resolved = prop.$ref ? resolveRef(prop.$ref, doc) : prop;
+        if (resolved?.properties) {
+          const childRequired = resolved.required ? new Set(resolved.required) : new Set<string>();
+          rows += renderSchemaRows(resolved, doc, borderStyle, childRequired, fieldPath);
+        }
+      }
+      return rows;
+    })
+    .join('');
+}
+
+/** Render responses section for an operation (used by both HTML and Word exports). */
+function renderResponseSection(op: OperationObject, doc: SwaggerDoc, borderStyle: string): string {
+  const responses = op.responses;
+  if (!responses || !Object.keys(responses).length) return '';
+
+  const entries = Object.entries(responses);
+  const parts: string[] = [];
+
+  for (const [statusCode, resp] of entries) {
+    const response = resp as ResponseObject;
+    const desc = response.description ?? '';
+    // Try OAS3 first, then OAS2
+    const schema = response.content?.['application/json']?.schema ?? response.schema;
+
+    if (schema) {
+      let resolved = schema;
+      if (schema.$ref) {
+        const refResolved = resolveRef(schema.$ref, doc);
+        if (refResolved) resolved = refResolved;
+      }
+      const requiredSet = new Set(resolved.required ?? []);
+      const rows = renderSchemaRows(resolved, doc, borderStyle, requiredSet);
+      if (rows) {
+        parts.push(`
+      <p style="margin:6px 0 2px;font-size:13px;font-weight:600;">Response ${escapeHtml(statusCode)}${desc ? ' — ' + escapeHtml(desc) : ''} (application/json)</p>
+      <table style="width:100%;border-collapse:collapse;margin:4px 0;font-size:13px;">
+        <thead><tr style="background:#f5f5f5;">
+          <th style="${borderStyle}text-align:left;">Field</th>
+          <th style="${borderStyle}text-align:left;">Type</th>
+          <th style="${borderStyle}text-align:left;">Required</th>
+          <th style="${borderStyle}text-align:left;">Description</th>
+        </tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`);
+        continue;
+      }
+    }
+    // No schema or no properties — just show status + description
+    parts.push(
+      `<p style="margin:6px 0 2px;font-size:13px;font-weight:600;">Response ${escapeHtml(statusCode)}${desc ? ' — ' + escapeHtml(desc) : ''}</p>`,
+    );
+  }
+
+  return parts.length ? parts.join('') : '';
+}
+
 function renderOperation(path: string, method: string, op: OperationObject, doc: SwaggerDoc): string {
   const color = methodColor(method);
   const params = op.parameters ?? [];
@@ -124,6 +235,10 @@ function renderOperation(path: string, method: string, op: OperationObject, doc:
       ${op.description ? `<div style="padding:3px 12px;font-size:13px;color:#666;">${escapeHtml(op.description)}</div>` : ''}
       ${params.length ? `<div style="padding:5px 12px;">${renderParamTable(params)}</div>` : ''}
       ${bodyHtml ? `<div style="padding:5px 12px;">${bodyHtml}</div>` : ''}
+      ${(() => {
+        const r = renderResponseSection(op, doc, 'border:1px solid #ddd;padding:5px 8px;');
+        return r ? `<div style="padding:5px 12px;">${r}</div>` : '';
+      })()}
     </div>`;
 }
 
@@ -198,12 +313,14 @@ function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
         </table>`
             : '';
           const bodyHtml = renderRequestBodyTable(op.operation, doc, 'border:1px solid #000;padding:4px 6px;');
+          const responseHtml = renderResponseSection(op.operation, doc, 'border:1px solid #000;padding:4px 6px;');
           return `
         <div style="margin:10px 0;padding:8px;border:1px solid #ccc;">
           <p style="margin:0 0 4px;"><strong style="color:${methodColor(op.method)};">[${escapeHtml(op.method.toUpperCase())}]</strong> <code>${escapeHtml(op.path)}</code>${op.operation.deprecated ? ' <em style="color:red;">[Deprecated]</em>' : ''}</p>
           ${op.operation.summary ? `<p style="margin:2px 0;font-size:13px;">${escapeHtml(op.operation.summary)}</p>` : ''}
           ${paramTable}
           ${bodyHtml}
+          ${responseHtml}
         </div>`;
         })
         .join('');
@@ -234,6 +351,251 @@ function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
 </html>`;
 }
 
+// ─── docx helpers ────────────────────────────────────────────────
+
+const THIN_BORDER = {
+  top: { style: BorderStyle.SINGLE, size: 1, color: '999999' },
+  bottom: { style: BorderStyle.SINGLE, size: 1, color: '999999' },
+  left: { style: BorderStyle.SINGLE, size: 1, color: '999999' },
+  right: { style: BorderStyle.SINGLE, size: 1, color: '999999' },
+};
+
+function docxTextCell(text: string, opts?: { bold?: boolean; shading?: string }): DocxTableCell {
+  return new DocxTableCell({
+    borders: THIN_BORDER,
+    width: { size: 25, type: WidthType.PERCENTAGE },
+    shading: opts?.shading ? { type: ShadingType.SOLID, color: opts.shading } : undefined,
+    children: [
+      new DocxParagraph({
+        children: [new TextRun({ text, bold: opts?.bold, size: 20 })],
+        spacing: { before: 40, after: 40 },
+      }),
+    ],
+  });
+}
+
+/** Build schema rows for docx table, resolving $ref recursively. */
+function docxSchemaRows(schema: SchemaObject, doc: SwaggerDoc, requiredSet: Set<string>, prefix = ''): DocxTableRow[] {
+  if (schema.$ref) {
+    const resolved = resolveRef(schema.$ref, doc);
+    if (!resolved) return [];
+    return docxSchemaRows(resolved, doc, resolved.required ? new Set(resolved.required) : new Set<string>(), prefix);
+  }
+  if (!schema.properties) return [];
+  const rows: DocxTableRow[] = [];
+  for (const [name, prop] of Object.entries(schema.properties)) {
+    const fieldPath = prefix ? `${prefix}.${name}` : name;
+    const type = prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object');
+    const itemType = prop.items?.type ? `<${prop.items.type}>` : '';
+    rows.push(
+      new DocxTableRow({
+        children: [
+          docxTextCell(fieldPath),
+          docxTextCell(`${type}${itemType}`),
+          docxTextCell(requiredSet.has(name) ? 'Yes' : 'No'),
+          docxTextCell(prop.description ?? ''),
+        ],
+      }),
+    );
+    // Recurse into nested objects
+    const nested = prop.properties || (prop.$ref ? resolveRef(prop.$ref, doc) : undefined)?.properties;
+    if (nested) {
+      const resolved = prop.$ref ? resolveRef(prop.$ref, doc) : prop;
+      if (resolved?.properties) {
+        const childRequired = resolved.required ? new Set(resolved.required) : new Set<string>();
+        rows.push(...docxSchemaRows(resolved, doc, childRequired, fieldPath));
+      }
+    }
+  }
+  return rows;
+}
+
+function docxParamRows(params: ParameterObject[]): DocxTableRow[] {
+  return params.map(
+    (p) =>
+      new DocxTableRow({
+        children: [
+          docxTextCell(p.name),
+          docxTextCell(p.in),
+          docxTextCell(p.required ? 'Yes' : 'No'),
+          docxTextCell(p.schema?.type ?? p.type ?? ''),
+          docxTextCell(p.description ?? ''),
+        ],
+      }),
+  );
+}
+
+function docxRequestBodySection(op: OperationObject, doc: SwaggerDoc): (DocxParagraph | DocxTable)[] {
+  const rb = op.requestBody;
+  if (!rb) return [];
+  const jsonContent = rb.content?.['application/json'];
+  if (!jsonContent?.schema) return [];
+  let schema = jsonContent.schema;
+  if (schema.$ref) {
+    const resolved = resolveRef(schema.$ref, doc);
+    if (!resolved) return [];
+    schema = resolved;
+  }
+  if (!schema.properties) return [];
+  const requiredSet = new Set(schema.required ?? []);
+  const headerRow = new DocxTableRow({
+    children: [
+      docxTextCell('Field', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Type', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Required', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Description', { bold: true, shading: 'f5f5f5' }),
+    ],
+  });
+  const dataRows = docxSchemaRows(schema, doc, requiredSet);
+  return [
+    new DocxParagraph({
+      children: [new TextRun({ text: 'Request Body (application/json)', bold: true, size: 22 })],
+      spacing: { before: 120, after: 40 },
+    }),
+    new DocxTable({ rows: [headerRow, ...dataRows], width: { size: 100, type: WidthType.PERCENTAGE } }),
+  ];
+}
+
+function docxResponseSection(op: OperationObject, doc: SwaggerDoc): (DocxParagraph | DocxTable)[] {
+  const responses = op.responses;
+  if (!responses || !Object.keys(responses).length) return [];
+  const children: (DocxParagraph | DocxTable)[] = [];
+  for (const [statusCode, resp] of Object.entries(responses)) {
+    const response = resp as ResponseObject;
+    const desc = response.description ?? '';
+    const schema = response.content?.['application/json']?.schema ?? response.schema;
+    const label = desc ? `Response ${statusCode} — ${desc}` : `Response ${statusCode}`;
+    if (schema) {
+      let resolved = schema;
+      if (schema.$ref) {
+        const refResolved = resolveRef(schema.$ref, doc);
+        if (refResolved) resolved = refResolved;
+      }
+      const requiredSet = new Set(resolved.required ?? []);
+      const rows = docxSchemaRows(resolved, doc, requiredSet);
+      if (rows.length) {
+        const headerRow = new DocxTableRow({
+          children: [
+            docxTextCell('Field', { bold: true, shading: 'f5f5f5' }),
+            docxTextCell('Type', { bold: true, shading: 'f5f5f5' }),
+            docxTextCell('Required', { bold: true, shading: 'f5f5f5' }),
+            docxTextCell('Description', { bold: true, shading: 'f5f5f5' }),
+          ],
+        });
+        children.push(
+          new DocxParagraph({
+            children: [new TextRun({ text: `${label} (application/json)`, bold: true, size: 22 })],
+            spacing: { before: 120, after: 40 },
+          }),
+          new DocxTable({ rows: [headerRow, ...rows], width: { size: 100, type: WidthType.PERCENTAGE } }),
+        );
+        continue;
+      }
+    }
+    children.push(
+      new DocxParagraph({
+        children: [new TextRun({ text: label, bold: true, size: 22 })],
+        spacing: { before: 120, after: 40 },
+      }),
+    );
+  }
+  return children;
+}
+
+async function buildDocx(doc: SwaggerDoc, tags: MenuTag[]): Promise<Blob> {
+  const children: (DocxParagraph | DocxTable)[] = [];
+
+  // Title & info
+  children.push(
+    new DocxParagraph({
+      text: doc.info.title,
+      heading: HeadingLevel.TITLE,
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 200 },
+    }),
+  );
+  children.push(new DocxParagraph({ children: [new TextRun({ text: `Version: ${doc.info.version}`, size: 22 })] }));
+  if (doc.info.description) {
+    children.push(
+      new DocxParagraph({ children: [new TextRun({ text: `Description: ${doc.info.description}`, size: 22 })] }),
+    );
+  }
+  children.push(new DocxParagraph({ text: '' })); // spacer
+
+  for (const t of tags) {
+    children.push(
+      new DocxParagraph({
+        text: t.tag,
+        heading: HeadingLevel.HEADING_2,
+        spacing: { before: 300, after: 100 },
+      }),
+    );
+    if (t.description) {
+      children.push(
+        new DocxParagraph({
+          children: [new TextRun({ text: t.description, italics: true, color: '666666', size: 22 })],
+          spacing: { after: 80 },
+        }),
+      );
+    }
+
+    for (const op of t.operations) {
+      const method = op.method.toUpperCase();
+      const path = op.path;
+      // Method + Path heading
+      children.push(
+        new DocxParagraph({
+          children: [
+            new TextRun({ text: `[${method}] `, bold: true, color: methodColor(op.method).replace('#', ''), size: 24 }),
+            new TextRun({ text: path, font: 'Courier New', size: 24 }),
+            ...(op.operation.deprecated ? [new TextRun({ text: ' [Deprecated]', color: 'f93e3e', size: 22 })] : []),
+          ],
+          spacing: { before: 200, after: 60 },
+        }),
+      );
+      if (op.operation.summary) {
+        children.push(new DocxParagraph({ children: [new TextRun({ text: op.operation.summary, size: 22 })] }));
+      }
+
+      // Parameters table
+      const params = op.operation.parameters ?? [];
+      if (params.length) {
+        const paramHeader = new DocxTableRow({
+          children: [
+            docxTextCell('Name', { bold: true, shading: 'f5f5f5' }),
+            docxTextCell('In', { bold: true, shading: 'f5f5f5' }),
+            docxTextCell('Required', { bold: true, shading: 'f5f5f5' }),
+            docxTextCell('Type', { bold: true, shading: 'f5f5f5' }),
+            docxTextCell('Description', { bold: true, shading: 'f5f5f5' }),
+          ],
+        });
+        children.push(
+          new DocxParagraph({
+            children: [new TextRun({ text: 'Parameters', bold: true, size: 22 })],
+            spacing: { before: 80, after: 40 },
+          }),
+          new DocxTable({
+            rows: [paramHeader, ...docxParamRows(params)],
+            width: { size: 100, type: WidthType.PERCENTAGE },
+          }),
+        );
+      }
+
+      // Request body
+      children.push(...docxRequestBodySection(op.operation, doc));
+
+      // Responses
+      children.push(...docxResponseSection(op.operation, doc));
+    }
+  }
+
+  const document = new Document({
+    sections: [{ children }],
+  });
+
+  return Packer.toBlob(document);
+}
+
 export default function OfficeDoc() {
   const { t } = useTranslation();
   const { swaggerDoc, menuTags, loading, usingMock } = useGroup();
@@ -252,6 +614,18 @@ export default function OfficeDoc() {
     downloadBlob(html, `${title}.doc`, 'application/msword');
   }
 
+  async function handleDownloadDocx() {
+    if (!swaggerDoc) return;
+    const blob = await buildDocx(swaggerDoc, menuTags);
+    const title = swaggerDoc.info.title || 'api-docs';
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = sanitizeFilename(`${title}.docx`);
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 100);
+  }
+
   const noData = !loading && (!swaggerDoc || usingMock);
 
   return (
@@ -265,7 +639,7 @@ export default function OfficeDoc() {
 
       {noData && <Alert type="warning" message={t('officeDoc.alert.mockData')} style={{ marginBottom: 16 }} />}
 
-      <Space size="middle">
+      <Space size="middle" wrap>
         <Button
           type="primary"
           icon={<FileTextOutlined />}
@@ -274,6 +648,14 @@ export default function OfficeDoc() {
           loading={loading}
         >
           {t('officeDoc.btn.html')}
+        </Button>
+        <Button
+          icon={<FileWordOutlined />}
+          onClick={handleDownloadDocx}
+          disabled={loading || !swaggerDoc || usingMock}
+          loading={loading}
+        >
+          {t('officeDoc.btn.docx')}
         </Button>
         <Button
           icon={<FileWordOutlined />}

--- a/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx
@@ -59,6 +59,150 @@ function methodColor(method: string): string {
   return map[method.toUpperCase()] ?? '#999';
 }
 
+function resolveRef(ref: string, doc: SwaggerDoc): SchemaObject | undefined {
+  const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
+  if (!match) return undefined;
+  return (doc.components?.schemas ?? (doc.definitions as Record<string, SchemaObject> | undefined) ?? {})[match[1]];
+}
+
+/**
+ * 根据 schema 推导出可读类型名。
+ *   $ref  -> "UserVO"
+ *   array -> "UserVO[]" / "string[]"
+ *   原子  -> "string / int32" / "integer"
+ *   其他  -> "object"
+ */
+function schemaDisplayType(schema?: SchemaObject): string {
+  if (!schema) return '';
+  if (schema.$ref) return schema.$ref.split('/').pop() ?? '$ref';
+  if (schema.type === 'array') {
+    const inner = schemaDisplayType(schema.items);
+    return `${inner || 'object'}[]`;
+  }
+  const parts = [schema.type, schema.format].filter(Boolean);
+  return parts.length ? parts.join(' / ') : 'object';
+}
+
+/**
+ * 从 content 里挑一个可展示的 schema：优先 application/json，否则第一个带 schema 的 entry；
+ * 兜底 OAS2 的 response.schema / requestBody.schema。
+ */
+function pickContentSchema(
+  content: Record<string, { schema?: SchemaObject }> | undefined,
+  fallback?: SchemaObject,
+): { mediaType: string; schema: SchemaObject } | undefined {
+  if (content) {
+    const json = content['application/json'];
+    if (json?.schema) return { mediaType: 'application/json', schema: json.schema };
+    for (const [mediaType, entry] of Object.entries(content)) {
+      if (entry?.schema) return { mediaType, schema: entry.schema };
+    }
+  }
+  if (fallback) return { mediaType: 'application/json', schema: fallback };
+  return undefined;
+}
+
+/** 循环解 $ref，防止自引用死循环。 */
+function unwrapRef(schema: SchemaObject, doc: SwaggerDoc, seen: Set<string> = new Set()): SchemaObject {
+  let current = schema;
+  while (current.$ref) {
+    if (seen.has(current.$ref)) return current;
+    seen.add(current.$ref);
+    const resolved = resolveRef(current.$ref, doc);
+    if (!resolved) return current;
+    current = resolved;
+  }
+  return current;
+}
+
+interface FieldRow {
+  fieldPath: string;
+  typeDisplay: string;
+  required: boolean;
+  description: string;
+}
+
+/**
+ * 把 schema 展开成字段行列表：
+ *   object     -> 遍历 properties
+ *   array      -> 进入 items；若 items 是 object 就展开字段（路径加 []）
+ *   $ref       -> 先解 ref 再处理
+ *   原子类型   -> 返回空数组，交给外部“Type:”行单独表达
+ */
+function flattenSchemaFields(
+  schema: SchemaObject,
+  doc: SwaggerDoc,
+  prefix = '',
+  requiredSet: Set<string> = new Set(),
+  depth = 0,
+  seenRefs: Set<string> = new Set(),
+): FieldRow[] {
+  if (depth > 6) return [];
+
+  if (schema.$ref) {
+    if (seenRefs.has(schema.$ref)) return [];
+    const nextSeen = new Set(seenRefs);
+    nextSeen.add(schema.$ref);
+    const resolved = resolveRef(schema.$ref, doc);
+    if (!resolved) return [];
+    return flattenSchemaFields(
+      resolved,
+      doc,
+      prefix,
+      resolved.required ? new Set(resolved.required) : new Set<string>(),
+      depth,
+      nextSeen,
+    );
+  }
+
+  if (schema.type === 'array' && schema.items) {
+    return flattenSchemaFields(schema.items, doc, prefix, requiredSet, depth, seenRefs);
+  }
+
+  const rows: FieldRow[] = [];
+  if (!schema.properties) return rows;
+
+  for (const [name, prop] of Object.entries(schema.properties)) {
+    const fieldPath = prefix ? `${prefix}.${name}` : name;
+    rows.push({
+      fieldPath,
+      typeDisplay: schemaDisplayType(prop),
+      required: requiredSet.has(name),
+      description: prop.description ?? '',
+    });
+
+    const nextSeen = new Set(seenRefs);
+    if (prop.$ref) nextSeen.add(prop.$ref);
+    const resolvedProp = prop.$ref ? unwrapRef(prop, doc, new Set(seenRefs)) : prop;
+    if (!resolvedProp) continue;
+
+    if (resolvedProp.properties) {
+      rows.push(
+        ...flattenSchemaFields(resolvedProp, doc, fieldPath, new Set(resolvedProp.required ?? []), depth + 1, nextSeen),
+      );
+    } else if (resolvedProp.type === 'array' && resolvedProp.items) {
+      const itemSchema = resolvedProp.items.$ref
+        ? unwrapRef(resolvedProp.items, doc, new Set(nextSeen))
+        : resolvedProp.items;
+      if (itemSchema?.properties) {
+        rows.push(
+          ...flattenSchemaFields(
+            itemSchema,
+            doc,
+            `${fieldPath}[]`,
+            new Set(itemSchema.required ?? []),
+            depth + 1,
+            nextSeen,
+          ),
+        );
+      }
+    }
+  }
+  return rows;
+}
+
+// ─── HTML renderers ─────────────────────────────────────────────────────────
+
 function renderParamTable(params: ParameterObject[]): string {
   if (!params.length) return '';
   const rows = params
@@ -68,7 +212,7 @@ function renderParamTable(params: ParameterObject[]): string {
       <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.name)}</td>
       <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.in)}</td>
       <td style="border:1px solid #ddd;padding:5px 8px;">${p.required ? 'Yes' : 'No'}</td>
-      <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.schema?.type ?? p.type ?? '')}</td>
+      <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(schemaDisplayType(p.schema) || p.type || '')}</td>
       <td style="border:1px solid #ddd;padding:5px 8px;">${escapeHtml(p.description)}</td>
     </tr>`,
     )
@@ -86,39 +230,20 @@ function renderParamTable(params: ParameterObject[]): string {
     </table>`;
 }
 
-function resolveRef(ref: string, doc: SwaggerDoc): SchemaObject | undefined {
-  const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
-  if (!match) return undefined;
-  return (doc.components?.schemas ?? (doc.definitions as Record<string, SchemaObject> | undefined) ?? {})[match[1]];
-}
-
-function renderRequestBodyTable(op: OperationObject, doc: SwaggerDoc, borderStyle: string): string {
-  const rb = op.requestBody;
-  if (!rb) return '';
-  const jsonContent = rb.content?.['application/json'];
-  if (!jsonContent?.schema) return '';
-  let schema = jsonContent.schema;
-  if (schema.$ref) {
-    const resolved = resolveRef(schema.$ref, doc);
-    if (!resolved) return '';
-    schema = resolved;
-  }
-  if (!schema.properties) return '';
-  const requiredSet = new Set(schema.required ?? []);
-  const rows = Object.entries(schema.properties)
-    .map(([name, prop]) => {
-      const type = prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object');
-      return `
+function renderFieldTable(rows: FieldRow[], borderStyle: string): string {
+  if (!rows.length) return '';
+  const body = rows
+    .map(
+      (r) => `
     <tr>
-      <td style="${borderStyle}">${escapeHtml(name)}</td>
-      <td style="${borderStyle}">${escapeHtml(type)}</td>
-      <td style="${borderStyle}">${requiredSet.has(name) ? 'Yes' : 'No'}</td>
-      <td style="${borderStyle}">${escapeHtml(prop.description)}</td>
-    </tr>`;
-    })
+      <td style="${borderStyle}">${escapeHtml(r.fieldPath)}</td>
+      <td style="${borderStyle}">${escapeHtml(r.typeDisplay)}</td>
+      <td style="${borderStyle}">${r.required ? 'Yes' : 'No'}</td>
+      <td style="${borderStyle}">${escapeHtml(r.description)}</td>
+    </tr>`,
+    )
     .join('');
   return `
-    <p style="margin:6px 0 2px;font-size:13px;font-weight:600;">Request Body (application/json)</p>
     <table style="width:100%;border-collapse:collapse;margin:4px 0;font-size:13px;">
       <thead><tr style="background:#f5f5f5;">
         <th style="${borderStyle}text-align:left;">Field</th>
@@ -126,104 +251,71 @@ function renderRequestBodyTable(op: OperationObject, doc: SwaggerDoc, borderStyl
         <th style="${borderStyle}text-align:left;">Required</th>
         <th style="${borderStyle}text-align:left;">Description</th>
       </tr></thead>
-      <tbody>${rows}</tbody>
+      <tbody>${body}</tbody>
     </table>`;
 }
 
-/** Render a schema's properties as table rows, resolving $ref recursively. */
-function renderSchemaRows(
-  schema: SchemaObject,
-  doc: SwaggerDoc,
-  borderStyle: string,
-  requiredSet: Set<string>,
-  prefix = '',
-): string {
-  if (schema.$ref) {
-    const resolved = resolveRef(schema.$ref, doc);
-    if (!resolved) return '';
-    return renderSchemaRows(
-      resolved,
-      doc,
-      borderStyle,
-      resolved.required ? new Set(resolved.required) : new Set<string>(),
-      prefix,
-    );
-  }
-  if (!schema.properties) return '';
-  return Object.entries(schema.properties)
-    .map(([name, prop]) => {
-      const fieldPath = prefix ? `${prefix}.${name}` : name;
-      const type = prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object');
-      const nested = prop.properties || (prop.$ref ? resolveRef(prop.$ref, doc) : undefined)?.properties;
-      let rows = `
-    <tr>
-      <td style="${borderStyle}">${escapeHtml(fieldPath)}</td>
-      <td style="${borderStyle}">${escapeHtml(type)}${prop.items?.type ? `&lt;${escapeHtml(prop.items.type)}&gt;` : ''}</td>
-      <td style="${borderStyle}">${requiredSet.has(name) ? 'Yes' : 'No'}</td>
-      <td style="${borderStyle}">${escapeHtml(prop.description)}</td>
-    </tr>`;
-      if (nested || (prop.$ref && resolveRef(prop.$ref, doc)?.properties)) {
-        const resolved = prop.$ref ? resolveRef(prop.$ref, doc) : prop;
-        if (resolved?.properties) {
-          const childRequired = resolved.required ? new Set(resolved.required) : new Set<string>();
-          rows += renderSchemaRows(resolved, doc, borderStyle, childRequired, fieldPath);
-        }
-      }
-      return rows;
-    })
-    .join('');
+function renderRequestBodySection(op: OperationObject, doc: SwaggerDoc, borderStyle: string): string {
+  const rb = op.requestBody;
+  if (!rb) return '';
+  const picked = pickContentSchema(rb.content);
+  if (!picked) return '';
+  const unwrapped = unwrapRef(picked.schema, doc);
+  const rows = flattenSchemaFields(unwrapped, doc, '', new Set(unwrapped.required ?? []));
+  const typeDisplay = schemaDisplayType(picked.schema);
+  return `
+    <p style="margin:6px 0 2px;font-size:13px;font-weight:600;">Request Body (${escapeHtml(picked.mediaType)}) &nbsp;<span style="font-weight:400;color:#555;">Type: <code>${escapeHtml(typeDisplay)}</code></span></p>
+    ${rows.length ? renderFieldTable(rows, borderStyle) : ''}`;
 }
 
-/** Render responses section for an operation (used by both HTML and Word exports). */
 function renderResponseSection(op: OperationObject, doc: SwaggerDoc, borderStyle: string): string {
   const responses = op.responses;
   if (!responses || !Object.keys(responses).length) return '';
 
-  const entries = Object.entries(responses);
-  const parts: string[] = [];
+  const parts: string[] = ['<p style="margin:8px 0 2px;font-size:13px;font-weight:600;">Responses</p>'];
+  parts.push(`
+    <table style="width:100%;border-collapse:collapse;margin:4px 0 10px;font-size:13px;">
+      <thead><tr style="background:#f5f5f5;">
+        <th style="${borderStyle}text-align:left;width:90px;">Code</th>
+        <th style="${borderStyle}text-align:left;">Description</th>
+        <th style="${borderStyle}text-align:left;width:220px;">Schema</th>
+      </tr></thead>
+      <tbody>
+        ${Object.entries(responses)
+          .map(([code, resp]) => {
+            const r = resp as ResponseObject;
+            const picked = pickContentSchema(r.content, r.schema);
+            const typeDisplay = picked ? schemaDisplayType(picked.schema) : '—';
+            return `<tr>
+              <td style="${borderStyle}"><code>${escapeHtml(code)}</code></td>
+              <td style="${borderStyle}">${escapeHtml(r.description ?? '')}</td>
+              <td style="${borderStyle}"><code>${escapeHtml(typeDisplay)}</code></td>
+            </tr>`;
+          })
+          .join('')}
+      </tbody>
+    </table>`);
 
-  for (const [statusCode, resp] of entries) {
-    const response = resp as ResponseObject;
-    const desc = response.description ?? '';
-    // Try OAS3 first, then OAS2
-    const schema = response.content?.['application/json']?.schema ?? response.schema;
-
-    if (schema) {
-      let resolved = schema;
-      if (schema.$ref) {
-        const refResolved = resolveRef(schema.$ref, doc);
-        if (refResolved) resolved = refResolved;
-      }
-      const requiredSet = new Set(resolved.required ?? []);
-      const rows = renderSchemaRows(resolved, doc, borderStyle, requiredSet);
-      if (rows) {
-        parts.push(`
-      <p style="margin:6px 0 2px;font-size:13px;font-weight:600;">Response ${escapeHtml(statusCode)}${desc ? ' — ' + escapeHtml(desc) : ''} (application/json)</p>
-      <table style="width:100%;border-collapse:collapse;margin:4px 0;font-size:13px;">
-        <thead><tr style="background:#f5f5f5;">
-          <th style="${borderStyle}text-align:left;">Field</th>
-          <th style="${borderStyle}text-align:left;">Type</th>
-          <th style="${borderStyle}text-align:left;">Required</th>
-          <th style="${borderStyle}text-align:left;">Description</th>
-        </tr></thead>
-        <tbody>${rows}</tbody>
-      </table>`);
-        continue;
-      }
-    }
-    // No schema or no properties — just show status + description
-    parts.push(
-      `<p style="margin:6px 0 2px;font-size:13px;font-weight:600;">Response ${escapeHtml(statusCode)}${desc ? ' — ' + escapeHtml(desc) : ''}</p>`,
-    );
+  for (const [code, resp] of Object.entries(responses)) {
+    const r = resp as ResponseObject;
+    const picked = pickContentSchema(r.content, r.schema);
+    if (!picked) continue;
+    const unwrapped = unwrapRef(picked.schema, doc);
+    const rows = flattenSchemaFields(unwrapped, doc, '', new Set(unwrapped.required ?? []));
+    if (!rows.length) continue;
+    parts.push(`
+      <p style="margin:8px 0 2px;font-size:13px;font-weight:600;">Response <code>${escapeHtml(code)}</code> (${escapeHtml(picked.mediaType)}) &nbsp;<span style="font-weight:400;color:#555;">Type: <code>${escapeHtml(schemaDisplayType(picked.schema))}</code></span></p>
+      ${renderFieldTable(rows, borderStyle)}`);
   }
 
-  return parts.length ? parts.join('') : '';
+  return parts.join('');
 }
 
 function renderOperation(path: string, method: string, op: OperationObject, doc: SwaggerDoc): string {
   const color = methodColor(method);
   const params = op.parameters ?? [];
-  const bodyHtml = renderRequestBodyTable(op, doc, 'border:1px solid #ddd;padding:5px 8px;');
+  const bodyHtml = renderRequestBodySection(op, doc, 'border:1px solid #ddd;padding:5px 8px;');
+  const responseHtml = renderResponseSection(op, doc, 'border:1px solid #ddd;padding:5px 8px;');
   return `
     <div style="margin:14px 0;border:1px solid #e8e8e8;border-radius:4px;overflow:hidden;">
       <div style="padding:8px 12px;background:#fafafa;display:flex;align-items:center;gap:10px;">
@@ -235,10 +327,7 @@ function renderOperation(path: string, method: string, op: OperationObject, doc:
       ${op.description ? `<div style="padding:3px 12px;font-size:13px;color:#666;">${escapeHtml(op.description)}</div>` : ''}
       ${params.length ? `<div style="padding:5px 12px;">${renderParamTable(params)}</div>` : ''}
       ${bodyHtml ? `<div style="padding:5px 12px;">${bodyHtml}</div>` : ''}
-      ${(() => {
-        const r = renderResponseSection(op, doc, 'border:1px solid #ddd;padding:5px 8px;');
-        return r ? `<div style="padding:5px 12px;">${r}</div>` : '';
-      })()}
+      ${responseHtml ? `<div style="padding:5px 12px;">${responseHtml}</div>` : ''}
     </div>`;
 }
 
@@ -266,6 +355,7 @@ function buildHtmlDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
     .wrap{max-width:960px;margin:0 auto;padding:24px;}
     h1{text-align:center;color:#00ab6d;}
     .info{background:#f9f9f9;border:1px solid #e8e8e8;border-radius:4px;padding:14px;margin-bottom:20px;}
+    code{background:#f5f5f5;padding:1px 4px;border-radius:3px;font-size:12px;}
   </style>
 </head>
 <body>
@@ -282,6 +372,7 @@ function buildHtmlDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
 }
 
 function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
+  const border = 'border:1px solid #000;padding:4px 6px;';
   const sections = tags
     .map((t) => {
       const ops = t.operations
@@ -291,11 +382,11 @@ function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
             .map(
               (p) => `
         <tr>
-          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.name)}</td>
-          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.in)}</td>
-          <td style="border:1px solid #000;padding:4px 6px;">${p.required ? 'Yes' : 'No'}</td>
-          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.schema?.type ?? p.type ?? '')}</td>
-          <td style="border:1px solid #000;padding:4px 6px;">${escapeHtml(p.description)}</td>
+          <td style="${border}">${escapeHtml(p.name)}</td>
+          <td style="${border}">${escapeHtml(p.in)}</td>
+          <td style="${border}">${p.required ? 'Yes' : 'No'}</td>
+          <td style="${border}">${escapeHtml(schemaDisplayType(p.schema) || p.type || '')}</td>
+          <td style="${border}">${escapeHtml(p.description)}</td>
         </tr>`,
             )
             .join('');
@@ -303,17 +394,17 @@ function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
             ? `
         <table style="width:100%;border-collapse:collapse;margin:6px 0;font-size:12px;">
           <thead><tr style="background:#e8e8e8;">
-            <th style="border:1px solid #000;padding:4px 6px;">Name</th>
-            <th style="border:1px solid #000;padding:4px 6px;">In</th>
-            <th style="border:1px solid #000;padding:4px 6px;">Required</th>
-            <th style="border:1px solid #000;padding:4px 6px;">Type</th>
-            <th style="border:1px solid #000;padding:4px 6px;">Description</th>
+            <th style="${border}">Name</th>
+            <th style="${border}">In</th>
+            <th style="${border}">Required</th>
+            <th style="${border}">Type</th>
+            <th style="${border}">Description</th>
           </tr></thead>
           <tbody>${paramRows}</tbody>
         </table>`
             : '';
-          const bodyHtml = renderRequestBodyTable(op.operation, doc, 'border:1px solid #000;padding:4px 6px;');
-          const responseHtml = renderResponseSection(op.operation, doc, 'border:1px solid #000;padding:4px 6px;');
+          const bodyHtml = renderRequestBodySection(op.operation, doc, border);
+          const responseHtml = renderResponseSection(op.operation, doc, border);
           return `
         <div style="margin:10px 0;padding:8px;border:1px solid #ccc;">
           <p style="margin:0 0 4px;"><strong style="color:${methodColor(op.method)};">[${escapeHtml(op.method.toUpperCase())}]</strong> <code>${escapeHtml(op.path)}</code>${op.operation.deprecated ? ' <em style="color:red;">[Deprecated]</em>' : ''}</p>
@@ -351,7 +442,7 @@ function buildWordDoc(doc: SwaggerDoc, tags: MenuTag[]): string {
 </html>`;
 }
 
-// ─── docx helpers ────────────────────────────────────────────────
+// ─── docx helpers ───────────────────────────────────────────────────────────
 
 const THIN_BORDER = {
   top: { style: BorderStyle.SINGLE, size: 1, color: '999999' },
@@ -363,7 +454,6 @@ const THIN_BORDER = {
 function docxTextCell(text: string, opts?: { bold?: boolean; shading?: string }): DocxTableCell {
   return new DocxTableCell({
     borders: THIN_BORDER,
-    width: { size: 25, type: WidthType.PERCENTAGE },
     shading: opts?.shading ? { type: ShadingType.SOLID, color: opts.shading } : undefined,
     children: [
       new DocxParagraph({
@@ -374,40 +464,27 @@ function docxTextCell(text: string, opts?: { bold?: boolean; shading?: string })
   });
 }
 
-/** Build schema rows for docx table, resolving $ref recursively. */
-function docxSchemaRows(schema: SchemaObject, doc: SwaggerDoc, requiredSet: Set<string>, prefix = ''): DocxTableRow[] {
-  if (schema.$ref) {
-    const resolved = resolveRef(schema.$ref, doc);
-    if (!resolved) return [];
-    return docxSchemaRows(resolved, doc, resolved.required ? new Set(resolved.required) : new Set<string>(), prefix);
-  }
-  if (!schema.properties) return [];
-  const rows: DocxTableRow[] = [];
-  for (const [name, prop] of Object.entries(schema.properties)) {
-    const fieldPath = prefix ? `${prefix}.${name}` : name;
-    const type = prop.type ?? (prop.$ref ? (prop.$ref.split('/').pop() ?? '$ref') : 'object');
-    const itemType = prop.items?.type ? `<${prop.items.type}>` : '';
-    rows.push(
+function docxFieldTable(rows: FieldRow[]): DocxTable {
+  const header = new DocxTableRow({
+    children: [
+      docxTextCell('Field', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Type', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Required', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Description', { bold: true, shading: 'f5f5f5' }),
+    ],
+  });
+  const dataRows = rows.map(
+    (r) =>
       new DocxTableRow({
         children: [
-          docxTextCell(fieldPath),
-          docxTextCell(`${type}${itemType}`),
-          docxTextCell(requiredSet.has(name) ? 'Yes' : 'No'),
-          docxTextCell(prop.description ?? ''),
+          docxTextCell(r.fieldPath),
+          docxTextCell(r.typeDisplay),
+          docxTextCell(r.required ? 'Yes' : 'No'),
+          docxTextCell(r.description),
         ],
       }),
-    );
-    // Recurse into nested objects
-    const nested = prop.properties || (prop.$ref ? resolveRef(prop.$ref, doc) : undefined)?.properties;
-    if (nested) {
-      const resolved = prop.$ref ? resolveRef(prop.$ref, doc) : prop;
-      if (resolved?.properties) {
-        const childRequired = resolved.required ? new Set(resolved.required) : new Set<string>();
-        rows.push(...docxSchemaRows(resolved, doc, childRequired, fieldPath));
-      }
-    }
-  }
-  return rows;
+  );
+  return new DocxTable({ rows: [header, ...dataRows], width: { size: 100, type: WidthType.PERCENTAGE } });
 }
 
 function docxParamRows(params: ParameterObject[]): DocxTableRow[] {
@@ -418,7 +495,7 @@ function docxParamRows(params: ParameterObject[]): DocxTableRow[] {
           docxTextCell(p.name),
           docxTextCell(p.in),
           docxTextCell(p.required ? 'Yes' : 'No'),
-          docxTextCell(p.schema?.type ?? p.type ?? ''),
+          docxTextCell(schemaDisplayType(p.schema) || p.type || ''),
           docxTextCell(p.description ?? ''),
         ],
       }),
@@ -428,84 +505,82 @@ function docxParamRows(params: ParameterObject[]): DocxTableRow[] {
 function docxRequestBodySection(op: OperationObject, doc: SwaggerDoc): (DocxParagraph | DocxTable)[] {
   const rb = op.requestBody;
   if (!rb) return [];
-  const jsonContent = rb.content?.['application/json'];
-  if (!jsonContent?.schema) return [];
-  let schema = jsonContent.schema;
-  if (schema.$ref) {
-    const resolved = resolveRef(schema.$ref, doc);
-    if (!resolved) return [];
-    schema = resolved;
-  }
-  if (!schema.properties) return [];
-  const requiredSet = new Set(schema.required ?? []);
-  const headerRow = new DocxTableRow({
-    children: [
-      docxTextCell('Field', { bold: true, shading: 'f5f5f5' }),
-      docxTextCell('Type', { bold: true, shading: 'f5f5f5' }),
-      docxTextCell('Required', { bold: true, shading: 'f5f5f5' }),
-      docxTextCell('Description', { bold: true, shading: 'f5f5f5' }),
-    ],
-  });
-  const dataRows = docxSchemaRows(schema, doc, requiredSet);
-  return [
+  const picked = pickContentSchema(rb.content);
+  if (!picked) return [];
+  const unwrapped = unwrapRef(picked.schema, doc);
+  const rows = flattenSchemaFields(unwrapped, doc, '', new Set(unwrapped.required ?? []));
+  const typeDisplay = schemaDisplayType(picked.schema);
+  const children: (DocxParagraph | DocxTable)[] = [
     new DocxParagraph({
-      children: [new TextRun({ text: 'Request Body (application/json)', bold: true, size: 22 })],
+      children: [
+        new TextRun({ text: `Request Body (${picked.mediaType})  `, bold: true, size: 22 }),
+        new TextRun({ text: `Type: ${typeDisplay}`, size: 22 }),
+      ],
       spacing: { before: 120, after: 40 },
     }),
-    new DocxTable({ rows: [headerRow, ...dataRows], width: { size: 100, type: WidthType.PERCENTAGE } }),
   ];
+  if (rows.length) children.push(docxFieldTable(rows));
+  return children;
 }
 
 function docxResponseSection(op: OperationObject, doc: SwaggerDoc): (DocxParagraph | DocxTable)[] {
   const responses = op.responses;
   if (!responses || !Object.keys(responses).length) return [];
-  const children: (DocxParagraph | DocxTable)[] = [];
-  for (const [statusCode, resp] of Object.entries(responses)) {
-    const response = resp as ResponseObject;
-    const desc = response.description ?? '';
-    const schema = response.content?.['application/json']?.schema ?? response.schema;
-    const label = desc ? `Response ${statusCode} — ${desc}` : `Response ${statusCode}`;
-    if (schema) {
-      let resolved = schema;
-      if (schema.$ref) {
-        const refResolved = resolveRef(schema.$ref, doc);
-        if (refResolved) resolved = refResolved;
-      }
-      const requiredSet = new Set(resolved.required ?? []);
-      const rows = docxSchemaRows(resolved, doc, requiredSet);
-      if (rows.length) {
-        const headerRow = new DocxTableRow({
-          children: [
-            docxTextCell('Field', { bold: true, shading: 'f5f5f5' }),
-            docxTextCell('Type', { bold: true, shading: 'f5f5f5' }),
-            docxTextCell('Required', { bold: true, shading: 'f5f5f5' }),
-            docxTextCell('Description', { bold: true, shading: 'f5f5f5' }),
-          ],
-        });
-        children.push(
-          new DocxParagraph({
-            children: [new TextRun({ text: `${label} (application/json)`, bold: true, size: 22 })],
-            spacing: { before: 120, after: 40 },
-          }),
-          new DocxTable({ rows: [headerRow, ...rows], width: { size: 100, type: WidthType.PERCENTAGE } }),
-        );
-        continue;
-      }
-    }
+
+  const children: (DocxParagraph | DocxTable)[] = [
+    new DocxParagraph({
+      children: [new TextRun({ text: 'Responses', bold: true, size: 22 })],
+      spacing: { before: 160, after: 40 },
+    }),
+  ];
+
+  const summaryHeader = new DocxTableRow({
+    children: [
+      docxTextCell('Code', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Description', { bold: true, shading: 'f5f5f5' }),
+      docxTextCell('Schema', { bold: true, shading: 'f5f5f5' }),
+    ],
+  });
+  const summaryRows = Object.entries(responses).map(([code, resp]) => {
+    const r = resp as ResponseObject;
+    const picked = pickContentSchema(r.content, r.schema);
+    const typeDisplay = picked ? schemaDisplayType(picked.schema) : '—';
+    return new DocxTableRow({
+      children: [docxTextCell(code), docxTextCell(r.description ?? ''), docxTextCell(typeDisplay)],
+    });
+  });
+  children.push(
+    new DocxTable({
+      rows: [summaryHeader, ...summaryRows],
+      width: { size: 100, type: WidthType.PERCENTAGE },
+    }),
+  );
+
+  for (const [code, resp] of Object.entries(responses)) {
+    const r = resp as ResponseObject;
+    const picked = pickContentSchema(r.content, r.schema);
+    if (!picked) continue;
+    const unwrapped = unwrapRef(picked.schema, doc);
+    const rows = flattenSchemaFields(unwrapped, doc, '', new Set(unwrapped.required ?? []));
+    if (!rows.length) continue;
     children.push(
       new DocxParagraph({
-        children: [new TextRun({ text: label, bold: true, size: 22 })],
+        children: [
+          new TextRun({ text: `Response ${code} (${picked.mediaType})  `, bold: true, size: 22 }),
+          new TextRun({ text: `Type: ${schemaDisplayType(picked.schema)}`, size: 22 }),
+        ],
         spacing: { before: 120, after: 40 },
       }),
+      docxFieldTable(rows),
     );
   }
+
   return children;
 }
 
 async function buildDocx(doc: SwaggerDoc, tags: MenuTag[]): Promise<Blob> {
   const children: (DocxParagraph | DocxTable)[] = [];
 
-  // Title & info
   children.push(
     new DocxParagraph({
       text: doc.info.title,
@@ -520,7 +595,7 @@ async function buildDocx(doc: SwaggerDoc, tags: MenuTag[]): Promise<Blob> {
       new DocxParagraph({ children: [new TextRun({ text: `Description: ${doc.info.description}`, size: 22 })] }),
     );
   }
-  children.push(new DocxParagraph({ text: '' })); // spacer
+  children.push(new DocxParagraph({ text: '' }));
 
   for (const t of tags) {
     children.push(
@@ -541,13 +616,11 @@ async function buildDocx(doc: SwaggerDoc, tags: MenuTag[]): Promise<Blob> {
 
     for (const op of t.operations) {
       const method = op.method.toUpperCase();
-      const path = op.path;
-      // Method + Path heading
       children.push(
         new DocxParagraph({
           children: [
             new TextRun({ text: `[${method}] `, bold: true, color: methodColor(op.method).replace('#', ''), size: 24 }),
-            new TextRun({ text: path, font: 'Courier New', size: 24 }),
+            new TextRun({ text: op.path, font: 'Courier New', size: 24 }),
             ...(op.operation.deprecated ? [new TextRun({ text: ' [Deprecated]', color: 'f93e3e', size: 22 })] : []),
           ],
           spacing: { before: 200, after: 60 },
@@ -557,7 +630,6 @@ async function buildDocx(doc: SwaggerDoc, tags: MenuTag[]): Promise<Blob> {
         children.push(new DocxParagraph({ children: [new TextRun({ text: op.operation.summary, size: 22 })] }));
       }
 
-      // Parameters table
       const params = op.operation.parameters ?? [];
       if (params.length) {
         const paramHeader = new DocxTableRow({
@@ -581,18 +653,12 @@ async function buildDocx(doc: SwaggerDoc, tags: MenuTag[]): Promise<Blob> {
         );
       }
 
-      // Request body
       children.push(...docxRequestBodySection(op.operation, doc));
-
-      // Responses
       children.push(...docxResponseSection(op.operation, doc));
     }
   }
 
-  const document = new Document({
-    sections: [{ children }],
-  });
-
+  const document = new Document({ sections: [{ children }] });
   return Packer.toBlob(document);
 }
 

--- a/knife4j-front/package-lock.json
+++ b/knife4j-front/package-lock.json
@@ -42,6 +42,7 @@
       "dependencies": {
         "@types/react-router-dom": "^5.3.3",
         "antd": "^5.7.3",
+        "docx": "^9.6.1",
         "dompurify": "^3.0.6",
         "i18next": "^23.7.6",
         "i18next-browser-languagedetector": "^7.2.0",
@@ -2245,7 +2246,6 @@
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -3339,6 +3339,12 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -3475,6 +3481,41 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/docx": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/dompurify": {
@@ -4183,6 +4224,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -4266,6 +4317,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4324,7 +4381,6 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -4416,6 +4472,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5117,6 +5179,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5163,6 +5237,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -5301,6 +5384,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.3",
@@ -5488,6 +5577,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -5741,6 +5836,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -6493,6 +6594,21 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6632,6 +6748,21 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6659,6 +6790,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6755,6 +6892,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-convert": {
@@ -7092,7 +7238,6 @@
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -7133,6 +7278,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -7285,6 +7436,24 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
## 变更范围

本 PR 同时处理三个关联紧密的 UI 任务，修改集中在同一组文件：

### TASK-048: OfficeDoc 离线文档导出补齐响应（Responses）部分
- 新增 `renderResponseSection()` 和 `renderSchemaRows()` 函数
- HTML 和 Word (.doc) 导出现在都包含每个接口的响应字段表
- 递归解析 `$ref`，兼容 OAS3 和 OAS2

### TASK-049: OfficeDoc 支持导出 .docx 格式
- 安装 `docx` npm 依赖（~50KB gzipped）
- 新增 `buildDocx()` 函数，使用 docx 库生成标准 OOXML 文件
- 新增"下载 Word (.docx)"按钮，保留原有 .doc 按钮
- 新增 locale key: `officeDoc.btn.docx`

### TASK-050: GlobalParam 表单「添加」按钮被挤到第二行
- 设置 Input 宽度为 160px
- 移除 Button 外层多余的 Space 包裹和未使用的 Space import

## 修改文件

- `knife4j-front/knife4j-ui-react/src/pages/document/OfficeDoc.tsx` — 主要改动
- `knife4j-front/knife4j-ui-react/src/pages/document/GlobalParam.tsx` — 布局修复
- `knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts` — 翻译
- `knife4j-front/knife4j-ui-react/src/locales/en-US.ts` — 翻译
- `knife4j-front/knife4j-ui-react/package.json` — 新增 docx 依赖
- `knife4j-front/package-lock.json` — lockfile 更新

## 验证

```bash
./scripts/test-front-core.sh
```

结果：test (147 passed) / lint / format:check / tsc / vite build / eslint 全部通过。

## 已知风险

- `docx` 库新增依赖，增加约 50KB gzipped bundle 体积
- 响应字段表对深层嵌套对象使用 `.` 前缀路径表示（如 `data.user.name`），与 doc.html 的表格缩进风格略有不同

## Issues

Closes #77 (TASK-048)
Closes #78 (TASK-049)
Closes #79 (TASK-050)

