### PR TITLE
release: bump version to 1.0.1

### DIFF
--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-aggregation-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-core/pom.xml
+++ b/knife4j/knife4j-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-demo/pom.xml
+++ b/knife4j/knife4j-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-dependencies/pom.xml
+++ b/knife4j/knife4j-dependencies/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-dependencies</artifactId>

--- a/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-openapi2-ui/pom.xml
+++ b/knife4j/knife4j-openapi2-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-openapi2-ui</artifactId>

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
 
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-openapi3-ui/pom.xml
+++ b/knife4j/knife4j-openapi3-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
     <name>knife4j-openapi3-webflux-jakarta-spring-boot-starter</name>

--- a/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </parent>
     <artifactId>knife4j-openapi3-webflux-spring-boot-starter</artifactId>
     <name>knife4j-openapi3-webflux-spring-boot-starter</name>

--- a/knife4j/knife4j-smoke-tests/boot2-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <modules>
         <module>knife4j-core</module>
         <module>knife4j-dependencies</module>


### PR DESCRIPTION
Bump all POM versions from 1.0.0 to 1.0.1 for Maven Central release.

## Changes
- 19 pom.xml: `<version>1.0.0</version>` → `<version>1.0.1</version>`

## Post-merge
After this PR is merged, an annotated tag `v1.0.1` will be pushed to trigger the release workflow.

