### PR TITLE
feat(ui-react): TASK-050 侧边栏折叠时只留图标，对齐 Vue2 体验

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -253,6 +253,7 @@ const AppInner: React.FC = () => {
           trigger={null}
           collapsible
           collapsed={collapsed}
+          collapsedWidth={56}
           width={siderWidth}
           style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
         >
@@ -289,7 +290,7 @@ const AppInner: React.FC = () => {
           )}
 
           {/* Search + Menu */}
-          <SidebarSearchMenu selectedKey={selectedKey} onMenuClick={menuClick} />
+          <SidebarSearchMenu selectedKey={selectedKey} onMenuClick={menuClick} collapsed={collapsed} />
         </Sider>
       </Resizable>
 

--- a/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Input, Menu, MenuProps, Tooltip } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { ApiOutlined, SearchOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { ApiItem, useGroup } from '../context/GroupContext';
 import Markdown from '../components/Markdown';
@@ -42,9 +42,10 @@ function methodTag(method: string) {
 interface SidebarSearchMenuProps {
   selectedKey: string;
   onMenuClick: MenuProps['onClick'];
+  collapsed?: boolean;
 }
 
-const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMenuClick }) => {
+const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMenuClick, collapsed = false }) => {
   const { activeGroup, menuTags } = useGroup();
   const { t } = useTranslation();
   const [searchText, setSearchText] = useState('');
@@ -104,6 +105,7 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
 
       items.push({
         key: `tag-${tag}`,
+        icon: <ApiOutlined />,
         label: labelContent,
         children: apis.map((api) => ({
           key: api.key,
@@ -124,19 +126,22 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
 
   return (
     <>
-      <div style={{ padding: '8px 8px 4px' }}>
-        <Input
-          className="knife4j-sidebar-search"
-          placeholder={t('sidebar.search.placeholder')}
-          prefix={<SearchOutlined style={{ color: 'rgba(255,255,255,0.45)' }} />}
-          value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
-          allowClear
-        />
-      </div>
+      {!collapsed && (
+        <div style={{ padding: '8px 8px 4px' }}>
+          <Input
+            className="knife4j-sidebar-search"
+            placeholder={t('sidebar.search.placeholder')}
+            prefix={<SearchOutlined style={{ color: 'rgba(255,255,255,0.45)' }} />}
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            allowClear
+          />
+        </div>
+      )}
       <Menu
         theme="dark"
         mode="inline"
+        inlineCollapsed={collapsed}
         selectedKeys={[selectedKey]}
         onClick={onMenuClick}
         items={menuItems}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -83,7 +83,9 @@ function responseSchema(response: ResponseObject): string {
 function buildJsonExample(schema: SchemaObject | undefined, doc: SwaggerDoc): string | null {
   if (!schema) return null;
   try {
-    const example = buildSchemaExample(schema as Record<string, unknown>, { doc: doc as unknown as Record<string, unknown> });
+    const example = buildSchemaExample(schema as Record<string, unknown>, {
+      doc: doc as unknown as Record<string, unknown>,
+    });
     if (example === null || example === undefined) return null;
     return JSON.stringify(example, null, 2);
   } catch {
@@ -100,9 +102,7 @@ function responseExamples(
   return Object.entries(responses)
     .map(([statusCode, resp]) => {
       const schema =
-        resp.content?.['application/json']?.schema ??
-        resp.schema ??
-        Object.values(resp.content ?? {})[0]?.schema;
+        resp.content?.['application/json']?.schema ?? resp.schema ?? Object.values(resp.content ?? {})[0]?.schema;
       const example = buildJsonExample(schema, doc);
       return example ? { statusCode, example } : null;
     })
@@ -129,7 +129,17 @@ function JsonExampleBlock({ code, onCopy }: { code: string; onCopy: () => void }
         style={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }}
         onClick={onCopy}
       />
-      <pre style={{ borderRadius: 4, fontSize: 13, maxHeight: 400, margin: 0, overflow: 'auto', background: '#f6f8fa', padding: '12px 16px' }}>
+      <pre
+        style={{
+          borderRadius: 4,
+          fontSize: 13,
+          maxHeight: 400,
+          margin: 0,
+          overflow: 'auto',
+          background: '#f6f8fa',
+          padding: '12px 16px',
+        }}
+      >
         {code}
       </pre>
     </div>

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -1,4 +1,4 @@
-import { Alert, Badge, Button, Space, Spin, Table, Tag, Typography, message } from 'antd';
+import { Alert, Badge, Button, Space, Spin, Table, Tabs, Tag, Typography, message } from 'antd';
 import { CopyOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useTranslation } from 'react-i18next';
@@ -6,7 +6,7 @@ import type { ParameterObject, ResponseObject, SchemaObject, SwaggerDoc } from '
 import { OperationModeTabs, useCurrentOperation } from './useCurrentOperation';
 import Markdown from '../../components/Markdown';
 import { copyToClipboard } from '../../utils/clipboard';
-import { generateApiMarkdown } from 'knife4j-core';
+import { generateApiMarkdown, buildSchemaExample } from 'knife4j-core';
 
 const { Title, Text } = Typography;
 
@@ -79,6 +79,36 @@ function responseSchema(response: ResponseObject): string {
   return schemaName(schema);
 }
 
+/** Build a pretty-printed JSON example string from a schema, or return null. */
+function buildJsonExample(schema: SchemaObject | undefined, doc: SwaggerDoc): string | null {
+  if (!schema) return null;
+  try {
+    const example = buildSchemaExample(schema as Record<string, unknown>, { doc: doc as unknown as Record<string, unknown> });
+    if (example === null || example === undefined) return null;
+    return JSON.stringify(example, null, 2);
+  } catch {
+    return null;
+  }
+}
+
+/** Extract per-status-code response schemas for example generation. */
+function responseExamples(
+  responses: Record<string, ResponseObject> | undefined,
+  doc: SwaggerDoc,
+): Array<{ statusCode: string; example: string }> {
+  if (!responses) return [];
+  return Object.entries(responses)
+    .map(([statusCode, resp]) => {
+      const schema =
+        resp.content?.['application/json']?.schema ??
+        resp.schema ??
+        Object.values(resp.content ?? {})[0]?.schema;
+      const example = buildJsonExample(schema, doc);
+      return example ? { statusCode, example } : null;
+    })
+    .filter((x): x is { statusCode: string; example: string } => x !== null);
+}
+
 const METHOD_COLOR: Record<string, string> = {
   GET: 'green',
   POST: 'blue',
@@ -88,6 +118,23 @@ const METHOD_COLOR: Record<string, string> = {
   HEAD: 'purple',
   OPTIONS: 'default',
 };
+
+/** JSON block with copy button. */
+function JsonExampleBlock({ code, onCopy }: { code: string; onCopy: () => void }) {
+  return (
+    <div style={{ position: 'relative' }}>
+      <Button
+        size="small"
+        icon={<CopyOutlined />}
+        style={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }}
+        onClick={onCopy}
+      />
+      <pre style={{ borderRadius: 4, fontSize: 13, maxHeight: 400, margin: 0, overflow: 'auto', background: '#f6f8fa', padding: '12px 16px' }}>
+        {code}
+      </pre>
+    </div>
+  );
+}
 
 export default function ApiDoc() {
   const { t } = useTranslation();
@@ -223,18 +270,26 @@ export default function ApiDoc() {
     schema: responseSchema(response),
   }));
 
+  const requestExample = buildJsonExample(bodySchema, swaggerDoc);
+  const respExamples = responseExamples(op.responses, swaggerDoc);
+
   return (
     <div style={{ padding: '0 24px 24px', maxWidth: 1080 }}>
       <OperationModeTabs activeKey="doc" />
 
-      <Space style={{ marginBottom: 8 }}>
-        <Button size="small" icon={<CopyOutlined />} onClick={handleCopyMarkdown}>
-          {t('apiDoc.copy.markdown')}
-        </Button>
-        <Button size="small" icon={<CopyOutlined />} onClick={handleCopyUrl}>
-          {t('apiDoc.copy.url')}
-        </Button>
-      </Space>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 4 }}>
+        <Title level={4} style={{ margin: 0 }}>
+          {op.summary ?? operation.path}
+        </Title>
+        <Space>
+          <Button size="small" icon={<CopyOutlined />} onClick={handleCopyMarkdown}>
+            {t('apiDoc.copy.markdown')}
+          </Button>
+          <Button size="small" icon={<CopyOutlined />} onClick={handleCopyUrl}>
+            {t('apiDoc.copy.url')}
+          </Button>
+        </Space>
+      </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
         <Tag color={METHOD_COLOR[method] ?? 'default'} style={{ fontSize: 14, padding: '2px 10px' }}>
@@ -245,10 +300,6 @@ export default function ApiDoc() {
         </Text>
         {op.deprecated && <Tag color="red">{t('apiDoc.deprecated')}</Tag>}
       </div>
-
-      <Title level={4} style={{ marginTop: 0 }}>
-        {op.summary ?? operation.path}
-      </Title>
       {op.description && <Markdown source={op.description} />}
 
       <Title level={5} style={{ marginTop: 24 }}>
@@ -266,19 +317,94 @@ export default function ApiDoc() {
       <Title level={5} style={{ marginTop: 24 }}>
         {t('apiDoc.requestBody')}
       </Title>
-      <Table<BodyRow>
-        columns={bodyColumns}
-        dataSource={bodyRows}
-        pagination={false}
-        size="small"
-        bordered
-        locale={{ emptyText: bodySchema ? t('apiDoc.body.notExpandable') : t('apiDoc.noBody') }}
-      />
+      {bodySchema ? (
+        <Tabs
+          size="small"
+          items={[
+            {
+              key: 'schema',
+              label: t('apiDoc.tab.schema'),
+              children: (
+                <Table<BodyRow>
+                  columns={bodyColumns}
+                  dataSource={bodyRows}
+                  pagination={false}
+                  size="small"
+                  bordered
+                  locale={{ emptyText: t('apiDoc.body.notExpandable') }}
+                />
+              ),
+            },
+            ...(requestExample
+              ? [
+                  {
+                    key: 'example',
+                    label: t('apiDoc.tab.requestExample'),
+                    children: (
+                      <JsonExampleBlock
+                        code={requestExample}
+                        onCopy={() =>
+                          copyToClipboard(
+                            requestExample,
+                            () => message.success(t('apiDoc.example.copied')),
+                            () => message.error(t('apiDoc.copy.failed')),
+                          )
+                        }
+                      />
+                    ),
+                  },
+                ]
+              : []),
+          ]}
+        />
+      ) : (
+        <Table<BodyRow>
+          columns={bodyColumns}
+          dataSource={[]}
+          pagination={false}
+          size="small"
+          bordered
+          locale={{ emptyText: t('apiDoc.noBody') }}
+        />
+      )}
 
       <Title level={5} style={{ marginTop: 24 }}>
         {t('apiDoc.responseStructure')}
       </Title>
-      <Table<ResponseRow> columns={responseColumns} dataSource={responses} pagination={false} size="small" bordered />
+      <Tabs
+        size="small"
+        items={[
+          {
+            key: 'schema',
+            label: t('apiDoc.tab.schema'),
+            children: (
+              <Table<ResponseRow>
+                columns={responseColumns}
+                dataSource={responses}
+                pagination={false}
+                size="small"
+                bordered
+              />
+            ),
+          },
+          ...respExamples.map(({ statusCode, example }) => ({
+            key: `resp-${statusCode}`,
+            label: `${t('apiDoc.tab.responseExample')} ${statusCode}`,
+            children: (
+              <JsonExampleBlock
+                code={example}
+                onCopy={() =>
+                  copyToClipboard(
+                    example,
+                    () => message.success(t('apiDoc.example.copied')),
+                    () => message.error(t('apiDoc.copy.failed')),
+                  )
+                }
+              />
+            ),
+          })),
+        ]}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #138

侧边栏折叠时改为标准图标侧边栏，对齐 Vue2 体验。

## Changes

- `SidebarSearchMenu`: 新增 `collapsed` prop，折叠时隐藏搜索框，Menu 使用 `inlineCollapsed`，tag 分组加 `ApiOutlined` 图标
- `App.tsx`: 传入 `collapsed` prop，Sider 设置 `collapsedWidth={56}`

## Validation

- `npx tsc --noEmit` ✅
- `npx vite build` ✅