### PR TITLE
fix(ui-react): eliminate petstore flash during initial load

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -281,7 +281,7 @@ const AppInner: React.FC = () => {
             <div style={{ padding: '0 8px 8px' }}>
               <Select
                 options={groupOptions}
-                defaultValue={groupOptions[0]?.value}
+                value={activeGroup.value}
                 style={{ width: '100%' }}
                 onChange={(val) => setActiveGroupValue(val)}
               />

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -11,7 +11,6 @@ import {
   type TagsSorter,
 } from '../api/knife4jClient';
 import type { MenuTag, SchemaObject, SwaggerDoc, SwaggerGroup, SwaggerUiConfig } from '../types/swagger';
-import { MOCK_GROUPS } from '../data/mockGroups';
 import { useSettings } from './SettingsContext';
 
 // ---- 兼容旧接口的 ApiItem / ApiGroup 类型 ----
@@ -159,34 +158,31 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   // 兼容旧接口：将真实数据转换为 ApiGroup[]
   // 关键区分：
   //   - loading 中（swaggerDoc 为 null 且 usingMock 为 false）→ 空数组，让 UI 显示 loading
-  //   - 真正降级（usingMock 为 true）→ MOCK_GROUPS fallback
   //   - 有真实数据 → 从 rawGroups 转换
-  const groups: ApiGroup[] = usingMock
-    ? MOCK_GROUPS
-    : swaggerDoc
-      ? rawGroups.map((g) => {
-          const isActive = g.name === activeGroupValue;
-          const apis: ApiItem[] = isActive
-            ? menuTags.flatMap((t) =>
-                t.operations.map((op) => ({
-                  key: `/${activeGroupValue}/${op.key}`,
-                  method: op.method.toUpperCase(),
-                  path: op.path,
-                  summary: op.summary,
-                  tag: t.tag,
-                  operationId: op.operationId,
-                  deprecated: op.deprecated,
-                })),
-              )
-            : [];
-          return { value: g.name, label: g.name, apis };
-        })
-      : [];
+  //   注意：不再在 groups 里暴露 MOCK_GROUPS，彻底杜绝 petstore 闪烁
+  const groups: ApiGroup[] = swaggerDoc
+    ? rawGroups.map((g) => {
+        const isActive = g.name === activeGroupValue;
+        const apis: ApiItem[] = isActive
+          ? menuTags.flatMap((t) =>
+              t.operations.map((op) => ({
+                key: `/${activeGroupValue}/${op.key}`,
+                method: op.method.toUpperCase(),
+                path: op.path,
+                summary: op.summary,
+                tag: t.tag,
+                operationId: op.operationId,
+                deprecated: op.deprecated,
+              })),
+            )
+          : [];
+        return { value: g.name, label: g.name, apis };
+      })
+    : [];
 
   // loading 期间 groups 为空，提供一个空占位对象，避免下游 .apis 报错
   const EMPTY_GROUP: ApiGroup = { value: '', label: '', apis: [] };
-  const activeGroup =
-    groups.find((g) => g.value === activeGroupValue) ?? groups[0] ?? (usingMock ? MOCK_GROUPS[0] : EMPTY_GROUP);
+  const activeGroup = groups.find((g) => g.value === activeGroupValue) ?? groups[0] ?? EMPTY_GROUP;
 
   const handleSetActiveGroup = useCallback((value: string) => {
     setActiveGroupValue(value);


### PR DESCRIPTION
## 问题

线上 demo 在加载真实 OpenAPI 数据之前，仍能短暂看到 Petstore 示例数据（一闪而过）。

Closes #91

## 根因

1. **GroupContext.tsx**: `groups` 在 `swaggerDoc` 为 null（加载中）时回退到 `MOCK_GROUPS`；`activeGroup` 在 `groups` 为空时进一步回退到 `MOCK_GROUPS[0]`
2. **App.tsx**: `<Select>` 使用非受控 `defaultValue`，初次渲染锁定在 Petstore 后不会随数据更新同步

## 修复

- **GroupContext.tsx**: loading 阶段 `groups` 返回空数组而非 `MOCK_GROUPS`；`activeGroup` fallback 使用 `EMPTY_GROUP` 而非 `MOCK_GROUPS[0]`；移除 `MOCK_GROUPS` import
- **App.tsx**: `Select` 从 `defaultValue` 改为受控 `value={activeGroup.value}`

## 验证

- prettier: 通过
- eslint: 通过
- vite build: 通过

