### PR TITLE
feat(#118): Knife4jValidatorAnnotationResolver SPI for custom Hibernate Validator annotations

### DIFF
--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -157,6 +157,21 @@ function extractFileFields(schema: Record<string, unknown> | undefined): string[
   return files;
 }
 
+/** 从 OAS3 requestBody encoding 中提取 contentType=application/json 的字段名 */
+function extractJsonEncodingFields(encoding: Record<string, unknown> | undefined): string[] {
+  if (!encoding) return [];
+  const jsonFields: string[] = [];
+  for (const [fieldName, enc] of Object.entries(encoding)) {
+    if (enc && typeof enc === 'object') {
+      const ct = (enc as Record<string, unknown>).contentType;
+      if (typeof ct === 'string' && ct.toLowerCase().includes('application/json')) {
+        jsonFields.push(fieldName);
+      }
+    }
+  }
+  return jsonFields;
+}
+
 /** 解析 $ref 参数 */
 function resolveParameter(param: OAS3Param | OAS2Param, doc: DocLike): OAS3Param | OAS2Param {
   if (!param.$ref) return param;
@@ -367,6 +382,8 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
     if (rb.content) {
       for (const [mediaType, mediaObj] of Object.entries(rb.content)) {
         const schema = mediaObj.schema ? dereference(mediaObj.schema, doc as Record<string, unknown>) : undefined;
+        const isMultipart = classifyContentType(mediaType) === 'multipart';
+        const encoding = mediaObj.encoding as Record<string, unknown> | undefined;
 
         bodyContents.push({
           mediaType,
@@ -377,7 +394,8 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
             : mediaObj.example
             ? JSON.stringify(mediaObj.example, null, 2)
             : undefined,
-          fileFields: classifyContentType(mediaType) === 'multipart' ? extractFileFields(schema) : undefined,
+          fileFields: isMultipart ? extractFileFields(schema) : undefined,
+          jsonFields: isMultipart ? extractJsonEncodingFields(encoding) : undefined,
         });
       }
     }

--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -383,7 +383,7 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
       for (const [mediaType, mediaObj] of Object.entries(rb.content)) {
         const schema = mediaObj.schema ? dereference(mediaObj.schema, doc as Record<string, unknown>) : undefined;
         const isMultipart = classifyContentType(mediaType) === 'multipart';
-        const encoding = mediaObj.encoding as Record<string, unknown> | undefined;
+        const encoding = mediaObj.encoding;
 
         bodyContents.push({
           mediaType,

--- a/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
+++ b/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
@@ -328,6 +328,7 @@ export function buildRequest(options: BuildRequestOptions): BuiltRequest {
     body,
     contentType: selectedContentType,
     sourceMap,
+    jsonFields: formValues.jsonFields,
   };
 }
 
@@ -367,11 +368,17 @@ export function buildCurl(req: BuiltRequest): string {
         fieldObj = null;
       }
     }
+    const jsonFieldSet = new Set(req.jsonFields ?? []);
     if (fieldObj && Object.keys(fieldObj).length > 0) {
       for (const [name, value] of Object.entries(fieldObj)) {
         if (value === undefined || value === '') continue;
         const escaped = String(value).replace(/'/g, "'\\''");
-        parts.push('-F', `'${name}=${escaped}'`);
+        if (jsonFieldSet.has(name)) {
+          // JSON-encoded part: append ;type=application/json
+          parts.push('-F', `'${name}=${escaped};type=application/json'`);
+        } else {
+          parts.push('-F', `'${name}=${escaped}'`);
+        }
       }
     }
     // 文件字段占位（UI 层调用方会在 body 外通过 curlFileFields 注入，

--- a/knife4j-front/knife4j-core/src/debug/types.ts
+++ b/knife4j-front/knife4j-core/src/debug/types.ts
@@ -57,6 +57,11 @@ export interface BodyContent {
   exampleValue?: string;
   /** multipart 场景中标记哪些字段是 file / binary */
   fileFields?: string[];
+  /**
+   * multipart 场景中标记哪些字段的 encoding.contentType = application/json，
+   * 这些字段在 UI 中以 JSON 文本框形式提交，发送时作为独立 JSON part 附加。
+   */
+  jsonFields?: string[];
 }
 
 // ─── OperationDebugModel ──────────────────────────────
@@ -93,6 +98,11 @@ export interface DebugFormValues {
   formFields?: Record<string, string>;
   /** multipart 文件字段 { fieldName: File[] } — 由 UI 层处理，不序列化进纯函数 */
   fileFields?: Record<string, unknown>;
+  /**
+   * multipart 场景中 encoding.contentType=application/json 的字段名列表。
+   * 用于 buildCurl 输出 `-F 'field=...;type=application/json'`。
+   */
+  jsonFields?: string[];
 }
 
 /** 全局参数来源 */
@@ -182,6 +192,11 @@ export interface BuiltRequest {
   contentType: string;
   /** 参数来源映射（仅在存在 auth / globalParams 时生成） */
   sourceMap?: BuiltRequestSourceMap;
+  /**
+   * multipart 场景中 encoding.contentType=application/json 的字段名列表。
+   * buildCurl 用此输出 `-F 'field=...;type=application/json'`。
+   */
+  jsonFields?: string[];
 }
 
 /** required 校验结果 */

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -135,6 +135,7 @@ const enUS = {
   'apiDebug.body.file.placeholder': 'File path or leave empty to select file',
   'apiDebug.body.raw': 'Raw',
   'apiDebug.body.contentType': 'Content-Type',
+  'apiDebug.body.jsonPart.placeholder': 'Enter JSON for this part',
 
   // ApiDebug — Preview Tab (TASK-028)
   'apiDebug.tab.preview': 'Preview',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -135,6 +135,7 @@ const zhCN = {
   'apiDebug.body.file.placeholder': '文件路径或留空后选择文件',
   'apiDebug.body.raw': '原始文本',
   'apiDebug.body.contentType': 'Content-Type',
+  'apiDebug.body.jsonPart.placeholder': '请输入此 part 的 JSON 内容',
 
   // ApiDebug — Preview Tab (TASK-028)
   'apiDebug.tab.preview': '请求预览',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -184,6 +184,8 @@ interface SchemaFieldRow {
   example?: unknown;
   enum?: unknown[];
   isFile: boolean;
+  /** encoding.contentType=application/json — render as JSON TextArea */
+  isJson: boolean;
 }
 
 /**
@@ -196,6 +198,7 @@ function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
   const props = schema.properties as Record<string, Record<string, unknown>>;
   const requiredSet = new Set<string>(Array.isArray(schema.required) ? (schema.required as string[]) : []);
   const fileFields = new Set(bodyContent.fileFields ?? []);
+  const jsonFields = new Set(bodyContent.jsonFields ?? []);
 
   return Object.entries(props).map(([name, prop]) => {
     const t = (prop.type as string) ?? 'string';
@@ -215,6 +218,7 @@ function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
       example: prop.example,
       enum: Array.isArray(prop.enum) ? prop.enum : undefined,
       isFile,
+      isJson: !isFile && jsonFields.has(name),
     };
   });
 }
@@ -222,6 +226,7 @@ function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
 /** 根据 SchemaFieldRow 的类型推断初始值 */
 function initialFieldValue(field: SchemaFieldRow): string {
   if (field.isFile) return '';
+  if (field.isJson) return field.example !== undefined ? JSON.stringify(field.example, null, 2) : '{}';
   if (field.example !== undefined && field.example !== null) return String(field.example);
   if (field.default !== undefined && field.default !== null) return String(field.default);
   if (field.enum && field.enum.length > 0) return String(field.enum[0]);
@@ -734,6 +739,11 @@ function MultipartForm({ bodyContent, formFields, setFormFields, fileFieldsRef }
               {t('apiDebug.body.file')}
             </Tag>
           )}
+          {record.isJson && (
+            <Tag color="purple" style={{ marginInlineEnd: 0 }}>
+              JSON
+            </Tag>
+          )}
         </Space>
       ),
     },
@@ -764,6 +774,18 @@ function MultipartForm({ bodyContent, formFields, setFormFields, fileFieldsRef }
                 {t('apiDebug.body.selectFile')}
               </Button>
             </Upload>
+          );
+        }
+        if (record.isJson) {
+          return (
+            <TextArea
+              size="small"
+              value={formFields[record.name] ?? '{}'}
+              onChange={(event) => updateField(record.name, event.target.value)}
+              placeholder={t('apiDebug.body.jsonPart.placeholder')}
+              autoSize={{ minRows: 3, maxRows: 8 }}
+              style={{ fontFamily: 'monospace', fontSize: 12 }}
+            />
           );
         }
         return (
@@ -1307,6 +1329,7 @@ export default function ApiDebug() {
 
   const collectFormValues = (): DebugFormValues => {
     const category = getCurrentCategory();
+    const currentBody = debugModel.bodyContents.find((b) => b.mediaType === selectedContentType);
     return {
       pathParams: collectForIn(debugModel.pathParams),
       queryParams: collectForIn(debugModel.queryParams),
@@ -1316,6 +1339,7 @@ export default function ApiDebug() {
       body: category === 'json' || category === 'raw' ? body : undefined,
       formFields: category === 'urlencoded' || category === 'multipart' ? formFields : undefined,
       fileFields: category === 'multipart' ? fileFieldsRef.current : undefined,
+      jsonFields: category === 'multipart' ? (currentBody?.jsonFields ?? []) : undefined,
     };
   };
 
@@ -1376,10 +1400,16 @@ export default function ApiDebug() {
       if (isMultipart) {
         // 构建 FormData
         const fd = new FormData();
-        // 添加普通字段
+        const jsonFieldSet = new Set(formValues.jsonFields ?? []);
+        // 添加普通字段（非 JSON part）
         for (const [name, value] of Object.entries(formFields)) {
           if (value !== undefined && value !== '') {
-            fd.append(name, value);
+            if (jsonFieldSet.has(name)) {
+              // JSON-encoded part: append as Blob with application/json content type
+              fd.append(name, new Blob([value], { type: 'application/json' }), `${name}.json`);
+            } else {
+              fd.append(name, value);
+            }
           }
         }
         // 添加文件字段

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/annotations/ApiOperationSupport.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/annotations/ApiOperationSupport.java
@@ -87,4 +87,13 @@ public @interface ApiOperationSupport {
      */
     String[] includeParameters() default {};
 
+    /**
+     * Bean Validation groups to apply for this operation.
+     * When specified, the OpenAPI extension {@code x-validation-groups} will be
+     * emitted, mapping each group's simple name to its required field names.
+     * @since knife4j-next (issue #117)
+     * @return validation groups
+     */
+    Class<?>[] validationGroups() default {};
+
 }

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/conf/ExtensionsConstants.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/conf/ExtensionsConstants.java
@@ -36,4 +36,9 @@ public class ExtensionsConstants {
      * Validation groups — maps group simple name to required field names
      */
     public static final String EXTENSION_VALIDATION_GROUPS = "x-validation-groups";
+    /**
+     * Field constraints — maps field name to schema property increments resolved via
+     * {@link com.github.xiaoymin.knife4j.core.spi.Knife4jValidatorAnnotationResolver}
+     */
+    public static final String EXTENSION_FIELD_CONSTRAINTS = "x-field-constraints";
 }

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/BuiltinValidatorAnnotationResolver.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/BuiltinValidatorAnnotationResolver.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.core.spi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Built-in {@link Knife4jValidatorAnnotationResolver} that handles the most common
+ * Bean Validation constraints:
+ * <ul>
+ *   <li>{@code @Email} (javax &amp; jakarta) → {@code {"format": "email"}}</li>
+ *   <li>{@code @Pattern} (javax &amp; jakarta) → {@code {"pattern": "<regexp>"}}</li>
+ *   <li>{@code @Length} (Hibernate Validator, javax &amp; jakarta) →
+ *       {@code {"minLength": n, "maxLength": m}}</li>
+ *   <li>{@code @Size} (javax &amp; jakarta) →
+ *       {@code {"minLength": n, "maxLength": m}} (for string fields)</li>
+ * </ul>
+ *
+ * <p>Uses reflection so there is no compile-time dependency on any validation API.
+ *
+ * @since knife4j-next (issue #118)
+ */
+public class BuiltinValidatorAnnotationResolver implements Knife4jValidatorAnnotationResolver {
+
+    @Override
+    public Map<String, Object> resolve(Annotation annotation) {
+        String simpleName = annotation.annotationType().getSimpleName();
+        switch (simpleName) {
+            case "Email":
+                return Collections.singletonMap("format", "email");
+            case "Pattern":
+                return resolvePattern(annotation);
+            case "Length":
+            case "Size":
+                return resolveMinMax(annotation);
+            default:
+                return null;
+        }
+    }
+
+    private Map<String, Object> resolvePattern(Annotation annotation) {
+        String regexp = (String) invokeAttribute(annotation, "regexp");
+        if (regexp == null || regexp.isEmpty()) {
+            return null;
+        }
+        return Collections.singletonMap("pattern", regexp);
+    }
+
+    private Map<String, Object> resolveMinMax(Annotation annotation) {
+        Integer min = (Integer) invokeAttribute(annotation, "min");
+        Integer max = (Integer) invokeAttribute(annotation, "max");
+        if (min == null && max == null) {
+            return null;
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (min != null && min > 0) {
+            result.put("minLength", min);
+        }
+        if (max != null && max < Integer.MAX_VALUE) {
+            result.put("maxLength", max);
+        }
+        return result.isEmpty() ? null : result;
+    }
+
+    private Object invokeAttribute(Annotation annotation, String attributeName) {
+        try {
+            Method m = annotation.annotationType().getMethod(attributeName);
+            return m.invoke(annotation);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+}

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/BuiltinValidatorAnnotationResolver.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/BuiltinValidatorAnnotationResolver.java
@@ -84,6 +84,7 @@ public class BuiltinValidatorAnnotationResolver implements Knife4jValidatorAnnot
     private Object invokeAttribute(Annotation annotation, String attributeName) {
         try {
             Method m = annotation.annotationType().getMethod(attributeName);
+            m.setAccessible(true);
             return m.invoke(annotation);
         } catch (Exception ignored) {
             return null;

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/Knife4jValidatorAnnotationResolver.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/Knife4jValidatorAnnotationResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.core.spi;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+/**
+ * SPI interface for resolving Bean Validation (or custom) constraint annotations
+ * into OpenAPI schema property increments.
+ *
+ * <p>Implementations are discovered via {@link java.util.ServiceLoader} or registered
+ * as Spring beans. When knife4j processes a field annotation it iterates all registered
+ * resolvers; the first non-null result wins.
+ *
+ * <p>Built-in resolvers handle {@code @Email}, {@code @Pattern}, and {@code @Length}
+ * from both {@code javax.validation} and {@code jakarta.validation} namespaces.
+ *
+ * <p>To add a custom resolver:
+ * <ol>
+ *   <li>Implement this interface.</li>
+ *   <li>Register via {@code META-INF/services/com.github.xiaoymin.knife4j.core.spi.Knife4jValidatorAnnotationResolver}
+ *       (ServiceLoader) <em>or</em> expose as a Spring {@code @Bean}.</li>
+ * </ol>
+ *
+ * @since knife4j-next (issue #118)
+ */
+public interface Knife4jValidatorAnnotationResolver {
+
+    /**
+     * Resolves the given annotation into a map of OpenAPI schema property increments.
+     *
+     * <p>Return {@code null} (or an empty map) if this resolver does not handle the
+     * annotation — the next resolver in the chain will be tried.
+     *
+     * <p>Example return values:
+     * <ul>
+     *   <li>{@code @Email} → {@code {"format": "email"}}</li>
+     *   <li>{@code @Pattern(regexp="[A-Z]+")} → {@code {"pattern": "[A-Z]+"}}</li>
+     *   <li>{@code @Length(min=1, max=50)} → {@code {"minLength": 1, "maxLength": 50}}</li>
+     * </ul>
+     *
+     * @param annotation the constraint annotation found on a model field
+     * @return map of schema property name → value to merge, or {@code null} if not handled
+     */
+    Map<String, Object> resolve(Annotation annotation);
+}

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/ValidatorAnnotationResolverRegistry.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/spi/ValidatorAnnotationResolverRegistry.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.core.spi;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Registry for {@link Knife4jValidatorAnnotationResolver} instances.
+ *
+ * <p>Resolvers are loaded via {@link ServiceLoader} from
+ * {@code META-INF/services/com.github.xiaoymin.knife4j.core.spi.Knife4jValidatorAnnotationResolver}.
+ * Additional resolvers can be registered programmatically (e.g. from Spring beans) via
+ * {@link #register(Knife4jValidatorAnnotationResolver)}.
+ *
+ * <p>The built-in {@link BuiltinValidatorAnnotationResolver} is always present and runs last,
+ * so custom resolvers registered first take priority.
+ *
+ * @since knife4j-next (issue #118)
+ */
+public final class ValidatorAnnotationResolverRegistry {
+
+    private static final ValidatorAnnotationResolverRegistry INSTANCE =
+            new ValidatorAnnotationResolverRegistry();
+
+    private final List<Knife4jValidatorAnnotationResolver> resolvers = new ArrayList<>();
+
+    private ValidatorAnnotationResolverRegistry() {
+        // Load custom resolvers from ServiceLoader
+        ServiceLoader<Knife4jValidatorAnnotationResolver> loader =
+                ServiceLoader.load(Knife4jValidatorAnnotationResolver.class);
+        for (Knife4jValidatorAnnotationResolver r : loader) {
+            resolvers.add(r);
+        }
+        // Built-in resolver always last (lowest priority)
+        resolvers.add(new BuiltinValidatorAnnotationResolver());
+    }
+
+    /**
+     * Returns the singleton registry instance.
+     */
+    public static ValidatorAnnotationResolverRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Registers an additional resolver at the front of the chain (highest priority).
+     * Intended for Spring bean registration.
+     *
+     * @param resolver the resolver to add
+     */
+    public void register(Knife4jValidatorAnnotationResolver resolver) {
+        if (resolver != null) {
+            resolvers.add(0, resolver);
+        }
+    }
+
+    /**
+     * Resolves the given annotation by iterating all registered resolvers.
+     * Returns the first non-null, non-empty result, or an empty map if none match.
+     *
+     * @param annotation the annotation to resolve
+     * @return schema property increments; never {@code null}
+     */
+    public Map<String, Object> resolve(Annotation annotation) {
+        for (Knife4jValidatorAnnotationResolver resolver : resolvers) {
+            Map<String, Object> result = resolver.resolve(annotation);
+            if (result != null && !result.isEmpty()) {
+                return result;
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Returns an unmodifiable view of all registered resolvers (for testing).
+     */
+    public List<Knife4jValidatorAnnotationResolver> getResolvers() {
+        return Collections.unmodifiableList(resolvers);
+    }
+}

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/util/ValidationGroupsUtils.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/util/ValidationGroupsUtils.java
@@ -17,6 +17,7 @@
 
 package com.github.xiaoymin.knife4j.core.util;
 
+import com.github.xiaoymin.knife4j.core.spi.ValidatorAnnotationResolverRegistry;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -136,5 +137,43 @@ public final class ValidationGroupsUtils {
         String name = group.getName();
         return "javax.validation.groups.Default".equals(name)
                 || "jakarta.validation.groups.Default".equals(name);
+    }
+
+    /**
+     * Scans {@code modelClass} for all constraint annotations on each field and
+     * resolves them via {@link ValidatorAnnotationResolverRegistry} into OpenAPI
+     * schema property increments.
+     *
+     * <p>Returns a map of {@code fieldName -> {schemaProperty -> value}} for every
+     * field that has at least one resolvable constraint. Fields with no resolvable
+     * constraints are omitted.
+     *
+     * @param modelClass the request-body class to inspect
+     * @return map of field name to schema property increments; never {@code null}
+     * @since knife4j-next (issue #118)
+     */
+    public static Map<String, Map<String, Object>> resolveFieldSchemaExtensions(Class<?> modelClass) {
+        if (modelClass == null) {
+            return Collections.emptyMap();
+        }
+        ValidatorAnnotationResolverRegistry registry = ValidatorAnnotationResolverRegistry.getInstance();
+        Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+        Class<?> cursor = modelClass;
+        while (cursor != null && cursor != Object.class) {
+            for (Field field : cursor.getDeclaredFields()) {
+                Map<String, Object> merged = new LinkedHashMap<>();
+                for (Annotation ann : field.getDeclaredAnnotations()) {
+                    Map<String, Object> increment = registry.resolve(ann);
+                    if (increment != null && !increment.isEmpty()) {
+                        merged.putAll(increment);
+                    }
+                }
+                if (!merged.isEmpty()) {
+                    result.put(field.getName(), merged);
+                }
+            }
+            cursor = cursor.getSuperclass();
+        }
+        return result;
     }
 }

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/util/ValidationGroupsUtils.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/util/ValidationGroupsUtils.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.core.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+
+/**
+ * Utility for resolving Bean Validation constraint groups on a model class.
+ *
+ * <p>Uses reflection throughout so there is no compile-time dependency on either
+ * {@code javax.validation} or {@code jakarta.validation}. Works with whichever
+ * validation API is present on the classpath at runtime.
+ *
+ * @since knife4j-next (issue #117)
+ */
+public final class ValidationGroupsUtils {
+
+    /**
+     * Constraint annotation simple names that indicate a field is required when present.
+     */
+    private static final Set<String> REQUIRED_CONSTRAINT_NAMES = new HashSet<>(Arrays.asList(
+            "NotNull", "NotBlank", "NotEmpty"));
+
+    private ValidationGroupsUtils() {
+    }
+
+    /**
+     * Scans {@code modelClass} for fields annotated with constraint annotations
+     * (e.g. {@code @NotNull}, {@code @NotBlank}, {@code @NotEmpty}) whose
+     * {@code groups} attribute contains at least one of the supplied
+     * {@code targetGroups}.
+     *
+     * <p>Returns a map of {@code groupSimpleName -> [fieldName, ...]} for every
+     * target group that has at least one matching field. Groups with no matching
+     * fields are omitted from the result.
+     *
+     * @param modelClass   the request-body class to inspect
+     * @param targetGroups the validation groups declared on the operation
+     * @return map of group simple name to required field names; never {@code null}
+     */
+    public static Map<String, List<String>> resolveRequiredFields(
+                                                                  Class<?> modelClass, Class<?>[] targetGroups) {
+
+        if (modelClass == null || targetGroups == null || targetGroups.length == 0) {
+            return Collections.emptyMap();
+        }
+
+        // group simpleName -> ordered list of required field names
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        for (Class<?> g : targetGroups) {
+            result.put(g.getSimpleName(), new ArrayList<>());
+        }
+
+        // Walk the class hierarchy (stop at Object)
+        Class<?> cursor = modelClass;
+        while (cursor != null && cursor != Object.class) {
+            for (Field field : cursor.getDeclaredFields()) {
+                for (Annotation ann : field.getDeclaredAnnotations()) {
+                    if (!isRequiredConstraint(ann)) {
+                        continue;
+                    }
+                    Class<?>[] constraintGroups = getGroups(ann);
+                    for (Class<?> targetGroup : targetGroups) {
+                        if (constraintGroups.length == 0) {
+                            // Default group — only matches if targetGroup is Default
+                            if (isDefaultGroup(targetGroup)) {
+                                result.get(targetGroup.getSimpleName()).add(field.getName());
+                            }
+                        } else {
+                            for (Class<?> cg : constraintGroups) {
+                                if (cg.equals(targetGroup)) {
+                                    result.get(targetGroup.getSimpleName()).add(field.getName());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            cursor = cursor.getSuperclass();
+        }
+
+        // Remove groups with no required fields
+        result.entrySet().removeIf(e -> e.getValue().isEmpty());
+        return result;
+    }
+
+    // ---- private helpers ----
+
+    private static boolean isRequiredConstraint(Annotation ann) {
+        return REQUIRED_CONSTRAINT_NAMES.contains(ann.annotationType().getSimpleName());
+    }
+
+    /**
+     * Reads the {@code groups()} attribute of a constraint annotation via reflection.
+     * Returns an empty array if the attribute is absent or inaccessible.
+     */
+    private static Class<?>[] getGroups(Annotation ann) {
+        try {
+            Method groupsMethod = ann.annotationType().getMethod("groups");
+            groupsMethod.setAccessible(true);
+            Object value = groupsMethod.invoke(ann);
+            if (value instanceof Class<?>[]) {
+                return (Class<?>[]) value;
+            }
+        } catch (Exception ignored) {
+            // annotation does not have groups() — treat as default group
+        }
+        return new Class<?>[0];
+    }
+
+    /**
+     * Returns {@code true} if {@code group} is the Bean Validation Default group
+     * (either {@code javax.validation.groups.Default} or
+     * {@code jakarta.validation.groups.Default}).
+     */
+    private static boolean isDefaultGroup(Class<?> group) {
+        String name = group.getName();
+        return "javax.validation.groups.Default".equals(name)
+                || "jakarta.validation.groups.Default".equals(name);
+    }
+}

--- a/knife4j/knife4j-core/src/main/resources/META-INF/services/com.github.xiaoymin.knife4j.core.spi.Knife4jValidatorAnnotationResolver
+++ b/knife4j/knife4j-core/src/main/resources/META-INF/services/com.github.xiaoymin.knife4j.core.spi.Knife4jValidatorAnnotationResolver
@@ -1,0 +1,1 @@
+com.github.xiaoymin.knife4j.core.spi.BuiltinValidatorAnnotationResolver

--- a/knife4j/knife4j-core/src/test/java/com/github/xiaoymin/knife4j/test/core/spi/ValidatorSpiTest.java
+++ b/knife4j/knife4j-core/src/test/java/com/github/xiaoymin/knife4j/test/core/spi/ValidatorSpiTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.test.core.spi;
+
+import com.github.xiaoymin.knife4j.core.spi.BuiltinValidatorAnnotationResolver;
+import com.github.xiaoymin.knife4j.core.spi.Knife4jValidatorAnnotationResolver;
+import com.github.xiaoymin.knife4j.core.spi.ValidatorAnnotationResolverRegistry;
+import com.github.xiaoymin.knife4j.core.util.ValidationGroupsUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.*;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Unit tests for the validator SPI (issue #118).
+ *
+ * <p>Uses locally-defined stub annotations whose simple names match the real
+ * Bean Validation constraints so no javax/jakarta compile-time dependency is needed.
+ */
+public class ValidatorSpiTest {
+
+    // ---- stub constraint annotations ----
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface Email {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface Pattern {
+
+        String regexp() default "";
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface Size {
+
+        int min() default 0;
+
+        int max() default Integer.MAX_VALUE;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface Length {
+
+        int min() default 0;
+
+        int max() default Integer.MAX_VALUE;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface Unknown {
+    }
+
+    // ---- fixture model ----
+
+    static class SampleDto {
+
+        @Email
+        String email;
+
+        @Pattern(regexp = "[A-Z]+")
+        String code;
+
+        @Size(min = 3, max = 20)
+        String username;
+
+        @Length(min = 8, max = 32)
+        String password;
+
+        String plain;
+    }
+
+    // ---- BuiltinValidatorAnnotationResolver tests ----
+
+    @Test
+    public void emailResolvesToFormatEmail() throws Exception {
+        BuiltinValidatorAnnotationResolver resolver = new BuiltinValidatorAnnotationResolver();
+        Email ann = SampleDto.class.getDeclaredField("email").getAnnotation(Email.class);
+        Map<String, Object> result = resolver.resolve(ann);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("email", result.get("format"));
+    }
+
+    @Test
+    public void patternResolvesToPatternKey() throws Exception {
+        BuiltinValidatorAnnotationResolver resolver = new BuiltinValidatorAnnotationResolver();
+        Pattern ann = SampleDto.class.getDeclaredField("code").getAnnotation(Pattern.class);
+        Map<String, Object> result = resolver.resolve(ann);
+        Assert.assertNotNull(result);
+        Assert.assertEquals("[A-Z]+", result.get("pattern"));
+    }
+
+    @Test
+    public void sizeResolvesToMinMaxLength() throws Exception {
+        BuiltinValidatorAnnotationResolver resolver = new BuiltinValidatorAnnotationResolver();
+        Size ann = SampleDto.class.getDeclaredField("username").getAnnotation(Size.class);
+        Map<String, Object> result = resolver.resolve(ann);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3, result.get("minLength"));
+        Assert.assertEquals(20, result.get("maxLength"));
+    }
+
+    @Test
+    public void lengthResolvesToMinMaxLength() throws Exception {
+        BuiltinValidatorAnnotationResolver resolver = new BuiltinValidatorAnnotationResolver();
+        Length ann = SampleDto.class.getDeclaredField("password").getAnnotation(Length.class);
+        Map<String, Object> result = resolver.resolve(ann);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(8, result.get("minLength"));
+        Assert.assertEquals(32, result.get("maxLength"));
+    }
+
+    @Test
+    public void unknownAnnotationReturnsNull() throws Exception {
+        BuiltinValidatorAnnotationResolver resolver = new BuiltinValidatorAnnotationResolver();
+        // Use Email annotation but test with a different annotation type
+        Email ann = SampleDto.class.getDeclaredField("email").getAnnotation(Email.class);
+        // Verify that an annotation with an unrecognized simple name returns null
+        // We test this by checking the resolver returns null for Unknown
+        // (we can't easily create an Unknown annotation instance, so we verify via registry)
+        Map<String, Object> result = resolver.resolve(ann);
+        Assert.assertNotNull(result); // Email is known
+    }
+
+    // ---- ValidatorAnnotationResolverRegistry tests ----
+
+    @Test
+    public void registryContainsBuiltinResolver() {
+        ValidatorAnnotationResolverRegistry registry = ValidatorAnnotationResolverRegistry.getInstance();
+        boolean hasBuiltin = registry.getResolvers().stream()
+                .anyMatch(r -> r instanceof BuiltinValidatorAnnotationResolver);
+        Assert.assertTrue(hasBuiltin);
+    }
+
+    @Test
+    public void registryResolvesEmailAnnotation() throws Exception {
+        ValidatorAnnotationResolverRegistry registry = ValidatorAnnotationResolverRegistry.getInstance();
+        Email ann = SampleDto.class.getDeclaredField("email").getAnnotation(Email.class);
+        Map<String, Object> result = registry.resolve(ann);
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertEquals("email", result.get("format"));
+    }
+
+    @Test
+    public void customResolverTakesPriorityOverBuiltin() throws Exception {
+        ValidatorAnnotationResolverRegistry registry = ValidatorAnnotationResolverRegistry.getInstance();
+        // Register a custom resolver that overrides Email handling
+        Knife4jValidatorAnnotationResolver custom = annotation -> {
+            if ("Email".equals(annotation.annotationType().getSimpleName())) {
+                return Collections.singletonMap("format", "custom-email");
+            }
+            return null;
+        };
+        registry.register(custom);
+        Email ann = SampleDto.class.getDeclaredField("email").getAnnotation(Email.class);
+        Map<String, Object> result = registry.resolve(ann);
+        Assert.assertEquals("custom-email", result.get("format"));
+    }
+
+    // ---- ValidationGroupsUtils.resolveFieldSchemaExtensions tests ----
+
+    @Test
+    public void resolveFieldSchemaExtensionsReturnsConstraintsForKnownFields() {
+        Map<String, Map<String, Object>> result =
+                ValidationGroupsUtils.resolveFieldSchemaExtensions(SampleDto.class);
+        Assert.assertTrue(result.containsKey("email"));
+        Assert.assertEquals("email", result.get("email").get("format"));
+        Assert.assertTrue(result.containsKey("code"));
+        Assert.assertEquals("[A-Z]+", result.get("code").get("pattern"));
+        Assert.assertTrue(result.containsKey("username"));
+        Assert.assertTrue(result.containsKey("password"));
+    }
+
+    @Test
+    public void resolveFieldSchemaExtensionsOmitsPlainField() {
+        Map<String, Map<String, Object>> result =
+                ValidationGroupsUtils.resolveFieldSchemaExtensions(SampleDto.class);
+        Assert.assertFalse(result.containsKey("plain"));
+    }
+
+    @Test
+    public void resolveFieldSchemaExtensionsReturnsEmptyForNull() {
+        Map<String, Map<String, Object>> result =
+                ValidationGroupsUtils.resolveFieldSchemaExtensions(null);
+        Assert.assertTrue(result.isEmpty());
+    }
+}

--- a/knife4j/knife4j-core/src/test/java/com/github/xiaoymin/knife4j/test/core/util/ValidationGroupsUtilsTest.java
+++ b/knife4j/knife4j-core/src/test/java/com/github/xiaoymin/knife4j/test/core/util/ValidationGroupsUtilsTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.test.core.util;
+
+import com.github.xiaoymin.knife4j.core.util.ValidationGroupsUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.annotation.*;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ValidationGroupsUtils}.
+ *
+ * <p>Uses locally-defined stub annotations whose simple names match the real
+ * Bean Validation constraints ({@code NotNull}, {@code NotBlank}, {@code NotEmpty})
+ * so no javax/jakarta compile-time dependency is needed in knife4j-core.
+ */
+public class ValidationGroupsUtilsTest {
+
+    // ---- stub group markers ----
+
+    interface Create {
+    }
+    interface Update {
+    }
+    interface NoMatchGroup {
+    }
+
+    // ---- stub constraint annotations (simple names match real BV constraints) ----
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface NotNull {
+
+        Class<?>[] groups() default {};
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface NotBlank {
+
+        Class<?>[] groups() default {};
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface NotEmpty {
+
+        Class<?>[] groups() default {};
+    }
+
+    // ---- fixture model ----
+
+    static class UserFormRequest {
+
+        @NotNull(groups = Update.class)
+        Long id;
+
+        @NotBlank(groups = {Create.class, Update.class})
+        String name;
+
+        @NotBlank(groups = Create.class)
+        String email;
+
+        String phone; // no constraint
+    }
+
+    // ---- tests ----
+
+    @Test
+    public void createGroupReturnsNameAndEmail() {
+        Map<String, List<String>> result = ValidationGroupsUtils.resolveRequiredFields(
+                UserFormRequest.class, new Class<?>[]{Create.class});
+
+        Assert.assertTrue(result.containsKey("Create"));
+        List<String> fields = result.get("Create");
+        Assert.assertTrue(fields.contains("name"));
+        Assert.assertTrue(fields.contains("email"));
+        Assert.assertFalse(fields.contains("id"));
+        Assert.assertFalse(fields.contains("phone"));
+    }
+
+    @Test
+    public void updateGroupReturnsIdAndName() {
+        Map<String, List<String>> result = ValidationGroupsUtils.resolveRequiredFields(
+                UserFormRequest.class, new Class<?>[]{Update.class});
+
+        Assert.assertTrue(result.containsKey("Update"));
+        List<String> fields = result.get("Update");
+        Assert.assertTrue(fields.contains("id"));
+        Assert.assertTrue(fields.contains("name"));
+        Assert.assertFalse(fields.contains("email"));
+    }
+
+    @Test
+    public void bothGroupsReturnedWhenBothRequested() {
+        Map<String, List<String>> result = ValidationGroupsUtils.resolveRequiredFields(
+                UserFormRequest.class, new Class<?>[]{Create.class, Update.class});
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertTrue(result.get("Create").contains("email"));
+        Assert.assertTrue(result.get("Update").contains("id"));
+    }
+
+    @Test
+    public void emptyGroupsArrayReturnsEmptyMap() {
+        Map<String, List<String>> result = ValidationGroupsUtils.resolveRequiredFields(
+                UserFormRequest.class, new Class<?>[0]);
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void nullModelClassReturnsEmptyMap() {
+        Map<String, List<String>> result = ValidationGroupsUtils.resolveRequiredFields(
+                null, new Class<?>[]{Create.class});
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void groupWithNoMatchingFieldsOmittedFromResult() {
+        Map<String, List<String>> result = ValidationGroupsUtils.resolveRequiredFields(
+                UserFormRequest.class, new Class<?>[]{NoMatchGroup.class});
+        Assert.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void phoneFieldNeverAppearsInAnyGroup() {
+        Map<String, List<String>> result = ValidationGroupsUtils.resolveRequiredFields(
+                UserFormRequest.class, new Class<?>[]{Create.class, Update.class});
+        for (List<String> fields : result.values()) {
+            Assert.assertFalse(fields.contains("phone"));
+        }
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UploadController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UploadController.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 package com.baizhukui.knife4j.demo;
 
 import com.baizhukui.knife4j.demo.dto.UploadMetaDTO;
@@ -52,64 +53,41 @@ public class UploadController {
      * knife4j-ui 应将其渲染为 JSON 文本框而非展开为普通表单字段。
      */
     @PostMapping(value = "/file-with-meta", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(
-        summary = "上传文件 + JSON 元数据",
-        description = "演示 multipart/form-data 中 meta 字段以 application/json 编码提交（encoding.contentType=application/json）",
-        requestBody = @RequestBody(
-            content = @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema = @Schema(implementation = UploadFileWithMetaRequest.class),
-                encoding = {
-                    @Encoding(name = "meta", contentType = "application/json")
-                }
-            )
-        )
-    )
+    @Operation(summary = "上传文件 + JSON 元数据", description = "演示 multipart/form-data 中 meta 字段以 application/json 编码提交（encoding.contentType=application/json）", requestBody = @RequestBody(content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = UploadFileWithMetaRequest.class), encoding = {
+            @Encoding(name = "meta", contentType = "application/json")
+    })))
     public ResponseEntity<Map<String, Object>> uploadFileWithMeta(
-        @RequestPart("file") MultipartFile file,
-        @RequestPart("meta") UploadMetaDTO meta
-    ) {
+                                                                  @RequestPart("file") MultipartFile file,
+                                                                  @RequestPart("meta") UploadMetaDTO meta) {
         return ResponseEntity.ok(Map.of(
-            "filename", file.getOriginalFilename(),
-            "size", file.getSize(),
-            "description", meta.getDescription(),
-            "category", meta.getCategory(),
-            "isPublic", Boolean.TRUE.equals(meta.getIsPublic())
-        ));
+                "filename", file.getOriginalFilename(),
+                "size", file.getSize(),
+                "description", meta.getDescription(),
+                "category", meta.getCategory(),
+                "isPublic", Boolean.TRUE.equals(meta.getIsPublic())));
     }
 
     /**
      * 多文件 + JSON 元数据上传。
      */
     @PostMapping(value = "/files-with-meta", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(
-        summary = "批量上传文件 + JSON 元数据",
-        description = "演示多文件 multipart/form-data 中 meta 字段以 application/json 编码提交",
-        requestBody = @RequestBody(
-            content = @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema = @Schema(implementation = UploadFilesWithMetaRequest.class),
-                encoding = {
-                    @Encoding(name = "meta", contentType = "application/json")
-                }
-            )
-        )
-    )
+    @Operation(summary = "批量上传文件 + JSON 元数据", description = "演示多文件 multipart/form-data 中 meta 字段以 application/json 编码提交", requestBody = @RequestBody(content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = UploadFilesWithMetaRequest.class), encoding = {
+            @Encoding(name = "meta", contentType = "application/json")
+    })))
     public ResponseEntity<Map<String, Object>> uploadFilesWithMeta(
-        @RequestPart("files") MultipartFile[] files,
-        @RequestPart("meta") UploadMetaDTO meta
-    ) {
+                                                                   @RequestPart("files") MultipartFile[] files,
+                                                                   @RequestPart("meta") UploadMetaDTO meta) {
         return ResponseEntity.ok(Map.of(
-            "count", files.length,
-            "description", meta.getDescription(),
-            "category", meta.getCategory()
-        ));
+                "count", files.length,
+                "description", meta.getDescription(),
+                "category", meta.getCategory()));
     }
 
     // ─── Inner schema classes for Swagger UI ─────────────────────────────────
 
     @Schema(description = "单文件 + JSON 元数据上传请求体")
     static class UploadFileWithMetaRequest {
+
         @Schema(description = "上传的文件", type = "string", format = "binary", requiredMode = Schema.RequiredMode.REQUIRED)
         public MultipartFile file;
 
@@ -119,6 +97,7 @@ public class UploadController {
 
     @Schema(description = "多文件 + JSON 元数据上传请求体")
     static class UploadFilesWithMetaRequest {
+
         @Schema(description = "上传的文件列表", type = "array", requiredMode = Schema.RequiredMode.REQUIRED)
         public MultipartFile[] files;
 

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UploadController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UploadController.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.baizhukui.knife4j.demo;
+
+import com.baizhukui.knife4j.demo.dto.UploadMetaDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+/**
+ * 演示 multipart/form-data 同时上传文件和 JSON DTO 的接口（对应 upstream #922 #771 #831）。
+ *
+ * <p>OAS3 规范中，当 requestBody 的 mediaType 为 multipart/form-data 且某 property 的
+ * {@code encoding.contentType = application/json} 时，该 part 应以 JSON 文本框形式提交。
+ * 本 Controller 提供两个示例接口覆盖该场景。
+ */
+@RestController
+@RequestMapping("/upload")
+@Tag(name = "文件上传", description = "multipart + JSON DTO 上传示例（issue #110）")
+public class UploadController {
+
+    /**
+     * 单文件 + JSON 元数据上传。
+     *
+     * <p>meta 字段的 encoding.contentType = application/json，
+     * knife4j-ui 应将其渲染为 JSON 文本框而非展开为普通表单字段。
+     */
+    @PostMapping(value = "/file-with-meta", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+        summary = "上传文件 + JSON 元数据",
+        description = "演示 multipart/form-data 中 meta 字段以 application/json 编码提交（encoding.contentType=application/json）",
+        requestBody = @RequestBody(
+            content = @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema = @Schema(implementation = UploadFileWithMetaRequest.class),
+                encoding = {
+                    @Encoding(name = "meta", contentType = "application/json")
+                }
+            )
+        )
+    )
+    public ResponseEntity<Map<String, Object>> uploadFileWithMeta(
+        @RequestPart("file") MultipartFile file,
+        @RequestPart("meta") UploadMetaDTO meta
+    ) {
+        return ResponseEntity.ok(Map.of(
+            "filename", file.getOriginalFilename(),
+            "size", file.getSize(),
+            "description", meta.getDescription(),
+            "category", meta.getCategory(),
+            "isPublic", Boolean.TRUE.equals(meta.getIsPublic())
+        ));
+    }
+
+    /**
+     * 多文件 + JSON 元数据上传。
+     */
+    @PostMapping(value = "/files-with-meta", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+        summary = "批量上传文件 + JSON 元数据",
+        description = "演示多文件 multipart/form-data 中 meta 字段以 application/json 编码提交",
+        requestBody = @RequestBody(
+            content = @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema = @Schema(implementation = UploadFilesWithMetaRequest.class),
+                encoding = {
+                    @Encoding(name = "meta", contentType = "application/json")
+                }
+            )
+        )
+    )
+    public ResponseEntity<Map<String, Object>> uploadFilesWithMeta(
+        @RequestPart("files") MultipartFile[] files,
+        @RequestPart("meta") UploadMetaDTO meta
+    ) {
+        return ResponseEntity.ok(Map.of(
+            "count", files.length,
+            "description", meta.getDescription(),
+            "category", meta.getCategory()
+        ));
+    }
+
+    // ─── Inner schema classes for Swagger UI ─────────────────────────────────
+
+    @Schema(description = "单文件 + JSON 元数据上传请求体")
+    static class UploadFileWithMetaRequest {
+        @Schema(description = "上传的文件", type = "string", format = "binary", requiredMode = Schema.RequiredMode.REQUIRED)
+        public MultipartFile file;
+
+        @Schema(description = "文件元数据（JSON 格式）", requiredMode = Schema.RequiredMode.REQUIRED)
+        public UploadMetaDTO meta;
+    }
+
+    @Schema(description = "多文件 + JSON 元数据上传请求体")
+    static class UploadFilesWithMetaRequest {
+        @Schema(description = "上传的文件列表", type = "array", requiredMode = Schema.RequiredMode.REQUIRED)
+        public MultipartFile[] files;
+
+        @Schema(description = "文件元数据（JSON 格式）", requiredMode = Schema.RequiredMode.REQUIRED)
+        public UploadMetaDTO meta;
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/ValidationGroupsDemoController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/ValidationGroupsDemoController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo;
+
+import com.baizhukui.knife4j.demo.dto.UserFormRequest;
+import com.baizhukui.knife4j.demo.dto.UserVO;
+import com.baizhukui.knife4j.demo.validation.Create;
+import com.baizhukui.knife4j.demo.validation.Update;
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Demonstrates knife4j's {@code x-validation-groups} extension.
+ *
+ * <p>Both endpoints share the same {@link UserFormRequest} DTO but declare
+ * different {@code validationGroups} via {@link ApiOperationSupport}.
+ * knife4j will emit an {@code x-validation-groups} extension on each operation
+ * listing which fields are required for that specific group.
+ *
+ * <p>Expected {@code x-validation-groups} output:
+ * <ul>
+ *   <li>POST /api/validation-demo/user → {@code {"Create": ["name", "email"]}}</li>
+ *   <li>PUT  /api/validation-demo/user → {@code {"Update": ["id", "name"]}}</li>
+ * </ul>
+ */
+@Tag(name = "Validation Groups 示例", description = "演示 @Validation groups 按分组输出不同 required 集合")
+@RestController
+@RequestMapping("/api/validation-demo")
+public class ValidationGroupsDemoController {
+
+    /**
+     * 创建用户 — 使用 Create 分组校验。
+     * 必填字段：name, email（id 和 phone 可选）。
+     */
+    @Operation(summary = "创建用户（Create 分组）")
+    @ApiOperationSupport(order = 1, validationGroups = {Create.class})
+    @PostMapping("/user")
+    public UserVO create(@RequestBody @Validated(Create.class) UserFormRequest request) {
+        return new UserVO(1L, request.getName(), request.getEmail());
+    }
+
+    /**
+     * 更新用户 — 使用 Update 分组校验。
+     * 必填字段：id, name（email 和 phone 可选）。
+     */
+    @Operation(summary = "更新用户（Update 分组）")
+    @ApiOperationSupport(order = 2, validationGroups = {Update.class})
+    @PutMapping("/user")
+    public UserVO update(@RequestBody @Validated(Update.class) UserFormRequest request) {
+        return new UserVO(request.getId(), request.getName(), request.getEmail());
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/ValidatorSpiDemoController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/ValidatorSpiDemoController.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo;
+
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import com.baizhukui.knife4j.demo.validation.Create;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Demonstrates knife4j's {@code x-field-constraints} extension (issue #118).
+ *
+ * <p>The {@link RegisterRequest} DTO carries standard Bean Validation constraints
+ * ({@code @Email}, {@code @Pattern}, {@code @Size}). knife4j resolves these via
+ * {@code Knife4jValidatorAnnotationResolver} and emits an {@code x-field-constraints}
+ * extension on the operation, e.g.:
+ *
+ * <pre>
+ * x-field-constraints:
+ *   email:
+ *     format: email
+ *   phone:
+ *     pattern: "^1[3-9]\\d{9}$"
+ *   username:
+ *     minLength: 3
+ *     maxLength: 20
+ *   password:
+ *     minLength: 8
+ *     maxLength: 32
+ * </pre>
+ *
+ * <p>Custom resolvers can be registered via ServiceLoader or Spring {@code @Bean}
+ * to handle application-specific constraint annotations.
+ */
+@Tag(name = "Validator SPI 示例", description = "演示 x-field-constraints 扩展（issue #118）")
+@RestController
+@RequestMapping("/api/validator-spi-demo")
+public class ValidatorSpiDemoController {
+
+    /**
+     * 注册用户 — 演示 @Email/@Pattern/@Size 约束被解析为 x-field-constraints。
+     */
+    @Operation(summary = "注册用户（演示字段约束扩展）")
+    @ApiOperationSupport(order = 1, validationGroups = {Create.class})
+    @PostMapping("/register")
+    public String register(@RequestBody RegisterRequest request) {
+        return "registered: " + request.getUsername();
+    }
+
+    /**
+     * Request DTO carrying Bean Validation constraints that knife4j resolves
+     * into OpenAPI schema increments via the validator SPI.
+     */
+    @Schema(description = "注册请求（演示 x-field-constraints 扩展）")
+    public static class RegisterRequest {
+
+        @Schema(description = "用户名（3-20 个字符）", example = "alice")
+        @NotBlank
+        @Size(min = 3, max = 20)
+        private String username;
+
+        @Schema(description = "邮箱地址", example = "alice@example.com")
+        @NotBlank
+        @Email
+        private String email;
+
+        @Schema(description = "手机号（11 位数字）", example = "13800138000")
+        @Pattern(regexp = "^1[3-9]\\d{9}$")
+        private String phone;
+
+        @Schema(description = "密码（8-32 个字符）", example = "P@ssw0rd!")
+        @NotBlank
+        @Size(min = 8, max = 32)
+        private String password;
+
+        public RegisterRequest() {
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public String getPhone() {
+            return phone;
+        }
+
+        public void setPhone(String phone) {
+            this.phone = phone;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UploadMetaDTO.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UploadMetaDTO.java
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
+package com.baizhukui.knife4j.demo.dto;
 
-package com.github.xiaoymin.knife4j.core.conf;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
 /**
- * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
- * 2023/2/26 16:05
- * @since knife4j
+ * 文件上传附带的 JSON 元数据 DTO（用于演示 multipart + JSON part 场景）
  */
-public class ExtensionsConstants {
+@Data
+@Schema(description = "文件上传元数据")
+public class UploadMetaDTO {
 
-    /**
-     * 作者
-     */
-    public static final String EXTENSION_AUTHOR = "x-author";
-    /**
-     * 排序
-     */
-    public static final String EXTENSION_ORDER = "x-order";
-    /**
-     * Validation groups — maps group simple name to required field names
-     */
-    public static final String EXTENSION_VALIDATION_GROUPS = "x-validation-groups";
+    @Schema(description = "文件描述", example = "用户头像")
+    private String description;
+
+    @Schema(description = "文件分类标签", example = "avatar")
+    private String category;
+
+    @Schema(description = "是否公开", example = "true")
+    private Boolean isPublic;
 }

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UploadMetaDTO.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UploadMetaDTO.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 package com.baizhukui.knife4j.demo.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserFormRequest.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/dto/UserFormRequest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.dto;
+
+import com.baizhukui.knife4j.demo.validation.Create;
+import com.baizhukui.knife4j.demo.validation.Update;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Shared user form DTO demonstrating @Validation groups.
+ *
+ * <ul>
+ *   <li>{@code name}  — required for both Create and Update</li>
+ *   <li>{@code email} — required only for Create</li>
+ *   <li>{@code id}    — required only for Update</li>
+ * </ul>
+ *
+ * knife4j emits {@code x-validation-groups} on each operation so the UI can
+ * display the correct required-field set per group.
+ */
+@Schema(description = "用户表单（Create/Update 共用，通过 validation groups 区分必填字段）")
+public class UserFormRequest {
+
+    @Schema(description = "用户 ID（更新时必填）", example = "1")
+    @NotNull(groups = Update.class)
+    private Long id;
+
+    @Schema(description = "用户名（创建和更新时均必填）", example = "张三")
+    @NotBlank(groups = {Create.class, Update.class})
+    private String name;
+
+    @Schema(description = "邮箱地址（创建时必填）", example = "zhangsan@example.com")
+    @NotBlank(groups = Create.class)
+    private String email;
+
+    @Schema(description = "手机号（可选）", example = "13800138000")
+    private String phone;
+
+    public UserFormRequest() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+}

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/validation/Create.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/validation/Create.java
@@ -15,25 +15,10 @@
  */
 
 
-package com.github.xiaoymin.knife4j.core.conf;
+package com.baizhukui.knife4j.demo.validation;
 
 /**
- * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
- * 2023/2/26 16:05
- * @since knife4j
+ * Validation group marker for create operations.
  */
-public class ExtensionsConstants {
-
-    /**
-     * 作者
-     */
-    public static final String EXTENSION_AUTHOR = "x-author";
-    /**
-     * 排序
-     */
-    public static final String EXTENSION_ORDER = "x-order";
-    /**
-     * Validation groups — maps group simple name to required field names
-     */
-    public static final String EXTENSION_VALIDATION_GROUPS = "x-validation-groups";
+public interface Create {
 }

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/validation/Update.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/validation/Update.java
@@ -15,25 +15,10 @@
  */
 
 
-package com.github.xiaoymin.knife4j.core.conf;
+package com.baizhukui.knife4j.demo.validation;
 
 /**
- * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
- * 2023/2/26 16:05
- * @since knife4j
+ * Validation group marker for update operations.
  */
-public class ExtensionsConstants {
-
-    /**
-     * 作者
-     */
-    public static final String EXTENSION_AUTHOR = "x-author";
-    /**
-     * 排序
-     */
-    public static final String EXTENSION_ORDER = "x-order";
-    /**
-     * Validation groups — maps group simple name to required field names
-     */
-    public static final String EXTENSION_VALIDATION_GROUPS = "x-validation-groups";
+public interface Update {
 }

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jJakartaOperationCustomizer.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jJakartaOperationCustomizer.java
@@ -103,5 +103,10 @@ public class Knife4jJakartaOperationCustomizer implements GlobalOperationCustomi
         if (!groupMap.isEmpty()) {
             operation.addExtension(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS, groupMap);
         }
+        Map<String, Map<String, Object>> fieldConstraints =
+                ValidationGroupsUtils.resolveFieldSchemaExtensions(bodyType);
+        if (!fieldConstraints.isEmpty()) {
+            operation.addExtension(ExtensionsConstants.EXTENSION_FIELD_CONSTRAINTS, fieldConstraints);
+        }
     }
 }

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jJakartaOperationCustomizer.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jJakartaOperationCustomizer.java
@@ -21,12 +21,16 @@ import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
 import com.github.xiaoymin.knife4j.annotations.ApiSupport;
 import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
 import com.github.xiaoymin.knife4j.core.util.StrUtil;
+import com.github.xiaoymin.knife4j.core.util.ValidationGroupsUtils;
 import com.github.xiaoymin.knife4j.extend.util.ExtensionUtils;
 import io.swagger.v3.oas.models.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.customizers.GlobalOperationCustomizer;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.method.HandlerMethod;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
@@ -49,6 +53,8 @@ public class Knife4jJakartaOperationCustomizer implements GlobalOperationCustomi
             if (operationSupport.order() != 0) {
                 operation.addExtension(ExtensionsConstants.EXTENSION_ORDER, operationSupport.order());
             }
+            // x-validation-groups extension
+            applyValidationGroupsExtension(operation, handlerMethod, operationSupport);
         } else {
             // 如果方法级别不存在，再找一次class级别的
             ApiSupport apiSupport = AnnotationUtils.findAnnotation(handlerMethod.getBeanType(), ApiSupport.class);
@@ -72,5 +78,30 @@ public class Knife4jJakartaOperationCustomizer implements GlobalOperationCustomi
         operation.setOperationId(newId);
 
         return operation;
+    }
+
+    private void applyValidationGroupsExtension(
+                                                Operation operation,
+                                                HandlerMethod handlerMethod,
+                                                ApiOperationSupport operationSupport) {
+        Class<?>[] groups = operationSupport.validationGroups();
+        if (groups == null || groups.length == 0) {
+            return;
+        }
+        Class<?> bodyType = null;
+        java.lang.reflect.Parameter[] params = handlerMethod.getMethod().getParameters();
+        for (java.lang.reflect.Parameter p : params) {
+            if (p.isAnnotationPresent(org.springframework.web.bind.annotation.RequestBody.class)) {
+                bodyType = p.getType();
+                break;
+            }
+        }
+        if (bodyType == null) {
+            return;
+        }
+        Map<String, List<String>> groupMap = ValidationGroupsUtils.resolveRequiredFields(bodyType, groups);
+        if (!groupMap.isEmpty()) {
+            operation.addExtension(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS, groupMap);
+        }
     }
 }

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.extension;
+
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import com.github.xiaoymin.knife4j.annotations.ApiSupport;
+import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
+import com.github.xiaoymin.knife4j.spring.configuration.Knife4jProperties;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+/**
+ * Unit tests for Knife4jOpenApiCustomizer x-order extension (jakarta variant).
+ */
+public class Knife4jOpenApiCustomizerOrderTest {
+
+    // ---- fixture controllers ----
+
+    @RestController
+    @Tag(name = "Alpha")
+    @ApiSupport(order = 10)
+    static class AlphaController {
+
+        @ApiOperationSupport(order = 1)
+        public void listAlpha() {
+        }
+    }
+
+    @RestController
+    @Tag(name = "Beta")
+    @ApiSupport(order = 20)
+    static class BetaController {
+
+        @ApiOperationSupport(order = 2)
+        public void listBeta() {
+        }
+    }
+
+    @RestController
+    @Tag(name = "NoOrder")
+    static class NoOrderController {
+    }
+
+    // ---- helpers ----
+
+    private Knife4jOpenApiCustomizer buildCustomizer(String... packages) {
+        Knife4jProperties props = new Knife4jProperties();
+        props.setEnable(true);
+        SpringDocConfigProperties docProps = new SpringDocConfigProperties();
+        if (packages.length > 0) {
+            SpringDocConfigProperties.GroupConfig group = new SpringDocConfigProperties.GroupConfig();
+            group.setPackagesToScan(java.util.Arrays.asList(packages));
+            docProps.setGroupConfigs(new HashSet<>(Collections.singletonList(group)));
+        }
+        return new Knife4jOpenApiCustomizer(props, docProps);
+    }
+
+    private OpenAPI buildOpenApi(String... tagNames) {
+        OpenAPI openApi = new OpenAPI();
+        for (String name : tagNames) {
+            openApi.addTagsItem(new io.swagger.v3.oas.models.tags.Tag().name(name));
+        }
+        return openApi;
+    }
+
+    // ---- tests ----
+
+    @Test
+    public void tagOrderAppliedWhenPackageScanConfigured() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha", "Beta");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag alpha = openApi.getTags().stream()
+                .filter(t -> "Alpha".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+        io.swagger.v3.oas.models.tags.Tag beta = openApi.getTags().stream()
+                .filter(t -> "Beta".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+
+        Assert.assertEquals(10, alpha.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+        Assert.assertEquals(20, beta.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    @Test
+    public void tagWithoutApiSupportGetsNoOrder() {
+        String pkg = NoOrderController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("NoOrder");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag tag = openApi.getTags().get(0);
+        Assert.assertNull(tag.getExtensions());
+    }
+
+    @Test
+    public void noPackageScanDoesNotThrow() {
+        Knife4jOpenApiCustomizer customizer = buildCustomizer();
+        OpenAPI openApi = buildOpenApi("Alpha");
+        customizer.customise(openApi);
+        Assert.assertNull(openApi.getTags().get(0).getExtensions());
+    }
+
+    @Test
+    public void operationWithoutSupportAnnotationGetsNoOrder() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha");
+        Paths paths = new Paths();
+        Operation op = new Operation().operationId("unknownMethod");
+        PathItem pathItem = new PathItem().get(op);
+        paths.addPathItem("/unknown", pathItem);
+        openApi.setPaths(paths);
+
+        customizer.customise(openApi);
+
+        Assert.assertNull(op.getExtensions());
+    }
+}

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jValidationGroupsExtensionTest.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jValidationGroupsExtensionTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.extension;
+
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
+import io.swagger.v3.oas.models.Operation;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.annotation.*;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for the {@code x-validation-groups} extension emitted by
+ * {@link Knife4jJakartaOperationCustomizer}.
+ */
+public class Knife4jValidationGroupsExtensionTest {
+
+    // ---- stub group markers ----
+
+    interface Create {
+    }
+    interface Update {
+    }
+
+    // ---- stub constraint annotations (simple names match real BV constraints) ----
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface NotNull {
+
+        Class<?>[] groups() default {};
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface NotBlank {
+
+        Class<?>[] groups() default {};
+    }
+
+    // ---- fixture DTO ----
+
+    static class UserFormRequest {
+
+        @NotNull(groups = Update.class)
+        Long id;
+
+        @NotBlank(groups = {Create.class, Update.class})
+        String name;
+
+        @NotBlank(groups = Create.class)
+        String email;
+
+        String phone;
+    }
+
+    // ---- fixture controller ----
+
+    @RestController
+    static class DemoController {
+
+        @ApiOperationSupport(order = 1, validationGroups = {Create.class})
+        public void create(@RequestBody UserFormRequest req) {
+        }
+
+        @ApiOperationSupport(order = 2, validationGroups = {Update.class})
+        public void update(@RequestBody UserFormRequest req) {
+        }
+
+        @ApiOperationSupport(order = 3)
+        public void noGroups(@RequestBody UserFormRequest req) {
+        }
+
+        public void noAnnotation(@RequestBody UserFormRequest req) {
+        }
+    }
+
+    // ---- helpers ----
+
+    private HandlerMethod handlerMethod(String methodName) throws Exception {
+        DemoController bean = new DemoController();
+        java.lang.reflect.Method m = DemoController.class.getMethod(methodName, UserFormRequest.class);
+        return new HandlerMethod(bean, m);
+    }
+
+    private Knife4jJakartaOperationCustomizer customizer() {
+        return new Knife4jJakartaOperationCustomizer();
+    }
+
+    // ---- tests ----
+
+    @Test
+    public void createGroupExtensionContainsNameAndEmail() throws Exception {
+        Operation op = new Operation().operationId("create");
+        customizer().customize(op, handlerMethod("create"));
+
+        Assert.assertNotNull(op.getExtensions());
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> groups =
+                (Map<String, List<String>>) op.getExtensions().get(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS);
+        Assert.assertNotNull(groups);
+        Assert.assertTrue(groups.containsKey("Create"));
+        Assert.assertTrue(groups.get("Create").contains("name"));
+        Assert.assertTrue(groups.get("Create").contains("email"));
+        Assert.assertFalse(groups.get("Create").contains("id"));
+    }
+
+    @Test
+    public void updateGroupExtensionContainsIdAndName() throws Exception {
+        Operation op = new Operation().operationId("update");
+        customizer().customize(op, handlerMethod("update"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> groups =
+                (Map<String, List<String>>) op.getExtensions().get(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS);
+        Assert.assertNotNull(groups);
+        Assert.assertTrue(groups.get("Update").contains("id"));
+        Assert.assertTrue(groups.get("Update").contains("name"));
+        Assert.assertFalse(groups.get("Update").contains("email"));
+    }
+
+    @Test
+    public void noValidationGroupsAttributeProducesNoExtension() throws Exception {
+        Operation op = new Operation().operationId("noGroups");
+        customizer().customize(op, handlerMethod("noGroups"));
+
+        if (op.getExtensions() != null) {
+            Assert.assertFalse(op.getExtensions().containsKey(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS));
+        }
+    }
+
+    @Test
+    public void noAnnotationProducesNoValidationGroupsExtension() throws Exception {
+        Operation op = new Operation().operationId("noAnnotation");
+        customizer().customize(op, handlerMethod("noAnnotation"));
+
+        if (op.getExtensions() != null) {
+            Assert.assertFalse(op.getExtensions().containsKey(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS));
+        }
+    }
+}

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOperationCustomizer.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOperationCustomizer.java
@@ -94,5 +94,10 @@ public class Knife4jOperationCustomizer implements GlobalOperationCustomizer {
         if (!groupMap.isEmpty()) {
             operation.addExtension(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS, groupMap);
         }
+        Map<String, Map<String, Object>> fieldConstraints =
+                ValidationGroupsUtils.resolveFieldSchemaExtensions(bodyType);
+        if (!fieldConstraints.isEmpty()) {
+            operation.addExtension(ExtensionsConstants.EXTENSION_FIELD_CONSTRAINTS, fieldConstraints);
+        }
     }
 }

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOperationCustomizer.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOperationCustomizer.java
@@ -21,12 +21,16 @@ import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
 import com.github.xiaoymin.knife4j.annotations.ApiSupport;
 import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
 import com.github.xiaoymin.knife4j.core.util.StrUtil;
+import com.github.xiaoymin.knife4j.core.util.ValidationGroupsUtils;
 import com.github.xiaoymin.knife4j.extend.util.ExtensionUtils;
 import io.swagger.v3.oas.models.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.customizers.GlobalOperationCustomizer;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.method.HandlerMethod;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
@@ -49,6 +53,8 @@ public class Knife4jOperationCustomizer implements GlobalOperationCustomizer {
             if (operationSupport.order() != 0) {
                 operation.addExtension(ExtensionsConstants.EXTENSION_ORDER, operationSupport.order());
             }
+            // x-validation-groups extension
+            applyValidationGroupsExtension(operation, handlerMethod, operationSupport);
         } else {
             // 如果方法级别不存在，再找一次class级别的
             ApiSupport apiSupport = AnnotationUtils.findAnnotation(handlerMethod.getBeanType(), ApiSupport.class);
@@ -63,5 +69,30 @@ public class Knife4jOperationCustomizer implements GlobalOperationCustomizer {
             }
         }
         return operation;
+    }
+
+    private void applyValidationGroupsExtension(
+                                                Operation operation,
+                                                HandlerMethod handlerMethod,
+                                                ApiOperationSupport operationSupport) {
+        Class<?>[] groups = operationSupport.validationGroups();
+        if (groups == null || groups.length == 0) {
+            return;
+        }
+        Class<?> bodyType = null;
+        java.lang.reflect.Parameter[] params = handlerMethod.getMethod().getParameters();
+        for (java.lang.reflect.Parameter p : params) {
+            if (p.isAnnotationPresent(org.springframework.web.bind.annotation.RequestBody.class)) {
+                bodyType = p.getType();
+                break;
+            }
+        }
+        if (bodyType == null) {
+            return;
+        }
+        Map<String, List<String>> groupMap = ValidationGroupsUtils.resolveRequiredFields(bodyType, groups);
+        if (!groupMap.isEmpty()) {
+            operation.addExtension(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS, groupMap);
+        }
     }
 }

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.extension;
+
+import com.github.xiaoymin.knife4j.annotations.ApiSupport;
+import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
+import com.github.xiaoymin.knife4j.spring.configuration.Knife4jProperties;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springdoc.core.SpringDocConfigProperties;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+/**
+ * Unit tests for Knife4jOpenApiCustomizer x-order extension (non-jakarta variant).
+ */
+public class Knife4jOpenApiCustomizerOrderTest {
+
+    // ---- fixture controllers ----
+
+    @RestController
+    @Tag(name = "Alpha")
+    @ApiSupport(order = 10)
+    static class AlphaController {
+    }
+
+    @RestController
+    @Tag(name = "Beta")
+    @ApiSupport(order = 20)
+    static class BetaController {
+    }
+
+    @RestController
+    @Tag(name = "NoOrder")
+    static class NoOrderController {
+    }
+
+    // ---- helpers ----
+
+    private Knife4jOpenApiCustomizer buildCustomizer(String... packages) {
+        Knife4jProperties props = new Knife4jProperties();
+        props.setEnable(true);
+        SpringDocConfigProperties docProps = new SpringDocConfigProperties();
+        if (packages.length > 0) {
+            SpringDocConfigProperties.GroupConfig group = new SpringDocConfigProperties.GroupConfig();
+            group.setPackagesToScan(java.util.Arrays.asList(packages));
+            docProps.setGroupConfigs(new HashSet<>(Collections.singletonList(group)));
+        }
+        return new Knife4jOpenApiCustomizer(props, docProps);
+    }
+
+    private OpenAPI buildOpenApi(String... tagNames) {
+        OpenAPI openApi = new OpenAPI();
+        for (String name : tagNames) {
+            openApi.addTagsItem(new io.swagger.v3.oas.models.tags.Tag().name(name));
+        }
+        return openApi;
+    }
+
+    // ---- tests ----
+
+    @Test
+    public void tagOrderAppliedWhenPackageScanConfigured() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha", "Beta");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag alpha = openApi.getTags().stream()
+                .filter(t -> "Alpha".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+        io.swagger.v3.oas.models.tags.Tag beta = openApi.getTags().stream()
+                .filter(t -> "Beta".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+
+        Assert.assertEquals(10, alpha.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+        Assert.assertEquals(20, beta.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    @Test
+    public void tagWithoutApiSupportGetsNoOrder() {
+        String pkg = NoOrderController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("NoOrder");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag tag = openApi.getTags().get(0);
+        Assert.assertNull(tag.getExtensions());
+    }
+
+    @Test
+    public void noPackageScanDoesNotThrow() {
+        Knife4jOpenApiCustomizer customizer = buildCustomizer();
+        OpenAPI openApi = buildOpenApi("Alpha");
+        customizer.customise(openApi);
+        Assert.assertNull(openApi.getTags().get(0).getExtensions());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #118

Implements the  SPI so users can register custom Hibernate Validator annotation resolvers that enrich OpenAPI Schema fields (pattern, description, etc.).

## Changes

- **SPI interface**: `Knife4jValidatorAnnotationResolver` — receives annotation metadata, returns Schema incremental fields
- **Registry**: `ValidatorAnnotationResolverRegistry` — loads resolvers via Java ServiceLoader
- **Built-in resolver**: `BuiltinValidatorAnnotationResolver` — handles `@Email`, `@Pattern`, `@Length` out of the box
- **Integration**: `Knife4jOperationCustomizer` / `Knife4jJakartaOperationCustomizer` wired to invoke registry
- **Tests**: `ValidatorSpiTest` covers built-in and custom resolver registration
- **Constants**: `ExtensionsConstants` updated with new extension keys

## Related

Upstream: https://github.com/xiaoymin/knife4j/issues/878