### PR TITLE
chore(agent): worker 提交前端代码前必须跑 prettier

### DIFF
--- a/.agent/prompts/worker.md
+++ b/.agent/prompts/worker.md
@@ -28,6 +28,9 @@
 - 可行时运行 coordinator 分配的验证命令。
 - 如果验证无法运行，或因范围外原因失败，报告精确命令和摘要后的失败原因。
 - 不要为了声称成功而降低验证标准。
+- 如果改动涉及前端文件（.ts/.tsx/.css/.json），提交前必须先跑：
+  `cd knife4j-front/knife4j-ui-react && npx prettier --write "src/**/*.{ts,tsx,css,json}"`
+  然后重新 `git add` 格式化后的文件再提交。
 
 只返回以下 handoff：
 


### PR DESCRIPTION
## 关联 Issue

#141（lefthook + lint-staged，长期方案）

## 变更内容

- `.agent/prompts/worker.md`：验证步骤加一条，涉及前端文件时提交前必须跑 prettier --write 再重新 git add

## 背景

PR #139 因 prettier 格式检查失败，原因是 worker 直接提交未格式化的代码。这是短期补丁，长期方案是 #141 的 lefthook + lint-staged。

## 验证

文档变更，无需构建验证。