### PR TITLE
docs: mark knife4j-openapi2-spring-boot-starter as maintenance-only (#122)

### DIFF
--- a/docs-site/guide/migration.md
+++ b/docs-site/guide/migration.md
@@ -63,6 +63,12 @@ After：
 
 ### Spring Boot 2.x + Springfox（OpenAPI2）
 
+::: warning 维护模式
+`knife4j-openapi2-spring-boot-starter` 处于**兼容维护模式**，不再接收新功能。前端仍使用 upstream 冻结的 Vue 2 webjars，无法享受 `knife4j-ui-react` 的新特性（SSE 流式响应、allOf/oneOf 渲染、二进制下载修复等）。
+
+若需使用新 UI 特性，请迁移到 OAS3 starter，参考 [从 Springfox 迁移到 OpenAPI3](./springfox-migration)。
+:::
+
 Before：
 
 ```xml

--- a/docs-site/guide/springfox-migration.md
+++ b/docs-site/guide/springfox-migration.md
@@ -356,7 +356,35 @@ public class UserController {/* ... */}
 
 ### `springfox-swagger2` 和 `knife4j-openapi2` 能继续用吗？
 
-可以。`knife4j-openapi2-spring-boot-starter` 仍然可用，只是底层 Springfox 停留在 `2.10.5` 不再更新。如果你不想迁移注解，可以继续使用 OpenAPI2 starter——但建议新项目直接使用 OpenAPI3。
+可以，但请注意维护定位：
+
+::: warning knife4j-openapi2-spring-boot-starter 处于维护模式
+`knife4j-openapi2-spring-boot-starter` 目前处于**兼容维护模式**，不再接收新功能。具体影响：
+
+- 底层 Springfox 停留在 `2.10.5`，不再更新。
+- 前端仍使用 upstream 冻结的 **Vue 2 webjars**（`knife4j-openapi2-ui`），无法享受 `knife4j-ui-react` 的新特性。
+- 新建的 UI 类 issue（SSE 流式响应、allOf/oneOf 渲染、二进制下载修复等）的修复**不会覆盖** OAS2 场景。
+
+若需使用 `knife4j-ui-react` 的新特性（tags/operations 排序、OAuth2 popup、Markdown 渲染、设置持久化、copy endpoint/url 等），请迁移到 OAS3 starter：
+
+```xml
+<!-- Spring Boot 2.x -->
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
+    <version>1.0.1</version>
+</dependency>
+
+<!-- Spring Boot 3.x Jakarta -->
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>1.0.1</version>
+</dependency>
+```
+
+如果你不想迁移注解，可以继续使用 OpenAPI2 starter——但建议新项目直接使用 OpenAPI3。
+:::
 
 ## 相关
 


### PR DESCRIPTION
## 关联 Issue

closes #122 (partial — 方案 C 文档声明部分)

## 变更内容

按 issue #122 建议的推进顺序，先完成「维护定位」声明（方案 C 路径），不涉及代码改动。

- `docs-site/guide/springfox-migration.md`：将原「可以继续用」的简短说明扩展为带 `warning` callout 的维护模式声明，明确列出 Vue 2 webjars 限制、不覆盖的 UI 修复范围，并提供 OAS3 迁移依赖示例。
- `docs-site/guide/migration.md`：在 OAS2 starter 依赖替换区块前增加 `warning` callout，说明维护模式定位并链接到 springfox-migration 指引。

## 未涉及

- 方案 A（运行时 OAS2→OAS3 转换）和方案 B（ui-react OAS2 兼容层）均未实施，留待社区反馈后决策。
- 未修改任何 Java 代码或前端代码。