### PR TITLE
ui-react: respect springdoc tags-sorter / operations-sorter in doc.html (#86)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -277,11 +277,11 @@ const AppInner: React.FC = () => {
           </div>
 
           {/* Group switcher */}
-          {!collapsed && (
+          {!collapsed && groupOptions.length > 0 && (
             <div style={{ padding: '0 8px 8px' }}>
               <Select
                 options={groupOptions}
-                defaultValue={groupOptions[0].value}
+                defaultValue={groupOptions[0]?.value}
                 style={{ width: '100%' }}
                 onChange={(val) => setActiveGroupValue(val)}
               />

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -3,7 +3,7 @@
  * 负责拉取 group 列表和 api-docs 文档
  */
 
-import type { MenuOperation, MenuTag, SwaggerDoc, SwaggerGroup, SwaggerUiConfig } from '../types/swagger';
+import type { SwaggerDoc, SwaggerGroup, MenuTag, MenuOperation, SwaggerUiConfig } from '../types/swagger';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
 
@@ -17,25 +17,6 @@ const METHOD_ORDER: Record<string, number> = {
   head: 5,
   options: 6,
 };
-
-/**
- * 字母序比较器：
- * - 中文字符按**拼音**排序（`zh-Hans-CN-u-co-pinyin`，例如「阿」<「吃」）
- * - ASCII / 拉丁字符按 locale 默认规则（与 `'abc'.localeCompare('abd')` 一致）
- * - `numeric` 让 "/api/v2" 排在 "/api/v10" 之前，符合直觉
- *
- * 当运行时（过旧的环境或 polyfill 不完整）不支持 `zh-Hans-CN-u-co-pinyin` 时，
- * Intl 会自动回退到最接近的可用 collation，不会抛异常。
- */
-const alphaCollator = new Intl.Collator('zh-Hans-CN-u-co-pinyin', {
-  sensitivity: 'base',
-  numeric: true,
-});
-
-/** 语义化字母比较器（拼音优先），供排序函数统一使用 */
-function compareAlpha(a: string, b: string): number {
-  return alphaCollator.compare(a, b);
-}
 
 /** tag 排序策略 */
 export type TagsSorter = 'alpha' | 'preserve';
@@ -127,13 +108,13 @@ function sortOperations(ops: MenuOperation[], sorter: OperationsSorter): MenuOpe
   if (sorter === 'preserve') return ops;
   const sorted = [...ops];
   if (sorter === 'alpha') {
-    sorted.sort((a, b) => compareAlpha(a.path, b.path) || compareAlpha(a.method, b.method));
+    sorted.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
   } else if (sorter === 'method') {
     sorted.sort((a, b) => {
       const ma = METHOD_ORDER[a.method] ?? 99;
       const mb = METHOD_ORDER[b.method] ?? 99;
       if (ma !== mb) return ma - mb;
-      return compareAlpha(a.path, b.path);
+      return a.path.localeCompare(b.path);
     });
   }
   return sorted;
@@ -182,9 +163,9 @@ export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): M
     tags = tags.map((t) => ({ ...t, operations: sortOperations(t.operations, operationsSorter) }));
   }
 
-  // 按策略对 tag 排序（中文 tag 按拼音）
+  // 按策略对 tag 排序
   if (tagsSorter === 'alpha') {
-    tags = [...tags].sort((a, b) => compareAlpha(a.tag, b.tag));
+    tags = [...tags].sort((a, b) => a.tag.localeCompare(b.tag));
   }
 
   return tags;

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -3,7 +3,7 @@
  * 负责拉取 group 列表和 api-docs 文档
  */
 
-import type { SwaggerDoc, SwaggerGroup, MenuTag, MenuOperation, SwaggerUiConfig } from '../types/swagger';
+import type { MenuOperation, MenuTag, SwaggerDoc, SwaggerGroup, SwaggerUiConfig } from '../types/swagger';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
 
@@ -17,6 +17,25 @@ const METHOD_ORDER: Record<string, number> = {
   head: 5,
   options: 6,
 };
+
+/**
+ * 字母序比较器：
+ * - 中文字符按**拼音**排序（`zh-Hans-CN-u-co-pinyin`，例如「阿」<「吃」）
+ * - ASCII / 拉丁字符按 locale 默认规则（与 `'abc'.localeCompare('abd')` 一致）
+ * - `numeric` 让 "/api/v2" 排在 "/api/v10" 之前，符合直觉
+ *
+ * 当运行时（过旧的环境或 polyfill 不完整）不支持 `zh-Hans-CN-u-co-pinyin` 时，
+ * Intl 会自动回退到最接近的可用 collation，不会抛异常。
+ */
+const alphaCollator = new Intl.Collator('zh-Hans-CN-u-co-pinyin', {
+  sensitivity: 'base',
+  numeric: true,
+});
+
+/** 语义化字母比较器（拼音优先），供排序函数统一使用 */
+function compareAlpha(a: string, b: string): number {
+  return alphaCollator.compare(a, b);
+}
 
 /** tag 排序策略 */
 export type TagsSorter = 'alpha' | 'preserve';
@@ -108,13 +127,13 @@ function sortOperations(ops: MenuOperation[], sorter: OperationsSorter): MenuOpe
   if (sorter === 'preserve') return ops;
   const sorted = [...ops];
   if (sorter === 'alpha') {
-    sorted.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
+    sorted.sort((a, b) => compareAlpha(a.path, b.path) || compareAlpha(a.method, b.method));
   } else if (sorter === 'method') {
     sorted.sort((a, b) => {
       const ma = METHOD_ORDER[a.method] ?? 99;
       const mb = METHOD_ORDER[b.method] ?? 99;
       if (ma !== mb) return ma - mb;
-      return a.path.localeCompare(b.path);
+      return compareAlpha(a.path, b.path);
     });
   }
   return sorted;
@@ -163,9 +182,9 @@ export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): M
     tags = tags.map((t) => ({ ...t, operations: sortOperations(t.operations, operationsSorter) }));
   }
 
-  // 按策略对 tag 排序
+  // 按策略对 tag 排序（中文 tag 按拼音）
   if (tagsSorter === 'alpha') {
-    tags = [...tags].sort((a, b) => a.tag.localeCompare(b.tag));
+    tags = [...tags].sort((a, b) => compareAlpha(a.tag, b.tag));
   }
 
   return tags;

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -3,29 +3,58 @@
  * 负责拉取 group 列表和 api-docs 文档
  */
 
-import type { SwaggerDoc, SwaggerGroup, MenuTag, MenuOperation } from '../types/swagger';
+import type { SwaggerDoc, SwaggerGroup, MenuTag, MenuOperation, SwaggerUiConfig } from '../types/swagger';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
+
+/** HTTP method 在 swagger-ui 'method' sorter 下的固定顺序 */
+const METHOD_ORDER: Record<string, number> = {
+  get: 0,
+  post: 1,
+  put: 2,
+  delete: 3,
+  patch: 4,
+  head: 5,
+  options: 6,
+};
+
+/** tag 排序策略 */
+export type TagsSorter = 'alpha' | 'preserve';
+/** operation 排序策略 */
+export type OperationsSorter = 'alpha' | 'method' | 'preserve';
+
+/**
+ * 拉取 springdoc / swagger-ui 的聚合配置：`/v3/api-docs/swagger-config`。
+ * 返回 `null` 表示端点不存在或返回异常（例如 springfox 场景）。
+ */
+export async function fetchSwaggerUiConfig(): Promise<SwaggerUiConfig | null> {
+  try {
+    const res = await fetch('v3/api-docs/swagger-config');
+    if (!res.ok) return null;
+    return (await res.json()) as SwaggerUiConfig;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * 从已获取的 SwaggerUiConfig 解析 group 列表。
+ * - 有 `urls` → 多文档场景
+ * - 否则 → 单文档，固定使用 `v3/api-docs`
+ */
+export function parseGroupsFromConfig(config: SwaggerUiConfig): SwaggerGroup[] {
+  if (config.urls && Array.isArray(config.urls)) {
+    return config.urls.map((u) => ({ name: u.name, url: u.url }));
+  }
+  return [{ name: 'default', url: 'v3/api-docs' }];
+}
 
 /** 拉取 group 列表（兼容 springfox / springdoc） */
 export async function fetchGroups(): Promise<SwaggerGroup[]> {
   // 优先尝试 springdoc: v3/api-docs/swagger-config
-  try {
-    const res = await fetch('v3/api-docs/swagger-config');
-    if (res.ok) {
-      const data = await res.json();
-      // springdoc 格式: { urls: [{name, url}] } 或单文档
-      if (data.urls && Array.isArray(data.urls)) {
-        return data.urls.map((u: { name: string; url: string }) => ({
-          name: u.name,
-          url: u.url,
-        }));
-      }
-      // 单文档，无分组
-      return [{ name: 'default', url: 'v3/api-docs' }];
-    }
-  } catch (_) {
-    /* ignore */
+  const config = await fetchSwaggerUiConfig();
+  if (config) {
+    return parseGroupsFromConfig(config);
   }
 
   // fallback: springfox swagger-resources
@@ -57,11 +86,48 @@ export async function fetchSwaggerDoc(url: string): Promise<SwaggerDoc | null> {
   }
 }
 
+/** 将外部传入的字符串归一化为 TagsSorter；无法识别的值一律视为 'preserve'（保持原序） */
+export function normalizeTagsSorter(value: unknown): TagsSorter {
+  return value === 'alpha' ? 'alpha' : 'preserve';
+}
+
+/** 将外部传入的字符串归一化为 OperationsSorter */
+export function normalizeOperationsSorter(value: unknown): OperationsSorter {
+  if (value === 'alpha') return 'alpha';
+  if (value === 'method') return 'method';
+  return 'preserve';
+}
+
+/** 排序选项（供 parseMenuTags 使用） */
+export interface MenuSortOptions {
+  tagsSorter?: TagsSorter;
+  operationsSorter?: OperationsSorter;
+}
+
+function sortOperations(ops: MenuOperation[], sorter: OperationsSorter): MenuOperation[] {
+  if (sorter === 'preserve') return ops;
+  const sorted = [...ops];
+  if (sorter === 'alpha') {
+    sorted.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
+  } else if (sorter === 'method') {
+    sorted.sort((a, b) => {
+      const ma = METHOD_ORDER[a.method] ?? 99;
+      const mb = METHOD_ORDER[b.method] ?? 99;
+      if (ma !== mb) return ma - mb;
+      return a.path.localeCompare(b.path);
+    });
+  }
+  return sorted;
+}
+
 /** 将 SwaggerDoc 解析为侧边栏菜单结构 */
-export function parseMenuTags(doc: SwaggerDoc): MenuTag[] {
+export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): MenuTag[] {
+  const tagsSorter = options.tagsSorter ?? 'preserve';
+  const operationsSorter = options.operationsSorter ?? 'preserve';
+
   const tagMap = new Map<string, MenuTag>();
 
-  // 初始化 tag 列表（保持顺序）
+  // 初始化 tag 列表（保持 doc.tags 原始顺序）
   (doc.tags ?? []).forEach((t) => {
     tagMap.set(t.name, { tag: t.name, description: t.description, operations: [] });
   });
@@ -90,7 +156,19 @@ export function parseMenuTags(doc: SwaggerDoc): MenuTag[] {
     });
   });
 
-  return Array.from(tagMap.values());
+  let tags = Array.from(tagMap.values());
+
+  // 按策略对 operations 排序
+  if (operationsSorter !== 'preserve') {
+    tags = tags.map((t) => ({ ...t, operations: sortOperations(t.operations, operationsSorter) }));
+  }
+
+  // 按策略对 tag 排序
+  if (tagsSorter === 'alpha') {
+    tags = [...tags].sort((a, b) => a.tag.localeCompare(b.tag));
+  }
+
+  return tags;
 }
 
 /** 获取 components.schemas（OAS3）或 definitions（OAS2） */

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -1,7 +1,18 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { fetchGroups, fetchSwaggerDoc, getSchemas, parseMenuTags } from '../api/knife4jClient';
-import type { MenuTag, SchemaObject, SwaggerDoc, SwaggerGroup } from '../types/swagger';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  fetchSwaggerDoc,
+  fetchSwaggerUiConfig,
+  getSchemas,
+  normalizeOperationsSorter,
+  normalizeTagsSorter,
+  parseGroupsFromConfig,
+  parseMenuTags,
+  type OperationsSorter,
+  type TagsSorter,
+} from '../api/knife4jClient';
+import type { MenuTag, SchemaObject, SwaggerDoc, SwaggerGroup, SwaggerUiConfig } from '../types/swagger';
 import { MOCK_GROUPS } from '../data/mockGroups';
+import { useSettings } from './SettingsContext';
 
 // ---- 兼容旧接口的 ApiItem / ApiGroup 类型 ----
 
@@ -33,6 +44,7 @@ interface GroupContextValue {
 
   // 真实数据
   swaggerDoc: SwaggerDoc | null;
+  swaggerUiConfig: SwaggerUiConfig | null;
   menuTags: MenuTag[];
   schemas: Record<string, SchemaObject>;
   loading: boolean;
@@ -43,22 +55,59 @@ const GroupContext = createContext<GroupContextValue | null>(null);
 
 export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [rawGroups, setRawGroups] = useState<SwaggerGroup[]>([]);
+  const [swaggerUiConfig, setSwaggerUiConfig] = useState<SwaggerUiConfig | null>(null);
   const [activeGroupValue, setActiveGroupValue] = useState<string>('');
   const [swaggerDoc, setSwaggerDoc] = useState<SwaggerDoc | null>(null);
   const [loading, setLoading] = useState(true);
   const [usingMock, setUsingMock] = useState(false);
 
-  // 初始化：拉取 group 列表
+  const { settings } = useSettings();
+
+  // 初始化：优先拉取 swagger-config（拿到 tagsSorter / operationsSorter），失败回退到 swagger-resources
   useEffect(() => {
-    fetchGroups().then((groups) => {
-      if (groups.length > 0) {
-        setRawGroups(groups);
-        setActiveGroupValue(groups[0].name);
-      } else {
-        setUsingMock(true);
-        setLoading(false);
+    let cancelled = false;
+    (async () => {
+      const config = await fetchSwaggerUiConfig();
+      if (cancelled) return;
+
+      if (config) {
+        setSwaggerUiConfig(config);
+        const groups = parseGroupsFromConfig(config);
+        if (groups.length > 0) {
+          setRawGroups(groups);
+          setActiveGroupValue(groups[0].name);
+          return;
+        }
       }
-    });
+
+      // swagger-config 不可用 → 回退 springfox swagger-resources
+      try {
+        const res = await fetch('swagger-resources');
+        if (res.ok) {
+          const data: Array<{ name: string; location: string; swaggerVersion?: string }> = await res.json();
+          const groups: SwaggerGroup[] = data.map((g) => ({
+            name: g.name,
+            url: g.location,
+            swaggerVersion: g.swaggerVersion,
+          }));
+          if (groups.length > 0) {
+            setRawGroups(groups);
+            setActiveGroupValue(groups[0].name);
+            return;
+          }
+        }
+      } catch {
+        /* ignore */
+      }
+
+      // 完全拿不到 → mock
+      setUsingMock(true);
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // 切换 group 时拉取对应 api-docs
@@ -78,8 +127,33 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     });
   }, [activeGroupValue, rawGroups, usingMock]);
 
+  // 计算最终生效的排序策略：用户显式覆盖优先，否则跟随后端 swagger-config
+  const effectiveTagsSorter: TagsSorter = useMemo(() => {
+    if (settings.tagsSorter === 'alpha') return 'alpha';
+    if (settings.tagsSorter === 'preserve') return 'preserve';
+    // 'auto' → 跟随后端
+    return normalizeTagsSorter(swaggerUiConfig?.tagsSorter);
+  }, [settings.tagsSorter, swaggerUiConfig]);
+
+  const effectiveOperationsSorter: OperationsSorter = useMemo(() => {
+    if (settings.operationsSorter === 'alpha') return 'alpha';
+    if (settings.operationsSorter === 'method') return 'method';
+    if (settings.operationsSorter === 'preserve') return 'preserve';
+    // 'auto' → 跟随后端
+    return normalizeOperationsSorter(swaggerUiConfig?.operationsSorter);
+  }, [settings.operationsSorter, swaggerUiConfig]);
+
   // 派生数据
-  const menuTags: MenuTag[] = swaggerDoc ? parseMenuTags(swaggerDoc) : [];
+  const menuTags: MenuTag[] = useMemo(
+    () =>
+      swaggerDoc
+        ? parseMenuTags(swaggerDoc, {
+            tagsSorter: effectiveTagsSorter,
+            operationsSorter: effectiveOperationsSorter,
+          })
+        : [],
+    [swaggerDoc, effectiveTagsSorter, effectiveOperationsSorter],
+  );
   const schemas: Record<string, SchemaObject> = swaggerDoc ? getSchemas(swaggerDoc) : {};
 
   // 兼容旧接口：将真实数据转换为 ApiGroup[]
@@ -125,6 +199,7 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         activeGroup,
         setActiveGroupValue: handleSetActiveGroup,
         swaggerDoc,
+        swaggerUiConfig,
         menuTags,
         schemas,
         loading,

--- a/knife4j-front/knife4j-ui-react/src/context/SettingsContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/SettingsContext.tsx
@@ -2,6 +2,22 @@ import React, { createContext, useContext, useState } from 'react';
 
 const STORAGE_KEY = 'Knife4jGlobalSettings';
 
+/**
+ * 前端覆盖的 tag 排序策略。
+ * - 'auto'：不覆盖，跟随后端 `/v3/api-docs/swagger-config` 的 `tagsSorter`；后端未配置时保持原序。
+ * - 'alpha'：按字母序排序。
+ * - 'preserve'：强制保持 OpenAPI JSON 的原始顺序（即使后端配置了 alpha）。
+ */
+export type TagsSorterOverride = 'auto' | 'alpha' | 'preserve';
+/**
+ * 前端覆盖的 operation 排序策略。
+ * - 'auto'：跟随后端 `operationsSorter`；后端未配置时保持原序。
+ * - 'alpha'：按路径字母序。
+ * - 'method'：按 HTTP method 顺序。
+ * - 'preserve'：强制保持原序。
+ */
+export type OperationsSorterOverride = 'auto' | 'alpha' | 'method' | 'preserve';
+
 export interface AppSettings {
   /** 是否启用 Host 覆盖 */
   enableHost: boolean;
@@ -15,6 +31,10 @@ export interface AppSettings {
   enableFilterMultipartApis: boolean;
   /** 过滤后保留的 method 类型（默认 POST） */
   enableFilterMultipartApiMethodType: string;
+  /** tag 排序覆盖（默认 'auto'：跟随 springdoc.swagger-ui.tags-sorter） */
+  tagsSorter: TagsSorterOverride;
+  /** operation 排序覆盖（默认 'auto'：跟随 springdoc.swagger-ui.operations-sorter） */
+  operationsSorter: OperationsSorterOverride;
   /**
    * 预留钩子：增强模式（swaggerBootstrapUi）
    * 当前版本不对接，保持 false；未来可按需启用。
@@ -29,6 +49,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   enableDynamicParameter: false,
   enableFilterMultipartApis: false,
   enableFilterMultipartApiMethodType: 'POST',
+  tagsSorter: 'auto',
+  operationsSorter: 'auto',
   enableSwaggerBootstrapUi: false,
 };
 

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -263,6 +263,17 @@ const enUS = {
   'settings.enableHost': 'Override Host (Use specified Host to replace API BaseURL in debug mode)',
   'settings.hostPlaceholder': 'Enter Host, e.g. http://localhost:8080',
   'settings.hostEmptyError': 'Please enter Host address first',
+  // Sidebar sorting (mirrors springdoc.swagger-ui.tags-sorter / operations-sorter)
+  'settings.tagsSorter': 'Tag sort (tagsSorter)',
+  'settings.tagsSorter.desc':
+    'Defaults to springdoc.swagger-ui.tags-sorter; selecting a value overrides the backend config.',
+  'settings.operationsSorter': 'Operation sort (operationsSorter)',
+  'settings.operationsSorter.desc':
+    'Defaults to springdoc.swagger-ui.operations-sorter; supports alphabetic by path, HTTP method order, or preserve.',
+  'settings.sorter.auto': 'Auto (follow backend)',
+  'settings.sorter.alpha': 'Alphabetic (alpha)',
+  'settings.sorter.method': 'By HTTP method',
+  'settings.sorter.preserve': 'Preserve source order',
 } as const;
 
 export default enUS;

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -261,6 +261,16 @@ const zhCN = {
   'settings.enableHost': '覆盖 Host（调试时使用指定 Host 替换接口 BaseURL）',
   'settings.hostPlaceholder': '输入 Host，例如 http://localhost:8080',
   'settings.hostEmptyError': '请先填写 Host 地址',
+  // 侧边栏排序（对应 springdoc.swagger-ui.tags-sorter / operations-sorter）
+  'settings.tagsSorter': '分组排序（tagsSorter）',
+  'settings.tagsSorter.desc': '默认跟随 springdoc.swagger-ui.tags-sorter；选择后覆盖后端配置。',
+  'settings.operationsSorter': '接口排序（operationsSorter）',
+  'settings.operationsSorter.desc':
+    '默认跟随 springdoc.swagger-ui.operations-sorter；支持按路径字母序、HTTP 方法顺序或保持原序。',
+  'settings.sorter.auto': '自动（跟随后端）',
+  'settings.sorter.alpha': '字母序（alpha）',
+  'settings.sorter.method': '按方法（method）',
+  'settings.sorter.preserve': '保持原序',
 } as const;
 
 export default zhCN;

--- a/knife4j-front/knife4j-ui-react/src/pages/document/Settings.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/Settings.tsx
@@ -94,6 +94,53 @@ export default function Settings() {
         </div>
       </div>
       <Divider style={{ margin: '4px 0' }} />
+
+      {/* tags-sorter 覆盖 */}
+      <div style={{ minHeight: 50, lineHeight: '50px' }}>
+        <Space align="center" wrap>
+          <Text>{t('settings.tagsSorter')}</Text>
+          <Select
+            value={settings.tagsSorter}
+            style={{ width: 200 }}
+            onChange={(val) => setSetting('tagsSorter', val)}
+            options={[
+              { value: 'auto', label: t('settings.sorter.auto') },
+              { value: 'alpha', label: t('settings.sorter.alpha') },
+              { value: 'preserve', label: t('settings.sorter.preserve') },
+            ]}
+          />
+        </Space>
+        <div style={{ marginTop: 4, marginLeft: 0, lineHeight: 1.4 }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            {t('settings.tagsSorter.desc')}
+          </Text>
+        </div>
+      </div>
+      <Divider style={{ margin: '4px 0' }} />
+
+      {/* operations-sorter 覆盖 */}
+      <div style={{ minHeight: 50, lineHeight: '50px' }}>
+        <Space align="center" wrap>
+          <Text>{t('settings.operationsSorter')}</Text>
+          <Select
+            value={settings.operationsSorter}
+            style={{ width: 200 }}
+            onChange={(val) => setSetting('operationsSorter', val)}
+            options={[
+              { value: 'auto', label: t('settings.sorter.auto') },
+              { value: 'alpha', label: t('settings.sorter.alpha') },
+              { value: 'method', label: t('settings.sorter.method') },
+              { value: 'preserve', label: t('settings.sorter.preserve') },
+            ]}
+          />
+        </Space>
+        <div style={{ marginTop: 4, marginLeft: 0, lineHeight: 1.4 }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            {t('settings.operationsSorter.desc')}
+          </Text>
+        </div>
+      </div>
+      <Divider style={{ margin: '4px 0' }} />
     </div>
   );
 }

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -10,6 +10,25 @@ export interface SwaggerGroup {
   location?: string; // swagger-resources 格式
 }
 
+/**
+ * springdoc / swagger-ui 配置，对应 `/v3/api-docs/swagger-config` 响应。
+ * 我们只使用其中与排序相关的字段；其余字段保留原始语义便于后续接入。
+ *
+ * 说明：
+ * - `tagsSorter` / `operationsSorter`：和 springdoc 一致，取值为 `'alpha'` 时按字母序排序；
+ *   `operationsSorter` 还可取 `'method'` 按 HTTP method 排序；其他值一律保持原序。
+ */
+export interface SwaggerUiConfig {
+  /** 分组列表（springdoc 多文档场景） */
+  urls?: Array<{ name: string; url: string }>;
+  /** tag 排序策略（例如 'alpha'） */
+  tagsSorter?: string;
+  /** operation 排序策略（例如 'alpha' / 'method'） */
+  operationsSorter?: string;
+  /** 其它 springdoc 配置字段允许透传 */
+  [key: string]: unknown;
+}
+
 export interface SwaggerContact {
   name?: string;
   url?: string;

--- a/knife4j/knife4j-demo/src/main/resources/application.yml
+++ b/knife4j/knife4j-demo/src/main/resources/application.yml
@@ -9,6 +9,8 @@ knife4j:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
   api-docs:
     path: /v3/api-docs
   info:


### PR DESCRIPTION
Closes #86

## 背景

用户反馈 `springdoc.swagger-ui.tags-sorter: alpha` 在 knife4j-next 的 `doc.html`（`knife4j-ui-react`）中未生效。

定位：前端 `knife4jClient.ts` 中 `fetchGroups()` 只从 `/v3/api-docs/swagger-config` 读取 `urls`，完全忽略 `tagsSorter` / `operationsSorter`；`parseMenuTags` 也无排序逻辑。`springdoc.swagger-ui.*` 配置本身只是 springdoc 官方 Swagger UI 消费，doc.html 不会使用。

## 改动

按方案 D（"优先读后端配置，同时提供前端覆盖开关"）实现：

- **类型**：新增 `SwaggerUiConfig` 类型，表示 `/v3/api-docs/swagger-config` 响应。
- **Client**：`knife4jClient.ts`
  - 新增 `fetchSwaggerUiConfig()` / `parseGroupsFromConfig()`
  - 新增 `TagsSorter` / `OperationsSorter` 类型和归一化函数
  - `parseMenuTags(doc, options)` 接受排序选项，支持 `alpha` / `method` / `preserve`
- **Context**：`GroupContext`
  - 启动时读取一次 swagger-config 并缓存到 context
  - 合并用户 override + 后端配置，计算 `effectiveTagsSorter` / `effectiveOperationsSorter`，传给 `parseMenuTags`
- **Settings**：`SettingsContext` 新增 `tagsSorter` / `operationsSorter` 字段，默认 `'auto'`（跟随后端）
- **UI**：`pages/document/Settings.tsx` 新增两个 Select 控件，`zh-CN` / `en-US` 增加对应文案
- **Demo**：`knife4j-demo/src/main/resources/application.yml` 打开 `tags-sorter: alpha` / `operations-sorter: alpha`，便于直观验证

## 向后兼容

- 所有新字段默认 `'auto'`，无 swagger-config 或字段缺失时回退 `'preserve'`（即当前行为），不影响任何现有项目。
- 旧的 `fetchGroups()` / `parseMenuTags(doc)` 签名保持兼容（第二个参数可选）。

## 验证

- `./scripts/test-front-core.sh` ✅（format:check / test / lint / build / prettier / eslint 全绿，147 个单元测试通过）
- `./scripts/test-java.sh` ✅（JDK 17，18 个模块全部 BUILD SUCCESS）

## 风险

- 若用户 OpenAPI JSON 中存在未在 `doc.tags` 声明但在 paths 中引用的 tag，启用 `alpha` 后它们会参与字母序排序（与 springdoc 官方 UI 行为一致）。
- 打包体积变化可忽略（约 +1 KB gzip）。

