### PR TITLE
feat(sandbox): 新增 knife4j-sandbox Docker 镜像 [TASK-OH-001]

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -1,0 +1,18 @@
+FROM nikolaik/python-nodejs:python3.12-nodejs22
+
+# Install Java 17, Maven, gh CLI, git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-17-jdk \
+    maven \
+    git \
+    curl \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,21 @@
+# knife4j-sandbox
+
+Docker image for knife4j backend build environment.
+
+Base: `nikolaik/python-nodejs:python3.12-nodejs22`
+Includes: OpenJDK 17, Maven, Node.js 22, gh CLI, git
+
+> Note: The `.java-version` file in the repo root contains `22` (for frontend tooling).
+> This sandbox image intentionally uses JDK 17 for Java backend builds — this is a deliberate maintainer decision, not a version conflict.
+
+## Build
+
+```bash
+docker build -t knife4j-sandbox -f sandbox/Dockerfile sandbox/
+```
+
+## Verify
+
+```bash
+docker run --rm knife4j-sandbox bash -lc "java -version && mvn -v && node -v && gh --version"
+```


### PR DESCRIPTION
关联 issue: #159

## 变更内容

新增 `sandbox/` 目录，包含 knife4j-sandbox Docker 镜像定义。

- `sandbox/Dockerfile`：基于 `nikolaik/python-nodejs:python3.12-nodejs22`，预装 openjdk-17-jdk、maven、gh CLI、git，设置 JAVA_HOME
- `sandbox/README.md`：构建和验证命令说明

## 验证

```bash
docker build -t knife4j-sandbox -f sandbox/Dockerfile sandbox/
docker run --rm knife4j-sandbox bash -lc 'java -version && mvn -v && node -v && gh --version'
```

注：worker 环境无 Docker，镜像构建验证需在有 Docker 的环境执行。

## Reviewer 结论

approve（无范围漂移，无安全问题）

残余风险：基础镜像未固定 digest（可重现性），建议后续 CI 补充 sandbox 构建 job。