### PR TITLE
fix(ui-react): restore en-US.ts indentation for prettier

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -69,11 +69,11 @@ const enUS = {
   'apiDoc.col.fieldName': 'Field Name',
 
   // ApiDoc — copy actions (TASK-042)
-'apiDoc.copy.markdown': 'Copy Markdown',
-'apiDoc.copy.markdown.success': 'Markdown copied',
-'apiDoc.copy.url': 'Copy Page URL',
-'apiDoc.copy.url.success': 'Page URL copied',
-'apiDoc.copy.failed': 'Copy failed, please select text manually',
+  'apiDoc.copy.markdown': 'Copy Markdown',
+  'apiDoc.copy.markdown.success': 'Markdown copied',
+  'apiDoc.copy.url': 'Copy Page URL',
+  'apiDoc.copy.url.success': 'Page URL copied',
+  'apiDoc.copy.failed': 'Copy failed, please select text manually',
 
   // Operation mode tabs (doc / debug)
   'operation.tab.doc': 'Doc',


### PR DESCRIPTION
Follow-up to #89 (merged before the prettier fix commit landed on master).

The previous PR was merged with a `front-core-test` failure caused by a missing 2-space indentation in `src/locales/en-US.ts` — the `apiDoc.copy.*` keys were left-aligned instead of indented. This PR cherry-picks the fix commit (`484728b2`) onto the current `master`.

Refs #88

