### PR TITLE
docs: 更新文档站链接为 knife4jnext.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ npm run dev -w knife4j-ui-react
 
 ## 文档与链接
 
+- 文档站：[knife4jnext.com](https://knife4jnext.com)
 - 仓库地址：[songxychn/knife4j-next](https://github.com/songxychn/knife4j-next)
 - Issue 反馈：[GitHub Issues](https://github.com/songxychn/knife4j-next/issues)
 - Release 记录：[GitHub Releases](https://github.com/songxychn/knife4j-next/releases)


### PR DESCRIPTION
## 变更内容

- README 文档链接更新为 https://knife4jnext.com
- GitHub 仓库 homepage 已直接更新（无需 PR）

## 验证

文档变更，无需构建验证。