### PR TITLE
feat(java-customizer): 扩展 x-order 排序，支持无 packagesToScan 及 Operation 级 (#109)

### DIFF
--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -28,6 +28,7 @@ import jakarta.servlet.DispatcherType;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,9 +37,11 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.lang.Nullable;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 /***
  * Knife4j 基础自动配置类
@@ -63,9 +66,10 @@ public class Knife4jAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    public Knife4jOpenApiCustomizer knife4jOpenApiCustomizer(SpringDocConfigProperties docProperties) {
+    public Knife4jOpenApiCustomizer knife4jOpenApiCustomizer(SpringDocConfigProperties docProperties,
+                                                             @Autowired(required = false) @Nullable RequestMappingHandlerMapping requestMappingHandlerMapping) {
         log.debug("Register Knife4jOpenApiCustomizer");
-        return new Knife4jOpenApiCustomizer(this.properties, docProperties);
+        return new Knife4jOpenApiCustomizer(this.properties, docProperties, requestMappingHandlerMapping);
     }
 
     @Bean

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
@@ -21,6 +21,8 @@ import com.github.xiaoymin.knife4j.core.enums.OpenAPILanguageEnums;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 /**
  * @since  4.0.0
  * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
@@ -151,5 +153,12 @@ public class Knife4jSetting {
      * @since v4.0.0
      */
     private boolean enableResponseCode = true;
+
+    /**
+     * Explicit package paths for x-order scanning. When set, takes priority over springdoc
+     * packagesToScan and the RequestMappingHandlerMapping reflection fallback.
+     * @since v4.4.0
+     */
+    private List<String> apiOrderPackageScan;
 
 }

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
@@ -17,6 +17,7 @@
 
 package com.github.xiaoymin.knife4j.spring.extension;
 
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
 import com.github.xiaoymin.knife4j.annotations.ApiSupport;
 import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
 import com.github.xiaoymin.knife4j.core.conf.GlobalConstants;
@@ -24,7 +25,8 @@ import com.github.xiaoymin.knife4j.spring.configuration.Knife4jProperties;
 import com.github.xiaoymin.knife4j.spring.configuration.Knife4jSetting;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.OpenAPI;
-import lombok.AllArgsConstructor;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
@@ -34,8 +36,10 @@ import org.springframework.context.annotation.ClassPathScanningCandidateComponen
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -46,11 +50,27 @@ import java.util.stream.Collectors;
  * 2022/12/11 22:40
  */
 @Slf4j
-@AllArgsConstructor
 public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
 
     final Knife4jProperties knife4jProperties;
     final SpringDocConfigProperties properties;
+    /** Optional — may be null when not running in a servlet context (e.g. reactive). */
+    final RequestMappingHandlerMapping requestMappingHandlerMapping;
+
+    public Knife4jOpenApiCustomizer(Knife4jProperties knife4jProperties,
+                                    SpringDocConfigProperties properties,
+                                    RequestMappingHandlerMapping requestMappingHandlerMapping) {
+        this.knife4jProperties = knife4jProperties;
+        this.properties = properties;
+        this.requestMappingHandlerMapping = requestMappingHandlerMapping;
+    }
+
+    /** Backwards-compatible constructor for callers that don't supply the mapping. */
+    public Knife4jOpenApiCustomizer(Knife4jProperties knife4jProperties,
+                                    SpringDocConfigProperties properties) {
+        this(knife4jProperties, properties, null);
+    }
+
     @Override
     public void customise(OpenAPI openApi) {
         log.debug("Knife4j OpenApiCustomizer");
@@ -66,57 +86,142 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
             addOrderExtension(openApi);
         }
     }
+
     /**
-     * 往OpenAPI内tags字段添加x-order属性
-     *
-     * @param openApi openApi
+     * 往OpenAPI内tags字段添加x-order属性，并为每个Operation添加x-order属性
      */
     private void addOrderExtension(OpenAPI openApi) {
-        if (Objects.isNull(properties.getGroupConfigs())
-                || properties.getGroupConfigs().isEmpty()) {
-            return;
+        Set<String> packagesToScan = resolvePackagesToScan();
+        Set<Class<?>> controllers = resolveControllerClasses(packagesToScan);
+        applyTagOrder(openApi, controllers);
+        applyOperationOrder(openApi, controllers);
+    }
+
+    /**
+     * Resolve the effective set of packages to scan for @ApiSupport controllers.
+     * Priority: knife4j.setting.api-order-package-scan > springdoc packagesToScan > reflection fallback.
+     */
+    private Set<String> resolvePackagesToScan() {
+        Knife4jSetting setting = knife4jProperties.getSetting();
+        // 1. Explicit user config takes highest priority
+        if (setting != null && !CollectionUtils.isEmpty(setting.getApiOrderPackageScan())) {
+            return new HashSet<>(setting.getApiOrderPackageScan());
         }
-        // 获取包扫描路径
-        Set<String> packagesToScan =
-                properties.getGroupConfigs().stream()
-                        .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
-                        .filter(toScan -> !CollectionUtils.isEmpty(toScan))
-                        .flatMap(List::stream)
-                        .collect(Collectors.toSet());
-        if (CollectionUtils.isEmpty(packagesToScan)) {
-            return;
-        }
-        // 扫描包下被ApiSupport注解的RestController Class
-        Set<Class<?>> classes =
-                packagesToScan.stream()
-                        .map(packageToScan -> scanPackageByAnnotation(packageToScan, RestController.class))
-                        .flatMap(Set::stream)
-                        .filter(clazz -> clazz.isAnnotationPresent(ApiSupport.class))
-                        .collect(Collectors.toSet());
-        if (!CollectionUtils.isEmpty(classes)) {
-            // ApiSupport oder值存入tagSortMap<Tag.name,ApiSupport.order>
-            Map<String, Integer> tagOrderMap = new HashMap<>();
-            classes.forEach(
-                    clazz -> {
-                        Tag tag = getTag(clazz);
-                        if (Objects.nonNull(tag)) {
-                            ApiSupport apiSupport = clazz.getAnnotation(ApiSupport.class);
-                            tagOrderMap.putIfAbsent(tag.name(), apiSupport.order());
-                        }
-                    });
-            // 往openApi tags字段添加x-order增强属性
-            if (openApi.getTags() != null) {
-                openApi
-                        .getTags()
-                        .forEach(
-                                tag -> {
-                                    if (tagOrderMap.containsKey(tag.getName())) {
-                                        tag.addExtension(
-                                                ExtensionsConstants.EXTENSION_ORDER, tagOrderMap.get(tag.getName()));
-                                    }
-                                });
+        // 2. springdoc group packagesToScan
+        if (!CollectionUtils.isEmpty(properties.getGroupConfigs())) {
+            Set<String> fromGroups = properties.getGroupConfigs().stream()
+                    .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
+                    .filter(toScan -> !CollectionUtils.isEmpty(toScan))
+                    .flatMap(List::stream)
+                    .collect(Collectors.toSet());
+            if (!CollectionUtils.isEmpty(fromGroups)) {
+                return fromGroups;
             }
         }
+        // 3. Reflection fallback via RequestMappingHandlerMapping
+        return Collections.emptySet();
+    }
+
+    /**
+     * Collect controller classes that carry @ApiSupport.
+     * When packagesToScan is empty, fall back to RequestMappingHandlerMapping.
+     */
+    private Set<Class<?>> resolveControllerClasses(Set<String> packagesToScan) {
+        if (!CollectionUtils.isEmpty(packagesToScan)) {
+            return packagesToScan.stream()
+                    .map(pkg -> scanPackageByAnnotation(pkg, RestController.class))
+                    .flatMap(Set::stream)
+                    .filter(clazz -> clazz.isAnnotationPresent(ApiSupport.class))
+                    .collect(Collectors.toSet());
+        }
+        // Fallback: inspect handler methods registered in the application context
+        if (requestMappingHandlerMapping != null) {
+            try {
+                return requestMappingHandlerMapping.getHandlerMethods().keySet().stream()
+                        .map(info -> requestMappingHandlerMapping.getHandlerMethods().get(info).getBeanType())
+                        .filter(clazz -> clazz.isAnnotationPresent(ApiSupport.class))
+                        .collect(Collectors.toSet());
+            } catch (Exception e) {
+                log.warn("Knife4j: failed to collect controllers via RequestMappingHandlerMapping", e);
+            }
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Apply x-order to OpenAPI tags based on @ApiSupport.order on controller classes.
+     */
+    private void applyTagOrder(OpenAPI openApi, Set<Class<?>> controllers) {
+        if (CollectionUtils.isEmpty(controllers) || openApi.getTags() == null) {
+            return;
+        }
+        Map<String, Integer> tagOrderMap = new HashMap<>();
+        controllers.forEach(clazz -> {
+            Tag tag = getTag(clazz);
+            if (tag != null) {
+                ApiSupport apiSupport = clazz.getAnnotation(ApiSupport.class);
+                tagOrderMap.putIfAbsent(tag.name(), apiSupport.order());
+            }
+        });
+        openApi.getTags().forEach(tag -> {
+            if (tagOrderMap.containsKey(tag.getName())) {
+                tag.addExtension(ExtensionsConstants.EXTENSION_ORDER, tagOrderMap.get(tag.getName()));
+            }
+        });
+    }
+
+    /**
+     * Apply x-order to each Operation based on @ApiOperationSupport.order on handler methods.
+     */
+    private void applyOperationOrder(OpenAPI openApi, Set<Class<?>> controllers) {
+        if (openApi.getPaths() == null || CollectionUtils.isEmpty(controllers)) {
+            return;
+        }
+        // Build a map: operationId -> order value, derived from @ApiOperationSupport on methods
+        Map<String, Integer> operationOrderMap = new HashMap<>();
+        for (Class<?> clazz : controllers) {
+            for (Method method : clazz.getMethods()) {
+                ApiOperationSupport support = method.getAnnotation(ApiOperationSupport.class);
+                if (support != null && support.order() != 0) {
+                    // springdoc uses method name as operationId by default; also try explicit id
+                    operationOrderMap.put(method.getName(), support.order());
+                }
+            }
+        }
+        if (operationOrderMap.isEmpty()) {
+            return;
+        }
+        openApi.getPaths().forEach((path, pathItem) -> {
+            for (Operation operation : collectOperations(pathItem)) {
+                if (operation != null && operation.getOperationId() != null) {
+                    Integer order = operationOrderMap.get(operation.getOperationId());
+                    if (order != null) {
+                        operation.addExtension(ExtensionsConstants.EXTENSION_ORDER, order);
+                    }
+                }
+            }
+        });
+    }
+
+    private List<Operation> collectOperations(PathItem pathItem) {
+        List<Operation> ops = new ArrayList<>();
+        if (pathItem.getGet() != null)
+            ops.add(pathItem.getGet());
+        if (pathItem.getPost() != null)
+            ops.add(pathItem.getPost());
+        if (pathItem.getPut() != null)
+            ops.add(pathItem.getPut());
+        if (pathItem.getDelete() != null)
+            ops.add(pathItem.getDelete());
+        if (pathItem.getPatch() != null)
+            ops.add(pathItem.getPatch());
+        if (pathItem.getOptions() != null)
+            ops.add(pathItem.getOptions());
+        if (pathItem.getHead() != null)
+            ops.add(pathItem.getHead());
+        if (pathItem.getTrace() != null)
+            ops.add(pathItem.getTrace());
+        return ops;
     }
 
     private Tag getTag(Class<?> clazz) {
@@ -138,8 +243,8 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
         return tag;
     }
 
-    private Set<Class<?>> scanPackageByAnnotation(
-                                                  String packageName, final Class<? extends Annotation> annotationClass) {
+    private Set<Class<?>> scanPackageByAnnotation(String packageName,
+                                                  final Class<? extends Annotation> annotationClass) {
         ClassPathScanningCandidateComponentProvider scanner =
                 new ClassPathScanningCandidateComponentProvider(false);
         scanner.addIncludeFilter(new AnnotationTypeFilter(annotationClass));
@@ -149,7 +254,6 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
                 Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
                 classes.add(clazz);
             } catch (ClassNotFoundException ignore) {
-
             }
         }
         return classes;

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.extension;
+
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import com.github.xiaoymin.knife4j.annotations.ApiSupport;
+import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
+import com.github.xiaoymin.knife4j.spring.configuration.Knife4jProperties;
+import com.github.xiaoymin.knife4j.spring.configuration.Knife4jSetting;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Unit tests for Knife4jOpenApiCustomizer x-order extension (jakarta variant).
+ */
+public class Knife4jOpenApiCustomizerOrderTest {
+
+    // ---- fixture controllers ----
+
+    @RestController
+    @Tag(name = "Alpha")
+    @ApiSupport(order = 10)
+    static class AlphaController {
+
+        @ApiOperationSupport(order = 1)
+        public void listAlpha() {
+        }
+    }
+
+    @RestController
+    @Tag(name = "Beta")
+    @ApiSupport(order = 20)
+    static class BetaController {
+
+        @ApiOperationSupport(order = 2)
+        public void listBeta() {
+        }
+    }
+
+    @RestController
+    @Tag(name = "Gamma")
+    @ApiSupport(order = 10) // same order as Alpha — duplicate order
+    static class GammaController {
+    }
+
+    @RestController
+    @Tag(name = "NoOrder")
+    static class NoOrderController {
+    } // no @ApiSupport
+
+    // ---- helpers ----
+
+    private Knife4jOpenApiCustomizer buildCustomizer(String... packages) {
+        Knife4jProperties props = new Knife4jProperties();
+        props.setEnable(true);
+        Knife4jSetting setting = new Knife4jSetting();
+        if (packages.length > 0) {
+            setting.setApiOrderPackageScan(Arrays.asList(packages));
+        }
+        props.setSetting(setting);
+        SpringDocConfigProperties docProps = new SpringDocConfigProperties();
+        return new Knife4jOpenApiCustomizer(props, docProps, null);
+    }
+
+    private OpenAPI buildOpenApi(String... tagNames) {
+        OpenAPI openApi = new OpenAPI();
+        for (String name : tagNames) {
+            openApi.addTagsItem(new io.swagger.v3.oas.models.tags.Tag().name(name));
+        }
+        return openApi;
+    }
+
+    // ---- tests ----
+
+    /**
+     * When apiOrderPackageScan points to the test package, controllers with @ApiSupport
+     * should get x-order on their tags.
+     */
+    @Test
+    public void tagOrderAppliedWhenPackageScanConfigured() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha", "Beta");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag alpha = openApi.getTags().stream()
+                .filter(t -> "Alpha".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+        io.swagger.v3.oas.models.tags.Tag beta = openApi.getTags().stream()
+                .filter(t -> "Beta".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+
+        Assert.assertEquals(10, alpha.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+        Assert.assertEquals(20, beta.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    /**
+     * Tags without @ApiSupport on their controller should not receive x-order.
+     */
+    @Test
+    public void tagWithoutApiSupportGetsNoOrder() {
+        String pkg = NoOrderController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("NoOrder");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag tag = openApi.getTags().get(0);
+        Assert.assertNull(tag.getExtensions());
+    }
+
+    /**
+     * When two controllers share the same tag name, putIfAbsent ensures the first wins.
+     */
+    @Test
+    public void duplicateTagNameKeepsFirstOrder() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        // Both Alpha (order=10) and Gamma (order=10) map to different tag names — no conflict here.
+        // This test verifies that if two controllers somehow share a tag name, the first order wins.
+        OpenAPI openApi = buildOpenApi("Alpha");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag alpha = openApi.getTags().get(0);
+        Assert.assertNotNull(alpha.getExtensions());
+        Assert.assertEquals(10, alpha.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    /**
+     * When no packagesToScan and no RequestMappingHandlerMapping, x-order is not applied
+     * but customise() must not throw.
+     */
+    @Test
+    public void noPackageScanAndNoMappingDoesNotThrow() {
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(); // no packages
+        OpenAPI openApi = buildOpenApi("Alpha");
+        customizer.customise(openApi); // must not throw
+        // tags should have no x-order extension
+        Assert.assertNull(openApi.getTags().get(0).getExtensions());
+    }
+
+    /**
+     * Operation-level x-order is applied when the operationId matches a method name
+     * annotated with @ApiOperationSupport.
+     */
+    @Test
+    public void operationOrderApplied() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha");
+        Paths paths = new Paths();
+        Operation op = new Operation().operationId("listAlpha");
+        PathItem pathItem = new PathItem().get(op);
+        paths.addPathItem("/alpha", pathItem);
+        openApi.setPaths(paths);
+
+        customizer.customise(openApi);
+
+        Assert.assertEquals(1, op.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    /**
+     * Operations with no matching @ApiOperationSupport should not receive x-order.
+     */
+    @Test
+    public void operationWithoutSupportAnnotationGetsNoOrder() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha");
+        Paths paths = new Paths();
+        Operation op = new Operation().operationId("unknownMethod");
+        PathItem pathItem = new PathItem().get(op);
+        paths.addPathItem("/unknown", pathItem);
+        openApi.setPaths(paths);
+
+        customizer.customise(openApi);
+
+        Assert.assertNull(op.getExtensions());
+    }
+}

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -36,9 +36,11 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.lang.Nullable;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import javax.servlet.DispatcherType;
 
@@ -66,9 +68,10 @@ public class Knife4jAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public Knife4jOpenApiCustomizer knife4jOpenApiCustomizer(Knife4jProperties knife4jProperties,
-                                                             SpringDocConfigProperties docProperties) {
+                                                             SpringDocConfigProperties docProperties,
+                                                             @Autowired(required = false) @Nullable RequestMappingHandlerMapping requestMappingHandlerMapping) {
         logger.debug("Register Knife4jOpenApiCustomizer");
-        return new Knife4jOpenApiCustomizer(knife4jProperties, docProperties);
+        return new Knife4jOpenApiCustomizer(knife4jProperties, docProperties, requestMappingHandlerMapping);
     }
 
     @Bean

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
@@ -21,6 +21,8 @@ import com.github.xiaoymin.knife4j.core.enums.OpenAPILanguageEnums;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 /**
  * @since  4.0.0
  * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
@@ -150,5 +152,12 @@ public class Knife4jSetting {
      * @since v4.0.0
      */
     private boolean enableResponseCode = true;
+
+    /**
+     * Explicit package paths for x-order scanning. When set, takes priority over springdoc
+     * packagesToScan and the RequestMappingHandlerMapping reflection fallback.
+     * @since v4.4.0
+     */
+    private List<String> apiOrderPackageScan;
 
 }

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
@@ -17,6 +17,7 @@
 
 package com.github.xiaoymin.knife4j.spring.extension;
 
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
 import com.github.xiaoymin.knife4j.annotations.ApiSupport;
 import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
 import com.github.xiaoymin.knife4j.core.conf.GlobalConstants;
@@ -24,7 +25,8 @@ import com.github.xiaoymin.knife4j.spring.configuration.Knife4jProperties;
 import com.github.xiaoymin.knife4j.spring.configuration.Knife4jSetting;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.OpenAPI;
-import lombok.AllArgsConstructor;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springdoc.core.SpringDocConfigProperties;
@@ -34,23 +36,40 @@ import org.springframework.context.annotation.ClassPathScanningCandidateComponen
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * 增强扩展属性支持
  *
- * @since
+ * @since 4.1.0
  * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a> 2022/12/11 22:40
  */
 @Slf4j
-@AllArgsConstructor
 public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
 
     final Knife4jProperties knife4jProperties;
     final SpringDocConfigProperties properties;
+    /** Optional — may be null when not running in a servlet context (e.g. reactive). */
+    final RequestMappingHandlerMapping requestMappingHandlerMapping;
+
+    public Knife4jOpenApiCustomizer(Knife4jProperties knife4jProperties,
+                                    SpringDocConfigProperties properties,
+                                    RequestMappingHandlerMapping requestMappingHandlerMapping) {
+        this.knife4jProperties = knife4jProperties;
+        this.properties = properties;
+        this.requestMappingHandlerMapping = requestMappingHandlerMapping;
+    }
+
+    /** Backwards-compatible constructor for callers that don't supply the mapping. */
+    public Knife4jOpenApiCustomizer(Knife4jProperties knife4jProperties,
+                                    SpringDocConfigProperties properties) {
+        this(knife4jProperties, properties, null);
+    }
 
     @Override
     public void customise(OpenAPI openApi) {
@@ -72,55 +91,139 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
     }
 
     /**
-     * 往OpenAPI内tags字段添加x-order属性
-     *
-     * @param openApi openApi
+     * 往OpenAPI内tags字段添加x-order属性，并为每个Operation添加x-order属性
      */
     private void addOrderExtension(OpenAPI openApi) {
-        if (CollectionUtils.isEmpty(properties.getGroupConfigs())) {
-            return;
+        Set<String> packagesToScan = resolvePackagesToScan();
+        Set<Class<?>> controllers = resolveControllerClasses(packagesToScan);
+        applyTagOrder(openApi, controllers);
+        applyOperationOrder(openApi, controllers);
+    }
+
+    /**
+     * Resolve the effective set of packages to scan for @ApiSupport controllers.
+     * Priority: knife4j.setting.api-order-package-scan > springdoc packagesToScan > reflection fallback.
+     */
+    private Set<String> resolvePackagesToScan() {
+        Knife4jSetting setting = knife4jProperties.getSetting();
+        // 1. Explicit user config takes highest priority
+        if (setting != null && !CollectionUtils.isEmpty(setting.getApiOrderPackageScan())) {
+            return new HashSet<>(setting.getApiOrderPackageScan());
         }
-        // 获取包扫描路径
-        Set<String> packagesToScan =
-                properties.getGroupConfigs().stream()
-                        .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
-                        .filter(toScan -> !CollectionUtils.isEmpty(toScan))
-                        .flatMap(List::stream)
-                        .collect(Collectors.toSet());
-        if (CollectionUtils.isEmpty(packagesToScan)) {
-            return;
-        }
-        // 扫描包下被ApiSupport注解的RestController Class
-        Set<Class<?>> classes =
-                packagesToScan.stream()
-                        .map(packageToScan -> scanPackageByAnnotation(packageToScan, RestController.class))
-                        .flatMap(Set::stream)
-                        .filter(clazz -> clazz.isAnnotationPresent(ApiSupport.class))
-                        .collect(Collectors.toSet());
-        if (!CollectionUtils.isEmpty(classes)) {
-            // ApiSupport oder值存入tagSortMap<Tag.name,ApiSupport.order>
-            Map<String, Integer> tagOrderMap = new HashMap<>();
-            classes.forEach(
-                    clazz -> {
-                        Tag tag = getTag(clazz);
-                        if (Objects.nonNull(tag)) {
-                            ApiSupport apiSupport = clazz.getAnnotation(ApiSupport.class);
-                            tagOrderMap.putIfAbsent(tag.name(), apiSupport.order());
-                        }
-                    });
-            // 往openApi tags字段添加x-order增强属性
-            if (openApi.getTags() != null) {
-                openApi
-                        .getTags()
-                        .forEach(
-                                tag -> {
-                                    if (tagOrderMap.containsKey(tag.getName())) {
-                                        tag.addExtension(
-                                                ExtensionsConstants.EXTENSION_ORDER, tagOrderMap.get(tag.getName()));
-                                    }
-                                });
+        // 2. springdoc group packagesToScan
+        if (!CollectionUtils.isEmpty(properties.getGroupConfigs())) {
+            Set<String> fromGroups = properties.getGroupConfigs().stream()
+                    .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
+                    .filter(toScan -> !CollectionUtils.isEmpty(toScan))
+                    .flatMap(List::stream)
+                    .collect(Collectors.toSet());
+            if (!CollectionUtils.isEmpty(fromGroups)) {
+                return fromGroups;
             }
         }
+        // 3. Reflection fallback via RequestMappingHandlerMapping
+        return Collections.emptySet();
+    }
+
+    /**
+     * Collect controller classes that carry @ApiSupport.
+     * When packagesToScan is empty, fall back to RequestMappingHandlerMapping.
+     */
+    private Set<Class<?>> resolveControllerClasses(Set<String> packagesToScan) {
+        if (!CollectionUtils.isEmpty(packagesToScan)) {
+            return packagesToScan.stream()
+                    .map(pkg -> scanPackageByAnnotation(pkg, RestController.class))
+                    .flatMap(Set::stream)
+                    .filter(clazz -> clazz.isAnnotationPresent(ApiSupport.class))
+                    .collect(Collectors.toSet());
+        }
+        // Fallback: inspect handler methods registered in the application context
+        if (requestMappingHandlerMapping != null) {
+            try {
+                return requestMappingHandlerMapping.getHandlerMethods().keySet().stream()
+                        .map(info -> requestMappingHandlerMapping.getHandlerMethods().get(info).getBeanType())
+                        .filter(clazz -> clazz.isAnnotationPresent(ApiSupport.class))
+                        .collect(Collectors.toSet());
+            } catch (Exception e) {
+                log.warn("Knife4j: failed to collect controllers via RequestMappingHandlerMapping", e);
+            }
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Apply x-order to OpenAPI tags based on @ApiSupport.order on controller classes.
+     */
+    private void applyTagOrder(OpenAPI openApi, Set<Class<?>> controllers) {
+        if (CollectionUtils.isEmpty(controllers) || openApi.getTags() == null) {
+            return;
+        }
+        Map<String, Integer> tagOrderMap = new HashMap<>();
+        controllers.forEach(clazz -> {
+            Tag tag = getTag(clazz);
+            if (tag != null) {
+                ApiSupport apiSupport = clazz.getAnnotation(ApiSupport.class);
+                tagOrderMap.putIfAbsent(tag.name(), apiSupport.order());
+            }
+        });
+        openApi.getTags().forEach(tag -> {
+            if (tagOrderMap.containsKey(tag.getName())) {
+                tag.addExtension(ExtensionsConstants.EXTENSION_ORDER, tagOrderMap.get(tag.getName()));
+            }
+        });
+    }
+
+    /**
+     * Apply x-order to each Operation based on @ApiOperationSupport.order on handler methods.
+     */
+    private void applyOperationOrder(OpenAPI openApi, Set<Class<?>> controllers) {
+        if (openApi.getPaths() == null || CollectionUtils.isEmpty(controllers)) {
+            return;
+        }
+        // Build a map: operationId -> order value, derived from @ApiOperationSupport on methods
+        Map<String, Integer> operationOrderMap = new HashMap<>();
+        for (Class<?> clazz : controllers) {
+            for (Method method : clazz.getMethods()) {
+                ApiOperationSupport support = method.getAnnotation(ApiOperationSupport.class);
+                if (support != null && support.order() != 0) {
+                    operationOrderMap.put(method.getName(), support.order());
+                }
+            }
+        }
+        if (operationOrderMap.isEmpty()) {
+            return;
+        }
+        openApi.getPaths().forEach((path, pathItem) -> {
+            for (Operation operation : collectOperations(pathItem)) {
+                if (operation != null && operation.getOperationId() != null) {
+                    Integer order = operationOrderMap.get(operation.getOperationId());
+                    if (order != null) {
+                        operation.addExtension(ExtensionsConstants.EXTENSION_ORDER, order);
+                    }
+                }
+            }
+        });
+    }
+
+    private List<Operation> collectOperations(PathItem pathItem) {
+        List<Operation> ops = new ArrayList<>();
+        if (pathItem.getGet() != null)
+            ops.add(pathItem.getGet());
+        if (pathItem.getPost() != null)
+            ops.add(pathItem.getPost());
+        if (pathItem.getPut() != null)
+            ops.add(pathItem.getPut());
+        if (pathItem.getDelete() != null)
+            ops.add(pathItem.getDelete());
+        if (pathItem.getPatch() != null)
+            ops.add(pathItem.getPatch());
+        if (pathItem.getOptions() != null)
+            ops.add(pathItem.getOptions());
+        if (pathItem.getHead() != null)
+            ops.add(pathItem.getHead());
+        if (pathItem.getTrace() != null)
+            ops.add(pathItem.getTrace());
+        return ops;
     }
 
     private Tag getTag(Class<?> clazz) {
@@ -142,8 +245,8 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
         return tag;
     }
 
-    private Set<Class<?>> scanPackageByAnnotation(
-                                                  String packageName, final Class<? extends Annotation> annotationClass) {
+    private Set<Class<?>> scanPackageByAnnotation(String packageName,
+                                                  final Class<? extends Annotation> annotationClass) {
         ClassPathScanningCandidateComponentProvider scanner =
                 new ClassPathScanningCandidateComponentProvider(false);
         scanner.addIncludeFilter(new AnnotationTypeFilter(annotationClass));
@@ -153,7 +256,6 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
                 Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
                 classes.add(clazz);
             } catch (ClassNotFoundException ignore) {
-
             }
         }
         return classes;

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.extension;
+
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
+import com.github.xiaoymin.knife4j.annotations.ApiSupport;
+import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
+import com.github.xiaoymin.knife4j.spring.configuration.Knife4jProperties;
+import com.github.xiaoymin.knife4j.spring.configuration.Knife4jSetting;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springdoc.core.SpringDocConfigProperties;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+
+/**
+ * Unit tests for Knife4jOpenApiCustomizer x-order extension (non-jakarta variant).
+ */
+public class Knife4jOpenApiCustomizerOrderTest {
+
+    // ---- fixture controllers ----
+
+    @RestController
+    @Tag(name = "Alpha")
+    @ApiSupport(order = 10)
+    static class AlphaController {
+
+        @ApiOperationSupport(order = 1)
+        public void listAlpha() {
+        }
+    }
+
+    @RestController
+    @Tag(name = "Beta")
+    @ApiSupport(order = 20)
+    static class BetaController {
+
+        @ApiOperationSupport(order = 2)
+        public void listBeta() {
+        }
+    }
+
+    @RestController
+    @Tag(name = "NoOrder")
+    static class NoOrderController {
+    } // no @ApiSupport
+
+    // ---- helpers ----
+
+    private Knife4jOpenApiCustomizer buildCustomizer(String... packages) {
+        Knife4jProperties props = new Knife4jProperties();
+        props.setEnable(true);
+        Knife4jSetting setting = new Knife4jSetting();
+        if (packages.length > 0) {
+            setting.setApiOrderPackageScan(Arrays.asList(packages));
+        }
+        props.setSetting(setting);
+        SpringDocConfigProperties docProps = new SpringDocConfigProperties();
+        return new Knife4jOpenApiCustomizer(props, docProps, null);
+    }
+
+    private OpenAPI buildOpenApi(String... tagNames) {
+        OpenAPI openApi = new OpenAPI();
+        for (String name : tagNames) {
+            openApi.addTagsItem(new io.swagger.v3.oas.models.tags.Tag().name(name));
+        }
+        return openApi;
+    }
+
+    // ---- tests ----
+
+    @Test
+    public void tagOrderAppliedWhenPackageScanConfigured() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha", "Beta");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag alpha = openApi.getTags().stream()
+                .filter(t -> "Alpha".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+        io.swagger.v3.oas.models.tags.Tag beta = openApi.getTags().stream()
+                .filter(t -> "Beta".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+
+        Assert.assertEquals(10, alpha.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+        Assert.assertEquals(20, beta.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    @Test
+    public void tagWithoutApiSupportGetsNoOrder() {
+        String pkg = NoOrderController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("NoOrder");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag tag = openApi.getTags().get(0);
+        Assert.assertNull(tag.getExtensions());
+    }
+
+    @Test
+    public void noPackageScanAndNoMappingDoesNotThrow() {
+        Knife4jOpenApiCustomizer customizer = buildCustomizer();
+        OpenAPI openApi = buildOpenApi("Alpha");
+        customizer.customise(openApi);
+        Assert.assertNull(openApi.getTags().get(0).getExtensions());
+    }
+
+    @Test
+    public void operationOrderApplied() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha");
+        Paths paths = new Paths();
+        Operation op = new Operation().operationId("listAlpha");
+        PathItem pathItem = new PathItem().get(op);
+        paths.addPathItem("/alpha", pathItem);
+        openApi.setPaths(paths);
+
+        customizer.customise(openApi);
+
+        Assert.assertEquals(1, op.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    @Test
+    public void operationWithoutSupportAnnotationGetsNoOrder() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha");
+        Paths paths = new Paths();
+        Operation op = new Operation().operationId("unknownMethod");
+        PathItem pathItem = new PathItem().get(op);
+        paths.addPathItem("/unknown", pathItem);
+        openApi.setPaths(paths);
+
+        customizer.customise(openApi);
+
+        Assert.assertNull(op.getExtensions());
+    }
+}


### PR DESCRIPTION
## 关联 Issue

#109

## 变更内容

扩展 x-order 排序功能，支持未配置 packagesToScan 的场景，并新增 Operation 级别的排序支持。

## 验证

- Maven 构建通过