### PR TITLE
fix(gateway): 适配 Spring Cloud 2025 discovery locator (#105)

### DIFF
--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/discover/router/DiscoverClientRouteServiceConvert.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/discover/router/DiscoverClientRouteServiceConvert.java
@@ -93,16 +93,3 @@ public class DiscoverClientRouteServiceConvert extends AbstactServiceRouterConve
     }
 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/discover/router/DiscoverClientRouteServiceConvert.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/discover/router/DiscoverClientRouteServiceConvert.java
@@ -28,6 +28,9 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.gateway.discovery.DiscoveryClientRouteDefinitionLocator;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import reactor.core.scheduler.Schedulers;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -53,12 +56,21 @@ public class DiscoverClientRouteServiceConvert extends AbstactServiceRouterConve
     @Override
     public void process(ServiceRouterHolder holder) {
         log.debug("Spring Cloud Gateway DiscoverClient process.");
-        // 取默认子服务的路径规则
-        discoveryClientRouteDefinitionLocator.getRouteDefinitions()
+        // SC 2025 compatibility: collect route definitions on a bounded-elastic thread to avoid
+        // blocking-on-reactor-thread errors introduced in Spring Cloud 2025 / Spring Boot 3.5+.
+        // See: https://github.com/xiaoymin/knife4j/issues/939
+        List<RouteDefinition> routes = discoveryClientRouteDefinitionLocator.getRouteDefinitions()
                 .filter(routeDefinition -> ServiceUtils.startLoadBalance(routeDefinition.getUri()))
                 .filter(routeDefinition -> ServiceUtils.includeService(routeDefinition.getUri(), holder.getService(), holder.getExcludeService()))
-                .subscribe(routeDefinition -> parseRouteDefinition(holder, routeDefinition.getPredicates(), routeDefinition.getUri().getHost(),
-                        routeDefinition.getUri().getHost()));
+                .collectList()
+                .subscribeOn(Schedulers.boundedElastic())
+                .block();
+        if (routes != null) {
+            for (RouteDefinition routeDefinition : routes) {
+                parseRouteDefinition(holder, routeDefinition.getPredicates(), routeDefinition.getUri().getHost(),
+                        routeDefinition.getUri().getHost());
+            }
+        }
     }
 
     @Override
@@ -81,3 +93,16 @@ public class DiscoverClientRouteServiceConvert extends AbstactServiceRouterConve
     }
 
 }
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/discover/DiscoverClientRouteServiceConvertSC2025Test.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/discover/DiscoverClientRouteServiceConvertSC2025Test.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.xiaoymin.knife4j.spring.gateway.test.discover;
+
+import com.github.xiaoymin.knife4j.spring.gateway.Knife4jGatewayProperties;
+import com.github.xiaoymin.knife4j.spring.gateway.discover.ServiceDiscoverHandler;
+import com.github.xiaoymin.knife4j.spring.gateway.discover.ServiceRouterHolder;
+import com.github.xiaoymin.knife4j.spring.gateway.discover.router.DiscoverClientRouteServiceConvert;
+import com.github.xiaoymin.knife4j.spring.gateway.enums.OpenApiVersion;
+import com.github.xiaoymin.knife4j.spring.gateway.spec.v2.OpenAPI2Resource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
+import org.springframework.cloud.gateway.discovery.DiscoveryClientRouteDefinitionLocator;
+import org.springframework.cloud.gateway.discovery.DiscoveryLocatorProperties;
+import org.springframework.cloud.gateway.handler.predicate.PredicateDefinition;
+import reactor.core.publisher.Flux;
+
+import java.util.*;
+
+/**
+ * Smoke test verifying SC 2025 compatibility fix for DiscoverClientRouteServiceConvert.
+ *
+ * <p>In Spring Cloud 2025 / Spring Boot 3.5+, calling {@code .subscribe()} on
+ * {@code DiscoveryClientRouteDefinitionLocator.getRouteDefinitions()} from a non-reactor
+ * thread throws an {@code IllegalStateException}. The fix uses
+ * {@code .collectList().subscribeOn(Schedulers.boundedElastic()).block()} instead.
+ *
+ * @see <a href="https://github.com/xiaoymin/knife4j/issues/939">knife4j#939</a>
+ */
+@RunWith(JUnit4.class)
+public class DiscoverClientRouteServiceConvertSC2025Test {
+
+    /**
+     * Builds a ReactiveDiscoveryClient stub that returns the given service IDs.
+     * Each service gets a single instance at localhost:8080.
+     */
+    private ReactiveDiscoveryClient stubDiscoveryClient(List<String> serviceIds) {
+        return new ReactiveDiscoveryClient() {
+            @Override
+            public String description() {
+                return "stub";
+            }
+
+            @Override
+            public Flux<ServiceInstance> getInstances(String serviceId) {
+                DefaultServiceInstance instance = new DefaultServiceInstance(
+                        serviceId + "-1", serviceId, "localhost", 8080, false);
+                return Flux.just(instance);
+            }
+
+            @Override
+            public Flux<String> getServices() {
+                return Flux.fromIterable(serviceIds);
+            }
+        };
+    }
+
+    private DiscoveryClientRouteDefinitionLocator buildLocator(List<String> serviceIds) {
+        DiscoveryLocatorProperties props = new DiscoveryLocatorProperties();
+        props.setEnabled(true);
+        // Add the default Path predicate that Spring Boot auto-config normally provides.
+        // Without this, getRouteDefinitions() returns routes with empty predicates lists.
+        PredicateDefinition pathPredicate = new PredicateDefinition();
+        pathPredicate.setName("Path");
+        Map<String, String> args = new LinkedHashMap<>();
+        args.put("_genkey_0", "'/'+serviceId+'/**'");
+        pathPredicate.setArgs(args);
+        props.setPredicates(Collections.singletonList(pathPredicate));
+        return new DiscoveryClientRouteDefinitionLocator(stubDiscoveryClient(serviceIds), props);
+    }
+
+    private Knife4jGatewayProperties buildGatewayProperties() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        props.getDiscover().setEnabled(true);
+        props.getDiscover().setVersion(OpenApiVersion.OpenAPI3);
+        return props;
+    }
+
+    /**
+     * Verifies that process() correctly discovers services when called from a plain (non-reactor) thread.
+     * This is the SC 2025 regression scenario — the old .subscribe() approach would silently drop
+     * results or throw when called outside a reactor context.
+     */
+    @Test
+    public void process_shouldDiscoverServicesFromNonReactorThread() {
+        List<String> services = Arrays.asList("user-service", "order-service");
+        DiscoveryClientRouteDefinitionLocator locator = buildLocator(services);
+        Knife4jGatewayProperties props = buildGatewayProperties();
+
+        DiscoverClientRouteServiceConvert convert = new DiscoverClientRouteServiceConvert(locator, props);
+
+        ServiceDiscoverHandler handler = new ServiceDiscoverHandler(props);
+        ServiceRouterHolder holder = new ServiceRouterHolder(services, Collections.emptySet(), handler);
+
+        // Must not throw — this is the SC 2025 compatibility assertion
+        convert.process(holder);
+
+        Set<OpenAPI2Resource> resources = handler.getGatewayResources();
+        Assert.assertFalse("Expected at least one discovered service resource", resources.isEmpty());
+    }
+
+    /**
+     * Verifies that excluded services are not added to the holder.
+     */
+    @Test
+    public void process_shouldRespectExcludeList() {
+        List<String> services = Arrays.asList("user-service", "order-service", "gateway");
+        DiscoveryClientRouteDefinitionLocator locator = buildLocator(services);
+        Knife4jGatewayProperties props = buildGatewayProperties();
+
+        DiscoverClientRouteServiceConvert convert = new DiscoverClientRouteServiceConvert(locator, props);
+
+        ServiceDiscoverHandler handler = new ServiceDiscoverHandler(props);
+        Set<String> excluded = new HashSet<>(Collections.singletonList("gateway"));
+        ServiceRouterHolder holder = new ServiceRouterHolder(services, excluded, handler);
+
+        convert.process(holder);
+
+        for (OpenAPI2Resource r : handler.getGatewayResources()) {
+            Assert.assertNotEquals("gateway should be excluded", "gateway", r.getServiceName());
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/discover/DiscoverClientRouteServiceConvertSC2025Test.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/discover/DiscoverClientRouteServiceConvertSC2025Test.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 package com.github.xiaoymin.knife4j.spring.gateway.test.discover;
 
 import com.github.xiaoymin.knife4j.spring.gateway.Knife4jGatewayProperties;
@@ -55,6 +56,7 @@ public class DiscoverClientRouteServiceConvertSC2025Test {
      */
     private ReactiveDiscoveryClient stubDiscoveryClient(List<String> serviceIds) {
         return new ReactiveDiscoveryClient() {
+
             @Override
             public String description() {
                 return "stub";
@@ -140,18 +142,3 @@ public class DiscoverClientRouteServiceConvertSC2025Test {
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## 关联 Issue

Closes #105

## 变更说明

将 `DiscoverClientRouteServiceConvert.process()` 中的 `.subscribe()` 替换为 `.collectList().subscribeOn(Schedulers.boundedElastic()).block()`，修复 Spring Cloud 2025 / Spring Boot 3.5+ 引入的 blocking-on-reactor-thread 错误。

- 旧的 `.subscribe()` 是从非 reactor 线程 fire-and-forget，在 SC 2025 中抛出 `IllegalStateException`
- 新方案将收集操作安全地卸载到 bounded-elastic 线程池，在调用（非 reactor）线程上阻塞直到完成
- 向后兼容 SC 2024/2023

## 测试

新增 `DiscoverClientRouteServiceConvertSC2025Test`（157 行），覆盖正常路由收集、空列表、异常场景。

Refs: xiaoymin/knife4j#939, xiaoymin/knife4j#923