### PR TITLE
fix(vue3): PR-3 High 级修复（router/Document/GlobalParameters/main/vite）

### DIFF
--- a/knife4j-vue3/src/main.js
+++ b/knife4j-vue3/src/main.js
@@ -5,6 +5,7 @@ import { setupStore } from './store/index.js'
 import router from '@/router/index.js'
 import { setupI18n } from '@/lang/index.js'
 import { createFromIconfontCN } from '@ant-design/icons-vue'
+import axios from 'axios'
 
 String.prototype.gblen = function () {
   let len = 0
@@ -31,9 +32,42 @@ const MyIcon = createFromIconfontCN({
   scriptUrl: iconFront
 })
 
+/***
+ * 全局组件，与 knife4j-vue (Vue 2) 行为保持一致：
+ * 供用户在模板中以组件标签直接引用（如 <ApiInfo>, <Authorize>）
+ */
+import Main from '@/views/index/Main.vue'
+import ApiInfo from '@/views/api/index.vue'
+import Authorize from '@/views/settings/Authorize.vue'
+import SwaggerModels from '@/views/settings/SwaggerModels.vue'
+import GlobalParameters from '@/views/settings/GlobalParameters.vue'
+import Settings from '@/views/settings/Settings.vue'
+import OfficelineDocument from '@/views/settings/OfficelineDocument.vue'
+import OtherMarkdown from '@/views/othermarkdown/index.vue'
+import MethodType from '@/components/common/MethodApi.vue'
+
+/***
+ * 响应数据拦截器（与 knife4j-vue main.js 行为一致）
+ * 默认直接返回 response.data，避免业务代码重复写 res.data
+ */
+axios.interceptors.response.use(function (response) {
+  return response.data;
+}, function (error) {
+  return Promise.reject(error);
+})
+
 const app = createApp(App)
 app.use(router)
 app.component('my-icon', MyIcon)
+app.component('Main', Main)
+app.component('ApiInfo', ApiInfo)
+app.component('Authorize', Authorize)
+app.component('SwaggerModels', SwaggerModels)
+app.component('GlobalParameters', GlobalParameters)
+app.component('Settings', Settings)
+app.component('OfficelineDocument', OfficelineDocument)
+app.component('OtherMarkdown', OtherMarkdown)
+app.component('MethodType', MethodType)
 setupStore(app)
 setupI18n(app)
 app.mount('#app')

--- a/knife4j-vue3/src/router/index.js
+++ b/knife4j-vue3/src/router/index.js
@@ -30,16 +30,19 @@ export const routes = [{
       path: '/SwaggerModels/:groupName',
       component: () => import('@/views/settings/SwaggerModels.vue')
     }, {
-      path: '/documentManager/GlobalParameters-:groupName',
+      path: '/documentManager/GlobalParameters$:groupName',
+      alias: '/documentManager/GlobalParameters-:groupName',
       component: () => import('@/views/settings/GlobalParameters.vue')
     }, {
-      path: '/documentManager/OfficelineDocument-:groupName',
+      path: '/documentManager/OfficelineDocument$:groupName',
+      alias: '/documentManager/OfficelineDocument-:groupName',
       component: () => import('@/views/settings/OfficelineDocument.vue')
     }, {
       path: '/documentManager/Settings',
       component: () => import('@/views/settings/Settings.vue')
     }, {
-      path: '/:groupName-:mdid-omd/:id',
+      path: '/:groupName$:mdid$omd/:id',
+      alias: '/:groupName-:mdid-omd/:id',
       component: () => import('@/views/othermarkdown/index.vue')
     }
   ]

--- a/knife4j-vue3/src/store/knife4jModels.js
+++ b/knife4j-vue3/src/store/knife4jModels.js
@@ -17,7 +17,6 @@ export const useknife4jModels = defineStore('knife4jModels', {
 
       },
       setValue(key, value) {
-        console.log(this)
         // 该方法是递归Models的方法
         // 判断是否已经赋值
         var that = this;

--- a/knife4j-vue3/src/views/api/Document.vue
+++ b/knife4j-vue3/src/views/api/Document.vue
@@ -20,6 +20,7 @@
       <a-row :class="'knife4j-api-' + api.methodType.toLowerCase()">
         <div class="knife4j-api-summary">
           <span class="knife4j-api-summary-method">
+            <UnlockOutlined v-if="api.securityFlag" style="font-size:16px;" />
             {{ api.methodType }}
           </span>
           <span class="knife4j-api-summary-path">{{ api.showUrl }}</span>
@@ -95,8 +96,8 @@
     </div>
     <!--响应参数需要判断是否存在多个code-schema的情况-->
     <div v-if="api.multipartResponseSchema">
-      <a-tabs @change="multipartTabCodeChanges">
-        <a-tab-pane v-for="resp in multipCodeDatas" :key="resp.code" :tab="$t('doc.responseHeaderParams')">
+        <a-tabs @change="multipartTabCodeChanges">
+          <a-tab-pane v-for="resp in multipCodeDatas" :key="resp.code" :tab="resp.code">
           <!--判断响应头-->
           <div v-if="resp.responseHeaderParameters">
               <!-- 响应Header -->
@@ -175,11 +176,13 @@
  import { useknife4jModels } from '@/store/knife4jModels.js'
  import { useI18n } from 'vue-i18n'
  import { message } from 'ant-design-vue'
+ import { UnlockOutlined } from '@ant-design/icons-vue'
 
  export default {
    name: "Document",
    components: {
      editor: VAceEditor,
+     UnlockOutlined,
      "DataType": defineAsyncComponent(() => import('./DataType.vue')),
      "EditorShow": defineAsyncComponent(() => import('./EditorShow.vue'))
    },
@@ -703,7 +706,7 @@
        // console.log("rcodes")
        // console.log(rcodes)
        if (rcodes != null && rcodes != undefined) {
-         rcodes.forEach(function (rc) {
+         rcodes.forEach(function (rc, i) {
            // 遍历
            if (rc.schema != undefined && rc.schema != null) {
              var respdata = [];
@@ -769,6 +772,12 @@
                that.multipData = nresobj;
              }
              that.multipCodeDatas.push(nresobj);
+           } else {
+             // 非 schema 响应：仅 fallback 第一条（与 knife4j-vue 行为保持一致）
+             // https://gitee.com/xiaoym/knife4j/issues/I5W145
+             if (i == 0) {
+               that.multipData = rc;
+             }
            }
          });
          var multipKeys = Object.keys(that.multipData);

--- a/knife4j-vue3/src/views/settings/GlobalParameters.vue
+++ b/knife4j-vue3/src/views/settings/GlobalParameters.vue
@@ -208,11 +208,13 @@ export default {
         const dfv = val;
         dfv[this.groupId] = this.globalParameters;
         localStore.setItem(Constants.globalParameter, dfv);
-        // 发送全局参数更新事件，使用Vue根实例作为事件总线
-        this.$root.$emit('global-parameters-updated', { 
-          groupId: this.groupId, 
-          parameters: this.globalParameters 
-        });
+        // 发送全局参数更新事件（Vue 3 移除了实例 event bus，这里通过 window CustomEvent 广播）
+        window.dispatchEvent(new CustomEvent('global-parameters-updated', {
+          detail: {
+            groupId: this.groupId,
+            parameters: this.globalParameters
+          }
+        }));
       })
     },
     deleteParam(record) {
@@ -241,11 +243,13 @@ export default {
             const dfv = val;
             dfv[key] = this.globalParameters;
             localStore.setItem(Constants.globalParameter, dfv);
-            // 发送全局参数更新事件，使用Vue根实例作为事件总线
-            gpInstance.$root.$emit('global-parameters-updated', { 
-              groupId: key, 
-              parameters: gpInstance.globalParameters 
-            })
+            // 发送全局参数更新事件（Vue 3 移除了实例 event bus，这里通过 window CustomEvent 广播）
+            window.dispatchEvent(new CustomEvent('global-parameters-updated', {
+              detail: {
+                groupId: key,
+                parameters: this.globalParameters
+              }
+            }));
           })
           this.visible = false;
         } else {
@@ -258,7 +262,6 @@ export default {
       this.visible = false;
     },
     addGlobalParameters() {
-      console.log(this.form)
       this.formRef.resetFields();
       this.visible = true;
       // this.$emit("childrenMethods", "addGlobalParameters", data);

--- a/knife4j-vue3/vite.config.js
+++ b/knife4j-vue3/vite.config.js
@@ -7,6 +7,37 @@ import viteCompression from 'vite-plugin-compression';
 import removeConsole from 'vite-plugin-remove-console';
 import { resolve } from 'path'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * 把 Vite 默认把 public/oauth 复制到 dist/oauth 的产物
+ * 移动到 dist/webjars/oauth，与 knife4j-vue (webpack) 构建结果保持一致。
+ * utils.js 中 getOAuth2Html(true) 会返回 "webjars/oauth/oauth2.html"，
+ * 必须在这个路径下可访问 OAuth2 的回调页面。
+ */
+function moveOauthToWebjars() {
+  let resolvedOutDir = 'dist';
+  return {
+    name: 'knife4j-move-oauth-to-webjars',
+    apply: 'build',
+    configResolved(config) {
+      resolvedOutDir = path.resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      const srcDir = path.resolve(resolvedOutDir, 'oauth');
+      const destDir = path.resolve(resolvedOutDir, 'webjars/oauth');
+      if (!fs.existsSync(srcDir)) {
+        return;
+      }
+      fs.mkdirSync(path.dirname(destDir), { recursive: true });
+      if (fs.existsSync(destDir)) {
+        fs.rmSync(destDir, { recursive: true, force: true });
+      }
+      fs.renameSync(srcDir, destDir);
+    }
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -24,7 +55,13 @@ export default defineConfig({
       algorithm: 'gzip', //压缩算法
       ext: '.gz', //文件类型
     }),
-    // removeConsole()
+    removeConsole({
+      // iconfont.js 是 iconfont.cn 生成的 IIFE 资源，不经过 babel 处理
+      external: ['src/assets/iconfonts/iconfont.js'],
+      // 同时匹配 console.log / console.debug 以及 knife4j 代码中常见的 window.console.log / window.console.debug
+      custom: ['console.log', 'console.debug', 'window.console.log', 'window.console.debug']
+    }),
+    moveOauthToWebjars()
   ],
   resolve: {
     alias: [


### PR DESCRIPTION
Closes #169

**背景**

PR-3 聚合修复 knife4j-vue3 中 1 个 Blocker（路由分隔符）和 8 个 High 级问题（Document/GlobalParameters/main/vite 的运行时或行为回归），以及少量被漏做的 Medium（移除遗留 console.log）。都是小而独立的改动，合并为单个 PR 方便 review。

**变更**

**1. router 路径分隔符回退（Blocker B8）**

knife4j-vue3/src/router/index.js 的主路径恢复为 $，与 knife4j-vue 对齐，同时保留 - 作为 alias，两种 URL 都能打开：

- /documentManager/GlobalParameters$:groupName（alias -）
- /documentManager/OfficelineDocument$:groupName（alias -）
- /:groupName$:mdid$omd/:id（alias -）

**2. Document.vue 三处修复（High H1/H2/H3）**

- H1：initResponseCodeParams 把 forEach((rc) => ...) 加上索引 i，补回 else 分支里 i == 0 时 that.multipData = rc 的 fallback（原 vue2 行为，issue I5W145 场景）。
- H2：多响应码的 tab pane 标签由固定的 $t('doc.responseHeaderParams') 改回 resp.code，不再所有 tab 都显示同一个标题。
- H3：knife4j-api-summary-method 附近补回 UnlockOutlined v-if=api.securityFlag 图标，并在 components 中注册。

**3. GlobalParameters.vue gpInstance / $root.$emit 修复（High H4）**

handleOk 方法里残留的未定义 gpInstance.$root.$emit(...) 会在 Vue 3 下直接抛 ReferenceError。把 gpInstance 替换为 this，同时因为 Vue 3 移除了实例 event bus（$root.$emit 不存在），把 storeGlobalParameters / handleOk 里的事件广播改为 window.dispatchEvent(new CustomEvent('global-parameters-updated', { detail: {...} }))。顺手去掉 addGlobalParameters 里 console.log(this.form) 调试日志。

**4. main.js 补全（High H8 / H9）**

- 补回 Vue 2 版本注册的全局组件：Main / ApiInfo / Authorize / SwaggerModels / GlobalParameters / Settings / OfficelineDocument / OtherMarkdown / MethodType，便于用户在模板里直接用组件名引用。
- 补回 axios 响应拦截器：axios.interceptors.response.use(r => r.data, err => Promise.reject(err))，与 knife4j-vue/src/main.js 行为一致。
- 移除 knife4j-vue3/src/store/knife4jModels.js 中 setValue 的 console.log(this) 遗留调试代码。

**5. vite 配置补齐（High H6 / H7）**

- H7：取消 removeConsole() 注释，并通过 custom 选项扩展匹配模式到 console.log / console.debug / window.console.log / window.console.debug，确保业务代码中出现的 window.console.log(...) 也被移除；src/assets/iconfonts/iconfont.js 加入 external 白名单，避免 babel 解析 IIFE 报错。
- H6：新增内联插件 moveOauthToWebjars，在 closeBundle 阶段把 dist/oauth/ 整个目录移动到 dist/webjars/oauth/，与 knife4j-vue 的 CopyWebPackPlugin 产物路径一致。utils.js 中 getOAuth2Html(true) 返回的 webjars/oauth/oauth2.html 路径现在真实可访问。
- H5 推迟：buildCopy.sh 等价脚本留到 PR-5（Maven 集成）处理，与本 PR 范围无关。

**验证**

```
cd knife4j-vue3
npx vite build --outDir=/tmp/vue3-pr3-test-dist --emptyOutDir
```

构建成功，产物目录：

```
dist/
├── doc.html
├── webjars/
│   ├── js/
│   ├── css/
│   ├── img/
│   └── oauth/          # 由 moveOauthToWebjars 从 dist/oauth/ 迁移
│       ├── oauth2.html
│       └── axios.min.js
├── favicon.ico
└── robots.txt
```

业务代码层面的 console.log / window.console.log 已全部被 removeConsole 擦除；产物中残留的 console.log 仅来自第三方库（ace editor / katex / mindmap diagram 等）和被 external 放过的 iconfont.js，属于不可避免的第三方日志，不影响验收语义。

**兼容性**

- 保留 - 风格路径作为 alias，现有 Vue 3 部署或收藏的新 URL 仍可访问。
- 全局组件注册仅补充，不覆盖已有 BasicLayout 的 componentMap 行为。
- window CustomEvent 广播是新协议，目前没有监听者，与原 Vue 2 $root.$emit 在 Vue 3 下完全失效等价，后续组件迁移可按需监听。

**范围约束**

- 未修改 knife4j-vue/。
- 未修改 core/（PR-1 范围，已合入 master）。
- 未修改 Authorize.vue / OAuth2.vue（PR-2 范围，已合入 master）。

