### PR TITLE
[OH-006/OH-007] OpenHands heartbeat 脚本 + 并行验证计划

### DIFF
--- a/.openhands/im-gateway/validation-plan.md
+++ b/.openhands/im-gateway/validation-plan.md
@@ -1,0 +1,64 @@
+# OpenHands 并行验证计划
+
+_Phase 5 - OpenClaw → OpenHands 迁移_
+
+## 目标
+
+在真实任务上对比 OpenClaw（当前）和 OpenHands（候选）的执行效果，为最终切换提供数据支撑。
+
+## 候选 Issue
+
+选取 3 个低风险任务作为对照样本，优先 `area:docs` 或 `area:ui-react`：
+
+| # | Issue | 标签 | 理由 |
+|---|-------|------|------|
+| 1 | [#115 ui-react: 目标的 description 不展示](https://github.com/songxychn/knife4j-next/issues/115) | area:ui-react | 纯前端 bug，范围明确，无 Java 依赖 |
+| 2 | [#150 ui-react: 字段约束信息 tooltip 展示](https://github.com/songxychn/knife4j-next/issues/150) | area:ui-react | 纯前端新功能，改动集中在单个组件 |
+| 3 | [#165 TASK-OH-007: 并行验证对照 issue（文档）](https://github.com/songxychn/knife4j-next/issues/165) | area:repo | 纯文档任务，无代码风险，适合验证文档类任务处理能力 |
+
+## 执行方案
+
+每个 issue 各执行两次：
+
+- **Run A**：OpenClaw（当前 coordinator + Claude Code worker）
+- **Run B**：OpenHands（GUI 模式，相同 issue 描述）
+
+两次执行独立进行，不共享中间产物。
+
+## 对比维度
+
+| 维度 | 说明 | 采集方式 |
+|------|------|----------|
+| 任务完成率 | PR 是否成功创建且 CI 全绿 | gh pr checks |
+| 平均执行时间 | 从拾取 issue 到创建 PR 的耗时（分钟） | 手动记录时间戳 |
+| LLM 消耗 | input/output token 数 | OpenClaw: session log；OpenHands: GUI 统计 |
+| 环境准备失败率 | 沙箱启动失败、依赖安装失败等 | 执行日志 |
+| PR 质量 | reviewer 主观评分（1-5 分） | 人工 review |
+
+## 记录表格
+
+| Issue | Run | 完成 | 耗时(min) | Input Token | Output Token | 环境失败 | PR 质量(1-5) | 备注 |
+|-------|-----|------|-----------|-------------|--------------|----------|--------------|------|
+| #115  | OpenClaw   | - | - | - | - | - | - | |
+| #115  | OpenHands  | - | - | - | - | - | - | |
+| #150  | OpenClaw   | - | - | - | - | - | - | |
+| #150  | OpenHands  | - | - | - | - | - | - | |
+| #165  | OpenClaw   | - | - | - | - | - | - | |
+| #165  | OpenHands  | - | - | - | - | - | - | |
+
+## 最终切换判定标准
+
+满足以下全部条件时，可将默认执行引擎切换为 OpenHands：
+
+1. **完成率**：OpenHands 完成率 ≥ OpenClaw 完成率 - 10%
+2. **执行时间**：OpenHands 平均耗时 ≤ OpenClaw 平均耗时 × 1.5
+3. **稳定性**：连续 3 个任务无环境准备失败
+
+未达标时继续使用 OpenClaw，每月重新评估一次。
+
+## 状态
+
+- [ ] Run A（OpenClaw）执行中
+- [ ] Run B（OpenHands）待启动
+- [ ] 数据汇总
+- [ ] 切换决策

--- a/scripts/openhands/heartbeat.sh
+++ b/scripts/openhands/heartbeat.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# heartbeat.sh - OpenHands 任务队列心跳脚本
+# 对标 OpenClaw heartbeat，定期检查 GitHub Issues 并（dry-run 模式）打印下一个待执行任务
+#
+# 用法:
+#   heartbeat.sh [--dry-run] [--once]
+#
+# 退出码:
+#   0 - 正常（队列空或成功打印下一任务）
+#   1 - 脚本错误（gh 未登录、网络失败等）
+#   2 - 工作区不干净（拒绝继续）
+#
+# Crontab 示例（每 2 小时唤醒一次）:
+#   0 */2 * * * /path/to/scripts/openhands/heartbeat.sh >> /var/log/openhands/heartbeat.log 2>&1
+
+set -euo pipefail
+
+# ── 常量 ──────────────────────────────────────────────────────────────────────
+REPO="songxychn/knife4j-next"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# ── 参数解析 ──────────────────────────────────────────────────────────────────
+DRY_RUN=false
+ONCE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --once)    ONCE=true ;;
+    --help|-h)
+      sed -n '2,20p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "[ERROR] 未知参数: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── 工具函数 ──────────────────────────────────────────────────────────────────
+log()  { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+err()  { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [ERROR] $*" >&2; }
+info() { log "[INFO] $*"; }
+warn() { log "[WARN] $*"; }
+
+# ── 前置检查 ──────────────────────────────────────────────────────────────────
+check_dependencies() {
+  if ! command -v gh &>/dev/null; then
+    err "gh CLI 未安装或不在 PATH 中"
+    exit 1
+  fi
+
+  if ! gh auth status &>/dev/null; then
+    err "gh 未登录，请先运行 'gh auth login'"
+    exit 1
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    err "jq 未安装，请先安装 jq"
+    exit 1
+  fi
+}
+
+check_workspace_clean() {
+  cd "$REPO_ROOT"
+
+  if ! git rev-parse --git-dir &>/dev/null; then
+    err "当前目录不是 git 仓库: $REPO_ROOT"
+    exit 1
+  fi
+
+  local dirty
+  dirty="$(git status --porcelain 2>/dev/null)"
+  if [[ -n "$dirty" ]]; then
+    err "工作区不干净，拒绝继续执行任务："
+    err "$dirty"
+    exit 2
+  fi
+
+  info "工作区干净 ✓"
+}
+
+# ── 任务队列 ──────────────────────────────────────────────────────────────────
+fetch_ready_issues() {
+  gh issue list \
+    --repo "$REPO" \
+    --label "agent-task" \
+    --label "status:ready" \
+    --state open \
+    --json number,title,labels \
+    --limit 20 \
+    2>/dev/null || {
+      err "获取 GitHub Issues 失败（网络错误或权限不足）"
+      exit 1
+    }
+}
+
+# 优先选带 source:im 标签的 issue，否则取第一条
+select_next_issue() {
+  local issues_json="$1"
+
+  # 优先 source:im
+  local im_issue
+  im_issue="$(echo "$issues_json" | jq -r '
+    map(select(.labels[].name == "source:im")) | first |
+    if . then "\(.number)\t\(.title)" else empty end
+  ' 2>/dev/null)"
+
+  if [[ -n "$im_issue" ]]; then
+    echo "$im_issue"
+    return
+  fi
+
+  # 否则取第一条
+  echo "$issues_json" | jq -r 'first | "\(.number)\t\(.title)"' 2>/dev/null
+}
+
+# ── 主流程 ────────────────────────────────────────────────────────────────────
+main() {
+  info "=== OpenHands Heartbeat 启动 ==="
+  info "模式: dry_run=${DRY_RUN}, once=${ONCE}"
+  info "仓库: ${REPO}"
+  info "工作区: ${REPO_ROOT}"
+
+  check_dependencies
+  check_workspace_clean
+
+  info "正在拉取 status:ready 任务队列..."
+  local issues_json
+  issues_json="$(fetch_ready_issues)"
+
+  local count
+  count="$(echo "$issues_json" | jq 'length')"
+
+  if [[ "$count" -eq 0 ]]; then
+    info "队列为空，无待执行任务。退出。"
+    exit 0
+  fi
+
+  info "发现 ${count} 个 ready 任务："
+  echo "$issues_json" | jq -r '.[] | "  #\(.number) \(.title)"'
+
+  local next_issue
+  next_issue="$(select_next_issue "$issues_json")"
+
+  if [[ -z "$next_issue" ]]; then
+    warn "无法选出下一个任务，跳过。"
+    exit 0
+  fi
+
+  local issue_number issue_title
+  issue_number="$(echo "$next_issue" | cut -f1)"
+  issue_title="$(echo "$next_issue" | cut -f2-)"
+
+  info "选中任务: #${issue_number} ${issue_title}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    info "[DRY-RUN] 将执行以下操作（未实际调用 OpenHands）："
+    info "  1. gh issue edit ${issue_number} --add-label status:in-progress"
+    info "  2. 调用 OpenHands API，传入 issue #${issue_number} 的任务描述"
+    info "  3. 等待 OpenHands 完成，获取 PR 链接"
+    info "  4. gh issue edit ${issue_number} --remove-label status:in-progress --add-label status:review"
+    info "[DRY-RUN] 完成，未做任何实际修改。"
+  else
+    warn "非 dry-run 模式暂未实现（本阶段为 dry-run only）"
+    warn "请使用 --dry-run 标志运行"
+    exit 1
+  fi
+
+  info "=== Heartbeat 完成 ==="
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## 关联 Issue

- Closes #164 (TASK-OH-006: OpenHands cron 脚本)
- Closes #165 (TASK-OH-007: 准备并行验证的对照 issue)

## 变更内容

### scripts/openhands/heartbeat.sh（OH-006）

新增 heartbeat 脚本，对标 OpenClaw heartbeat 功能：

- 检查工作区是否干净（退出码 2 表示不干净）
- 列出 status:ready 的 agent-task issue
- 优先选带 source:im 标签的 issue，否则取第一条
- 支持 --dry-run 和 --once flag
- 本阶段为 dry-run only，不真实调用 OpenHands API
- 退出码：0 正常，1 脚本错误，2 工作区不干净

### .openhands/im-gateway/validation-plan.md（OH-007）

新增并行验证计划文档：

- 3 个候选 issue（#115、#150、#165）
- 对比维度：完成率、执行时间、token 消耗、环境失败率、PR 质量
- 最终切换判定标准

## 验证

```
bash -n scripts/openhands/heartbeat.sh  # 语法检查通过
scripts/openhands/heartbeat.sh --dry-run --once  # 成功列出 6 个 ready 任务
test -f .openhands/im-gateway/validation-plan.md  # 文件存在
```