### PR TITLE
feat(demo): surface online demo link and fix mock flash on load

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress'
+import {defineConfig} from 'vitepress'
 
 const siteUrl = 'https://knife4jnext.com'
 
@@ -44,6 +44,7 @@ export default defineConfig({
       { text: '功能', link: '/guide/features' },
       { text: '迁移', link: '/guide/migration' },
       { text: '配置参考', link: '/reference/configuration' },
+      { text: '在线 Demo', link: 'https://demo.knife4jnext.com/doc.html' },
       { text: 'GitHub', link: 'https://github.com/songxychn/knife4j-next' }
     ],
     sidebar: [

--- a/docs-site/guide/demo.md
+++ b/docs-site/guide/demo.md
@@ -4,6 +4,8 @@ title: Demo 预览
 
 # Demo 预览（knife4j-demo）
 
+> 🚀 **在线体验**：[https://demo.knife4jnext.com/doc.html](https://demo.knife4jnext.com/doc.html) —— 点击即可直接打开最新版 `knife4j-next` 的效果。
+
 `knife4j-demo` 是仓库内置的最小可运行工程，用来：
 
 1. 作为**官方站点在线预览**的后端。
@@ -96,9 +98,9 @@ docker compose up -d
 
 ## 在线预览
 
-官方站点预留的在线预览地址：
+官方站点提供的在线预览地址：
 
-- `https://demo.knife4jnext.com/doc.html`（如对应域名已上线）
+- 👉 [https://demo.knife4jnext.com/doc.html](https://demo.knife4jnext.com/doc.html) —— 点击直接打开，即可体验 knife4j-next 真实效果
 - 版本跟随 `master`，每次 `master` 合并后由 `watchtower` 自动刷新
 
 如果访问失败，优先在本地跑一遍，以避免把预览环境问题当成功能问题。

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { fetchGroups, fetchSwaggerDoc, parseMenuTags, getSchemas } from '../api/knife4jClient';
-import type { SwaggerGroup, SwaggerDoc, MenuTag, SchemaObject } from '../types/swagger';
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { fetchGroups, fetchSwaggerDoc, getSchemas, parseMenuTags } from '../api/knife4jClient';
+import type { MenuTag, SchemaObject, SwaggerDoc, SwaggerGroup } from '../types/swagger';
+import { MOCK_GROUPS } from '../data/mockGroups';
 
 // ---- 兼容旧接口的 ApiItem / ApiGroup 类型 ----
 
@@ -21,8 +22,6 @@ export interface ApiGroup {
 }
 
 // ---- mock fallback（真实接口不可用时降级） ----
-
-import { MOCK_GROUPS } from '../data/mockGroups';
 
 // ---- context 类型 ----
 
@@ -84,10 +83,14 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const schemas: Record<string, SchemaObject> = swaggerDoc ? getSchemas(swaggerDoc) : {};
 
   // 兼容旧接口：将真实数据转换为 ApiGroup[]
-  const groups: ApiGroup[] =
-    usingMock || !swaggerDoc
-      ? MOCK_GROUPS
-      : rawGroups.map((g) => {
+  // 关键区分：
+  //   - loading 中（swaggerDoc 为 null 且 usingMock 为 false）→ 空数组，让 UI 显示 loading
+  //   - 真正降级（usingMock 为 true）→ MOCK_GROUPS fallback
+  //   - 有真实数据 → 从 rawGroups 转换
+  const groups: ApiGroup[] = usingMock
+    ? MOCK_GROUPS
+    : swaggerDoc
+      ? rawGroups.map((g) => {
           const isActive = g.name === activeGroupValue;
           const apis: ApiItem[] = isActive
             ? menuTags.flatMap((t) =>
@@ -103,9 +106,13 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
               )
             : [];
           return { value: g.name, label: g.name, apis };
-        });
+        })
+      : [];
 
-  const activeGroup = groups.find((g) => g.value === activeGroupValue) ?? groups[0] ?? MOCK_GROUPS[0];
+  // loading 期间 groups 为空，提供一个空占位对象，避免下游 .apis 报错
+  const EMPTY_GROUP: ApiGroup = { value: '', label: '', apis: [] };
+  const activeGroup =
+    groups.find((g) => g.value === activeGroupValue) ?? groups[0] ?? (usingMock ? MOCK_GROUPS[0] : EMPTY_GROUP);
 
   const handleSetActiveGroup = useCallback((value: string) => {
     setActiveGroupValue(value);


### PR DESCRIPTION
## 范围

让文档站「在线 Demo」触手可及，并修复访问 https://demo.knife4jnext.com/doc.html 时先看到 Petstore、再跳到用户接口的闪现问题。

## 改动

### docs-site（文档站）

- `docs-site/guide/demo.md`：在页面顶部新增 callout，直接放置 https://demo.knife4jnext.com/doc.html 超链接；「在线预览」章节 URL 改为可点击链接并附说明。
- `docs-site/.vitepress/config.ts`：顶部导航栏新增 `在线 Demo` 外链入口，用户无需进入文档即可一键跳转。

### knife4j-ui-react（UI）

- `src/context/GroupContext.tsx`：修复在线 demo 首屏先展示 Petstore mock、再切到真实接口的闪现。
  - 旧逻辑：`usingMock || !swaggerDoc ? MOCK_GROUPS : ...`——加载态被当作降级态，导致真实数据到达前先渲染了写死的 petstore 数据。
  - 新逻辑拆成三路：
    - `usingMock` 为 true（接口真正不可用）→ 降级到 `MOCK_GROUPS`
    - 已拿到 `swaggerDoc` → 渲染真实数据
    - 仍在加载 → 空数组 + 空占位 `activeGroup`，让 UI 正常展示 loading，不再闪现 Petstore

## 验证

- `./scripts/test-front-core.sh`：通过（147 tests passed；knife4j-core + knife4j-ui-react 全流程 lint / test / build / format:check / tsc / vite build）
- `./scripts/test-docs.sh`：通过（老文档站 knife4j-doc 构建成功）
- `cd docs-site && npm run build`：通过（vitepress 新站构建成功）

## 风险与回滚

- 文档改动纯展示层，无风险。
- `GroupContext` 改动保留了原有 `usingMock` 降级路径和 `MOCK_GROUPS` import；仅调整了判定顺序与 loading 期的 `activeGroup` 占位，回滚只需一次 revert commit。

## 未解决项

- 无。