### PR TITLE
ui-react: drop Copy Endpoint and rename Copy URL to Copy Page URL

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -69,13 +69,11 @@ const enUS = {
   'apiDoc.col.fieldName': 'Field Name',
 
   // ApiDoc — copy actions (TASK-042)
-  'apiDoc.copy.endpoint': 'Copy Endpoint',
-  'apiDoc.copy.endpoint.success': 'Endpoint copied',
-  'apiDoc.copy.markdown': 'Copy Markdown',
-  'apiDoc.copy.markdown.success': 'Markdown copied',
-  'apiDoc.copy.url': 'Copy URL',
-  'apiDoc.copy.url.success': 'URL copied',
-  'apiDoc.copy.failed': 'Copy failed, please select text manually',
+'apiDoc.copy.markdown': 'Copy Markdown',
+'apiDoc.copy.markdown.success': 'Markdown copied',
+'apiDoc.copy.url': 'Copy Page URL',
+'apiDoc.copy.url.success': 'Page URL copied',
+'apiDoc.copy.failed': 'Copy failed, please select text manually',
 
   // Operation mode tabs (doc / debug)
   'operation.tab.doc': 'Doc',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -69,12 +69,10 @@ const zhCN = {
   'apiDoc.col.fieldName': '字段名',
 
   // ApiDoc — 复制操作 (TASK-042)
-  'apiDoc.copy.endpoint': '复制接口',
-  'apiDoc.copy.endpoint.success': '接口已复制',
   'apiDoc.copy.markdown': '复制文档 Markdown',
   'apiDoc.copy.markdown.success': 'Markdown 已复制',
-  'apiDoc.copy.url': '复制地址',
-  'apiDoc.copy.url.success': '地址已复制',
+  'apiDoc.copy.url': '复制本页地址',
+  'apiDoc.copy.url.success': '本页地址已复制',
   'apiDoc.copy.failed': '复制失败，请手动选择文本',
 
   // Operation mode tabs (doc / debug)

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -106,14 +106,6 @@ export default function ApiDoc() {
   const method = operation.method.toUpperCase();
   const op = operation.operation;
 
-  const handleCopyEndpoint = () => {
-    copyToClipboard(
-      `${method} ${operation.path}`,
-      () => message.success(t('apiDoc.copy.endpoint.success')),
-      () => message.error(t('apiDoc.copy.failed')),
-    );
-  };
-
   const handleCopyMarkdown = () => {
     const md = generateApiMarkdown({
       method,
@@ -236,9 +228,6 @@ export default function ApiDoc() {
       <OperationModeTabs activeKey="doc" />
 
       <Space style={{ marginBottom: 8 }}>
-        <Button size="small" icon={<CopyOutlined />} onClick={handleCopyEndpoint}>
-          {t('apiDoc.copy.endpoint')}
-        </Button>
         <Button size="small" icon={<CopyOutlined />} onClick={handleCopyMarkdown}>
           {t('apiDoc.copy.markdown')}
         </Button>


### PR DESCRIPTION
Closes #88

## What

ApiDoc 顶部的操作条由三个复制按钮精简为两个：

- 删除 `复制接口` 按钮 —— 它只复制 `METHOD /path`，和下方已经展示的方法/路径行重复，实用价值不高
- `复制地址` 重命名为 `复制本页地址`（英文：`Copy Page URL`），明确复制的是当前浏览器页面 URL 而不是接口地址，避免歧义
- 同步清理 `apiDoc.copy.endpoint` / `apiDoc.copy.endpoint.success` 两个 i18n 键

## Files touched

- `knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx`
- `knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts`
- `knife4j-front/knife4j-ui-react/src/locales/en-US.ts`

## Verification

- ReadLints：对三个文件无新增错误
- 运行时：ApiDoc 顶部仅保留 `复制文档 Markdown` / `复制本页地址` 两个按钮，点击后者复制 `window.location.href`

