### PR TITLE
fix(vue3): Vue2 功能对齐 - 修复插槽/表格/Markdown/SwaggerModels

### DIFF
--- a/knife4j-vue3/src/components/Markdown/index.vue
+++ b/knife4j-vue3/src/components/Markdown/index.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="knife4j-markdown" v-html="markdownSource">
-    </div>
+  <div class="knife4j-markdown" v-html="markdownSource">
+  </div>
 </template>
 
 <script>
@@ -11,53 +11,47 @@ import random from 'lodash/random';
 mermaid.initialize({ logLevel: 5 });
 
 function MermaIdCall(v) {
-    // nothing to do
-    // console.log('call.')
+  // nothing to do
 }
 // 按需加载
 // https://mermaid-js.github.io/mermaid/#/Setup?id=render
 var renderer = new marked.Renderer();
 renderer.code = function (code, language) {
-    if (language === 'mermaid') {
-        let elementId = 'mermaId-' + random(1, 1000000) + random(1, 10);
-        //console.log("randomId:", elementId)
-        try {
-            let codeSvg = mermaid.mermaidAPI.render(elementId, code, MermaIdCall);
-            //console.log('codeSvg:', codeSvg)
-            return '<div class="mermaid" id="' + elementId + '">' + codeSvg + '</div>';
-        } catch (e) {
-            // 可能出现语法错误的情况，捕获异常,返回默认值
-            // console.log('error', e)
-        }
-        return '<pre><code class="language-' + language + '">' + code + '</code></pre>';
-
+  if (language === 'mermaid') {
+    let elementId = 'mermaId-' + random(1, 1000000) + random(1, 10);
+    try {
+      let codeSvg = mermaid.mermaidAPI.render(elementId, code, MermaIdCall);
+      return '<div class="mermaid" id="' + elementId + '">' + codeSvg + '</div>';
+    } catch (e) {
+      // 可能出现语法错误的情况，捕获异常,返回默认值
     }
-    else {
-        return '<pre><code class="language-' + language + '">' + code + '</code></pre>';
-    }
+    return '<pre><code class="language-' + language + '">' + code + '</code></pre>';
+  }
+  else {
+    return '<pre><code class="language-' + language + '">' + code + '</code></pre>';
+  }
 };
 marked.setOptions({
-    gfm: true,
-    tables: true,
-    breaks: false,
-    pedantic: false,
-    sanitize: false,
-    smartLists: true,
-    smartypants: false,
-    renderer: renderer
+  gfm: true,
+  tables: true,
+  breaks: false,
+  pedantic: false,
+  sanitize: false,
+  smartLists: true,
+  smartypants: false,
+  renderer: renderer
 })
 export default {
-    name: "Markdown",
-    props: {
-        source: {
-            type: String
-        }
-    },
-    computed: {
-        markdownSource() {
-            return marked.parse(this.source);
-        }
+  name: "Markdown",
+  props: {
+    source: {
+      type: String
     }
-
+  },
+  computed: {
+    markdownSource() {
+      return marked.parse(this.source);
+    }
+  }
 }
 </script>

--- a/knife4j-vue3/src/components/SiderMenu/SubMenu.vue
+++ b/knife4j-vue3/src/components/SiderMenu/SubMenu.vue
@@ -1,8 +1,8 @@
-<template functional>
+<template>
   <a-sub-menu :key="menuInfo.key">
-    <span slot="title">
+    <template #title>
       <mail-outlined /><span>{{ menuInfo.name }}</span>
-    </span>
+    </template>
     <template v-for="item in menuInfo.children">
       <a-menu-item v-if="!item.children" :key="item.key">
         <pie-chart-outlined />

--- a/knife4j-vue3/src/components/officeDocument/officeDocTemplate.js
+++ b/knife4j-vue3/src/components/officeDocument/officeDocTemplate.js
@@ -121,7 +121,7 @@ export function getDocumentVueTemplates(title, resumecss, dataStr) {
               </div>
             </a-col>
           </a-row>
-    
+
           <!--目录-->
           <a-row id="knife4j-doc-m" class="knife4j-doc-m">
             <a-row style="float: right;width: 57px;z-index: 10000;overflow: hidden;">
@@ -324,7 +324,7 @@ export function getDocumentVueTemplates(title, resumecss, dataStr) {
                   v-html="formaterJson(api.multipData.responseValue)"
                 ></pre>
               </div>
-              
+
 
             <!--接口遍历结束-->
             </div>
@@ -359,18 +359,15 @@ export function getDocumentVueTemplates(title, resumecss, dataStr) {
           },
           {
             title: "请求类型",
-            dataIndex: "in",
-            scopedSlots: { customRender: "typeTemplate" }
+            dataIndex: "in"
           },
           {
             title: "是否必须",
-            dataIndex: "require",
-            scopedSlots: { customRender: "requireTemplate" }
+            dataIndex: "require"
           },
           {
             title: "数据类型",
-            dataIndex: "type",
-            scopedSlots: { customRender: "datatypeTemplate" }
+            dataIndex: "type"
           },
           {
             title: "schema",
@@ -388,8 +385,7 @@ export function getDocumentVueTemplates(title, resumecss, dataStr) {
           {
             title: "说明",
             dataIndex: "description",
-            width: "55%",
-            scopedSlots: { customRender: "descriptionTemplate" }
+            width: "55%"
           },
           {
             title: "schema",
@@ -525,7 +521,7 @@ export function getDocumentVueTemplates(title, resumecss, dataStr) {
             })
           },
           created(){
-           
+
           },
           methods:{
             genUnionTableKey() {
@@ -569,8 +565,8 @@ export function getDocumentVueTemplates(title, resumecss, dataStr) {
       }
 
       main();
-      
-      
+
+
     </script>
   </body>
   </html>`

--- a/knife4j-vue3/src/components/officeDocument/officeDocTemplateUS.js
+++ b/knife4j-vue3/src/components/officeDocument/officeDocTemplateUS.js
@@ -121,7 +121,7 @@ export function getDocumentVueTemplatesUS(title, resumecss, dataStr) {
               </div>
             </a-col>
           </a-row>
-    
+
           <!--目录-->
           <a-row id="knife4j-doc-m" class="knife4j-doc-m">
             <a-row style="float: right;width: 57px;z-index: 10000;overflow: hidden;">
@@ -324,7 +324,7 @@ export function getDocumentVueTemplatesUS(title, resumecss, dataStr) {
                   v-html="formaterJson(api.multipData.responseValue)"
                 ></pre>
               </div>
-              
+
 
             <!--接口遍历结束-->
             </div>
@@ -359,18 +359,15 @@ export function getDocumentVueTemplatesUS(title, resumecss, dataStr) {
           },
           {
             title: "in",
-            dataIndex: "in",
-            scopedSlots: { customRender: "typeTemplate" }
+            dataIndex: "in"
           },
           {
             title: "require",
-            dataIndex: "require",
-            scopedSlots: { customRender: "requireTemplate" }
+            dataIndex: "require"
           },
           {
             title: "type",
-            dataIndex: "type",
-            scopedSlots: { customRender: "datatypeTemplate" }
+            dataIndex: "type"
           },
           {
             title: "schema",
@@ -388,8 +385,7 @@ export function getDocumentVueTemplatesUS(title, resumecss, dataStr) {
           {
             title: "description",
             dataIndex: "description",
-            width: "55%",
-            scopedSlots: { customRender: "descriptionTemplate" }
+            width: "55%"
           },
           {
             title: "schema",
@@ -525,7 +521,7 @@ export function getDocumentVueTemplatesUS(title, resumecss, dataStr) {
             })
           },
           created(){
-           
+
           },
           methods:{
             genUnionTableKey() {
@@ -569,8 +565,8 @@ export function getDocumentVueTemplatesUS(title, resumecss, dataStr) {
       }
 
       main();
-      
-      
+
+
     </script>
   </body>
   </html>`

--- a/knife4j-vue3/src/lang/en.js
+++ b/knife4j-vue3/src/lang/en.js
@@ -23,8 +23,7 @@ const langOptions = {
       {
         title: 'description',
         width: '35%',
-        dataIndex: 'description',
-        scopedSlots: { customRender: 'descriptionValueTemplate' }
+        dataIndex: 'description'
       },
       {
         title: 'schema',
@@ -42,23 +41,19 @@ const langOptions = {
       {
         title: 'description',
         dataIndex: 'description',
-        width: '25%',
-        scopedSlots: { customRender: 'descriptionValueTemplate' }
+        width: '25%'
       },
       {
         title: 'in',
-        dataIndex: 'in',
-        scopedSlots: { customRender: 'typeTemplate' }
+        dataIndex: 'in'
       },
       {
         title: 'require',
-        dataIndex: 'require',
-        scopedSlots: { customRender: 'requireTemplate' }
+        dataIndex: 'require'
       },
       {
         title: 'type',
-        dataIndex: 'type',
-        scopedSlots: { customRender: 'datatypeTemplate' }
+        dataIndex: 'type'
       },
       {
         title: 'schema',
@@ -76,13 +71,11 @@ const langOptions = {
       {
         title: 'description',
         dataIndex: 'description',
-        width: '55%',
-        scopedSlots: { customRender: 'descriptionTemplate' }
+        width: '55%'
       },
       {
         title: 'schema',
-        dataIndex: 'schema',
-        scopedSlots: { customRender: 'schemaTemplate' }
+        dataIndex: 'schema'
       }
     ],
     //文档说明-响应Header
@@ -112,7 +105,6 @@ const langOptions = {
       {
         title: 'description',
         dataIndex: 'description',
-        scopedSlots: { customRender: 'descriptionTemplate' },
         width: '40%'
       },
       {
@@ -130,25 +122,16 @@ const langOptions = {
       {
         title: 'name',
         dataIndex: 'name',
-        width: '20%',
-        scopedSlots: {
-          customRender: 'headerName'
-        }
+        width: '20%'
       },
       {
         title: 'value',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'headerValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: 'operation',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-FormData类型请求头
@@ -156,33 +139,21 @@ const langOptions = {
       {
         title: 'name',
         dataIndex: 'name',
-        width: '20%',
-        scopedSlots: {
-          customRender: 'formName'
-        }
+        width: '20%'
       },
       {
         title: 'type',
         dataIndex: 'type',
-        width: '12%',
-        scopedSlots: {
-          customRender: 'formType'
-        }
+        width: '12%'
       },
       {
         title: 'value',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'formValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: 'operation',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-url-form类型请求参数头
@@ -190,25 +161,16 @@ const langOptions = {
       {
         title: 'name',
         dataIndex: 'name',
-        width: '20%',
-        scopedSlots: {
-          customRender: 'urlFormName'
-        }
+        width: '20%'
       },
       {
         title: 'value',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'urlFormValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: 'operation',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-响应Header
@@ -243,10 +205,7 @@ const langOptions = {
       },
       {
         title: 'value',
-        dataIndex: 'value',
-        scopedSlots: {
-          customRender: 'paramIpt'
-        }
+        dataIndex: 'value'
       }
     ]
   },
@@ -363,34 +322,22 @@ const langOptions = {
     tableHeader: [{
         title: 'name',
         dataIndex: 'name',
-        width: '15%',
-        scopedSlots: {
-          customRender: 'name'
-        }
+        width: '15%'
       },
       {
         title: 'value',
         className: 'column-money',
         dataIndex: 'value',
-        width: '65%',
-        scopedSlots: {
-          customRender: 'paramContentLabel'
-        }
+        width: '65%'
       },
       {
         title: 'type',
         dataIndex: 'in',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'paramTypeLable'
-        }
+        width: '10%'
       },
       {
         title: 'operation',
-        dataIndex: 'operation',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        dataIndex: 'operation'
       }
     ],
     form:{

--- a/knife4j-vue3/src/lang/jp.js
+++ b/knife4j-vue3/src/lang/jp.js
@@ -24,8 +24,7 @@ const langOptions = {
       {
         title: '説明',
         width: '35%',
-        dataIndex: 'description',
-        scopedSlots: { customRender: 'descriptionValueTemplate' }
+        dataIndex: 'description'
       },
       {
         title: 'schema',
@@ -43,23 +42,19 @@ const langOptions = {
       {
         title: 'パラメータの説明',
         dataIndex: 'description',
-        width: '25%',
-        scopedSlots: { customRender: 'descriptionValueTemplate' }
+        width: '25%'
       },
       {
         title: 'リクエストタイプ',
-        dataIndex: 'in',
-        scopedSlots: { customRender: 'typeTemplate' }
+        dataIndex: 'in'
       },
       {
         title: '必須かどうか',
-        dataIndex: 'require',
-        scopedSlots: { customRender: 'requireTemplate' }
+        dataIndex: 'require'
       },
       {
         title: 'データタイプ',
-        dataIndex: 'type',
-        scopedSlots: { customRender: 'datatypeTemplate' }
+        dataIndex: 'type'
       },
       {
         title: 'schema',
@@ -77,13 +72,11 @@ const langOptions = {
       {
         title: '説明',
         dataIndex: 'description',
-        width: '55%',
-        scopedSlots: { customRender: 'descriptionTemplate' }
+        width: '55%'
       },
       {
         title: 'schema',
-        dataIndex: 'schema',
-        scopedSlots: { customRender: 'schemaTemplate' }
+        dataIndex: 'schema'
       }
     ],
     //文档说明-响应Header
@@ -113,7 +106,6 @@ const langOptions = {
       {
         title: 'パラメータの説明',
         dataIndex: 'description',
-        scopedSlots: { customRender: 'descriptionTemplate' },
         width: '40%'
       },
       {
@@ -131,25 +123,16 @@ const langOptions = {
       {
         title: 'リクエストヘッダ',
         dataIndex: 'name',
-        width: '20%',
-        scopedSlots: {
-          customRender: 'headerName'
-        }
+        width: '20%'
       },
       {
         title: 'コンテンツ',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'headerValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: 'オプション',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-FormData类型请求头
@@ -157,33 +140,21 @@ const langOptions = {
       {
         title: 'パラメータ名',
         dataIndex: 'name',
-        width: '20%',
-        scopedSlots: {
-          customRender: 'formName'
-        }
+        width: '20%'
       },
       {
         title: 'タイプ',
         dataIndex: 'type',
-        width: '12%',
-        scopedSlots: {
-          customRender: 'formType'
-        }
+        width: '12%'
       },
       {
         title: 'パラメータ値',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'formValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: 'オプション',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-url-form类型请求参数头
@@ -191,25 +162,16 @@ const langOptions = {
       {
         title: 'パラメータ名',
         dataIndex: 'name',
-        width: '20%',
-        scopedSlots: {
-          customRender: 'urlFormName'
-        }
+        width: '20%'
       },
       {
         title: 'パラメータ値',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'urlFormValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: 'オプション',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-响应Header
@@ -244,10 +206,7 @@ const langOptions = {
       },
       {
         title: 'パラメータ値',
-        dataIndex: 'value',
-        scopedSlots: {
-          customRender: 'paramIpt'
-        }
+        dataIndex: 'value'
       }
     ]
   },
@@ -353,34 +312,22 @@ const langOptions = {
     tableHeader: [{
       title: 'パラメータ名',
       dataIndex: 'name',
-      width: '15%',
-      scopedSlots: {
-        customRender: 'name'
-      }
+      width: '15%'
     },
     {
       title: 'パラメータ値',
       className: 'column-money',
       dataIndex: 'value',
-      width: '65%',
-      scopedSlots: {
-        customRender: 'paramContentLabel'
-      }
+      width: '65%'
     },
     {
       title: 'パラメータのタイプ',
       dataIndex: 'in',
-      width: '10%',
-      scopedSlots: {
-        customRender: 'paramTypeLable'
-      }
+      width: '10%'
     },
     {
       title: 'オプション',
-      dataIndex: 'operation',
-      scopedSlots: {
-        customRender: 'operation'
-      }
+      dataIndex: 'operation'
     }
     ],
     form: {

--- a/knife4j-vue3/src/lang/zh.js
+++ b/knife4j-vue3/src/lang/zh.js
@@ -25,7 +25,6 @@ const langOptions = {
         title: '说明',
         width: '35%',
         dataIndex: 'description',
-        scopedSlots: { customRender: 'descriptionValueTemplate' }
       },
       {
         title: 'schema',
@@ -43,23 +42,19 @@ const langOptions = {
       {
         title: '参数说明',
         dataIndex: 'description',
-        width: '25%',
-        scopedSlots: { customRender: 'descriptionValueTemplate' }
+        width: '25%'
       },
       {
         title: '请求类型',
-        dataIndex: 'in',
-        scopedSlots: { customRender: 'typeTemplate' }
+        dataIndex: 'in'
       },
       {
         title: '是否必须',
-        dataIndex: 'require',
-        scopedSlots: { customRender: 'requireTemplate' }
+        dataIndex: 'require'
       },
       {
         title: '数据类型',
-        dataIndex: 'type',
-        scopedSlots: { customRender: 'datatypeTemplate' }
+        dataIndex: 'type'
       },
       {
         title: 'schema',
@@ -78,12 +73,10 @@ const langOptions = {
         title: '说明',
         dataIndex: 'description',
         width: '55%',
-        scopedSlots: { customRender: 'descriptionTemplate' }
       },
       {
         title: 'schema',
-        dataIndex: 'schema',
-        scopedSlots: { customRender: 'schemaTemplate' }
+        dataIndex: 'schema'
       }
     ],
     //文档说明-响应Header
@@ -113,7 +106,6 @@ const langOptions = {
       {
         title: '参数说明',
         dataIndex: 'description',
-        scopedSlots: { customRender: 'descriptionTemplate' },
         width: '40%'
       },
       {
@@ -132,24 +124,15 @@ const langOptions = {
         title: '请求头',
         dataIndex: 'name',
         width: '20%',
-        scopedSlots: {
-          customRender: 'headerName'
-        }
       },
       {
         title: '内容',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'headerValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: '操作',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-FormData类型请求头
@@ -158,32 +141,20 @@ const langOptions = {
         title: '参数名称',
         dataIndex: 'name',
         width: '20%',
-        scopedSlots: {
-          customRender: 'formName'
-        }
       },
       {
         title: '类型',
         dataIndex: 'type',
-        width: '12%',
-        scopedSlots: {
-          customRender: 'formType'
-        }
+        width: '12%'
       },
       {
         title: '参数值',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'formValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: '操作',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-url-form类型请求参数头
@@ -192,24 +163,15 @@ const langOptions = {
         title: '参数名称',
         dataIndex: 'name',
         width: '20%',
-        scopedSlots: {
-          customRender: 'urlFormName'
-        }
       },
       {
         title: '参数值',
-        dataIndex: 'content',
-        scopedSlots: {
-          customRender: 'urlFormValue'
-        }
+        dataIndex: 'content'
       },
       {
         title: '操作',
         dataIndex: 'operation',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        width: '10%'
       }
     ],
     //调试-响应Header
@@ -245,9 +207,7 @@ const langOptions = {
       {
         title: '参数值',
         dataIndex: 'value',
-        scopedSlots: {
-          customRender: 'paramIpt'
-        }
+
       }
     ]
   },
@@ -354,33 +314,21 @@ const langOptions = {
         title: '参数名称',
         dataIndex: 'name',
         width: '15%',
-        scopedSlots: {
-          customRender: 'name'
-        }
-      },
+        },
       {
         title: '参数值',
         className: 'column-money',
         dataIndex: 'value',
-        width: '65%',
-        scopedSlots: {
-          customRender: 'paramContentLabel'
-        }
+        width: '65%'
       },
       {
         title: '参数类型',
         dataIndex: 'in',
-        width: '10%',
-        scopedSlots: {
-          customRender: 'paramTypeLable'
-        }
+        width: '10%'
       },
       {
         title: '操作',
-        dataIndex: 'operation',
-        scopedSlots: {
-          customRender: 'operation'
-        }
+        dataIndex: 'operation'
       }
     ],
     form:{

--- a/knife4j-vue3/src/store/constants.js
+++ b/knife4j-vue3/src/store/constants.js
@@ -8,34 +8,22 @@ const constants = {
   globalParameterTableColumns: [{
     title: '参数名称',
     dataIndex: 'name',
-    width: '15%',
-    scopedSlots: {
-      customRender: 'name'
-    }
+    width: '15%'
   },
   {
     title: '参数值',
     className: 'column-money',
     dataIndex: 'value',
-    width: '65%',
-    scopedSlots: {
-      customRender: 'paramContentLabel'
-    }
+    width: '65%'
   },
   {
     title: '参数类型',
     dataIndex: 'in',
-    width: '10%',
-    scopedSlots: {
-      customRender: 'paramTypeLable'
-    }
+    width: '10%'
   },
   {
     title: '操作',
-    dataIndex: 'operation',
-    scopedSlots: {
-      customRender: 'operation'
-    }
+    dataIndex: 'operation'
   }
   ],
   globalSecurityParameters: 'Knife4jGlobalSecurityParameters',
@@ -300,81 +288,51 @@ const constants = {
   debugRequestHeaderColumn: [{
     title: '请求头',
     dataIndex: 'name',
-    width: '20%',
-    scopedSlots: {
-      customRender: 'headerName'
-    }
+    width: '20%'
   },
   {
     title: '内容',
-    dataIndex: 'content',
-    scopedSlots: {
-      customRender: 'headerValue'
-    }
+    dataIndex: 'content'
   },
   {
     title: '操作',
     dataIndex: 'operation',
-    width: '10%',
-    scopedSlots: {
-      customRender: 'operation'
-    }
+    width: '10%'
   }
   ],
   debugFormRequestHeader: [{
     title: '参数名称',
     dataIndex: 'name',
-    width: '20%',
-    scopedSlots: {
-      customRender: 'formName'
-    }
+    width: '20%'
   },
   {
     title: '类型',
     dataIndex: 'type',
-    width: '12%',
-    scopedSlots: {
-      customRender: 'formType'
-    }
+    width: '12%'
   },
   {
     title: '参数值',
-    dataIndex: 'content',
-    scopedSlots: {
-      customRender: 'formValue'
-    }
+    dataIndex: 'content'
   },
   {
     title: '操作',
     dataIndex: 'operation',
-    width: '10%',
-    scopedSlots: {
-      customRender: 'operation'
-    }
+    width: '10%'
   }
   ],
   debugUrlFormRequestHeader: [{
     title: '参数名称',
     dataIndex: 'name',
-    width: '20%',
-    scopedSlots: {
-      customRender: 'urlFormName'
-    }
+    width: '20%'
   },
   {
     title: '参数值',
-    dataIndex: 'content',
-    scopedSlots: {
-      customRender: 'urlFormValue'
-    }
+    dataIndex: 'content'
   },
   {
     title: '操作',
     dataIndex: 'operation',
-    width: '10%',
-    scopedSlots: {
-      customRender: 'operation'
-    }
+    width: '10%'
   }
   ],
   debugCacheApiId: 'Knife4jCacheApi'

--- a/knife4j-vue3/src/views/api/DataType.vue
+++ b/knife4j-vue3/src/views/api/DataType.vue
@@ -3,7 +3,7 @@
     <span v-if="!record.validateStatus">{{text==null||text==''?'string':text}}</span>
     <span v-else class="knife4j-request-validate-jsr">
       <a-tooltip placement="right">
-        <template slot="title">
+        <template #title>
           <div v-for="pt in validators" :key="pt.key">{{pt.val}}</div>
         </template>
         {{text}}

--- a/knife4j-vue3/src/views/api/DebugResponse.vue
+++ b/knife4j-vue3/src/views/api/DebugResponse.vue
@@ -2,7 +2,7 @@
   <a-row class="knife4j-debug-response">
     <a-row v-if="debugSend">
       <a-tabs defaultActiveKey="debugResponse">
-        <template slot="tabBarExtraContent">
+        <template #tabBarExtraContent>
           <a-row v-if="responseStatus" class="knife4j-debug-status">
             <span>
               <a-checkbox :defaultChecked="responseFieldDescriptionChecked" @change="showFieldDesChange"><span

--- a/knife4j-vue3/src/views/api/Document.vue
+++ b/knife4j-vue3/src/views/api/Document.vue
@@ -85,12 +85,14 @@
       <div class="api-title" v-html="$t('doc.response')"></div>
       <a-table :defaultExpandAllRows="expanRows" :columns="responseStatuscolumns" :dataSource="api.responseCodes"
         rowKey="code" size="small" :pagination="page">
-        <template slot="descriptionTemplate" slot-scope="text">
-          <div v-html="text"></div>
-        </template>
-        <template slot="schemaTemplate" slot-scope="text,record">
-          <span v-if="text != null" v-html="text"></span>
-          <span v-else-if="record.schemaTitle != null" v-html="record.schemaTitle"></span>
+        <template #bodyCell="{ column, text, record }">
+          <template v-if="column.dataIndex === 'description'">
+            <div v-html="text"></div>
+          </template>
+          <template v-else-if="column.dataIndex === 'schema'">
+            <span v-if="text != null" v-html="text"></span>
+            <span v-else-if="record.schemaTitle != null" v-html="record.schemaTitle"></span>
+          </template>
         </template>
       </a-table>
     </div>
@@ -110,8 +112,10 @@
           <div class="api-title" v-html="$t('doc.responseParams')"></div>
           <a-table :defaultExpandAllRows="expanRows" :columns="responseParametersColumns" :dataSource="resp.data"
             rowKey="id" size="small" :pagination="page">
-            <template slot="descriptionTemplate" slot-scope="text">
-              <span v-html="text"></span>
+            <template #bodyCell="{ column, text }">
+              <template v-if="column.dataIndex === 'description'">
+                <span v-html="text"></span>
+              </template>
             </template>
           </a-table>
             <!-- 响应示例 -->
@@ -140,8 +144,10 @@
       <div class="api-title" v-html="$t('doc.responseParams')"></div>
        <a-table :defaultExpandAllRows="expanRows" :columns="responseParametersColumns" :dataSource="multipData.data"
          rowKey="id" size="small" :pagination="page">
-         <template slot="descriptionTemplate" slot-scope="text">
-           <span v-html="text"></span>
+         <template #bodyCell="{ column, text }">
+           <template v-if="column.dataIndex === 'description'">
+             <span v-html="text"></span>
+           </template>
          </template>
        </a-table>
        <div class="api-title" v-html="$t('doc.responseExample')">

--- a/knife4j-vue3/src/views/api/OnlineDocument.vue
+++ b/knife4j-vue3/src/views/api/OnlineDocument.vue
@@ -47,17 +47,17 @@
     </div>
     <a-table defaultExpandAllRows :columns="columns" :dataSource="reqParameters" :rowKey="genUnionTableKey" size="small"
       :pagination="page">
-      <template slot="requireTemplate" slot-scope="text">
-        <span v-if="text" style="color:red">{{ text.toLocaleString() }}</span>
-        <span v-else>{{ text.toLocaleString() }}</span>
-      </template>
-
-      <template slot="typeTemplate" slot-scope="text">
-        <span :class="'knife4j-request-' + text">{{ text }}</span>
-      </template>
-
-      <template slot="datatypeTemplate" slot-scope="text, record">
-        <data-type :text="text" :record="record"></data-type>
+      <template #bodyCell="{ column, text, record }">
+        <template v-if="column.dataIndex === 'require'">
+          <span v-if="text" style="color:red">{{ text.toLocaleString() }}</span>
+          <span v-else>{{ text.toLocaleString() }}</span>
+        </template>
+        <template v-else-if="column.dataIndex === 'in'">
+          <span :class="'knife4j-request-' + text">{{ text }}</span>
+        </template>
+        <template v-else-if="column.dataIndex === 'type'">
+          <data-type :text="text" :record="record"></data-type>
+        </template>
       </template>
     </a-table>
     <div class="api-title">
@@ -65,8 +65,10 @@
     </div>
     <a-table :defaultExpandAllRows="expanRows" :columns="responseStatuscolumns" :dataSource="api.responseCodes"
       rowKey="code" size="small" :pagination="page">
-      <template slot="descriptionTemplate" slot-scope="text">
-        <div v-html="text"></div>
+      <template #bodyCell="{ column, text }">
+        <template v-if="column.dataIndex === 'description'">
+          <div v-html="text"></div>
+        </template>
       </template>
     </a-table>
     <!--响应参数需要判断是否存在多个code-schema的情况-->
@@ -134,6 +136,7 @@
 <script>
 import KUtils from "@/core/utils";
 import Constants from "@/store/constants";
+import localStore from '@/store/local.js'
 import { VAceEditor } from 'vue3-ace-editor'
 import { defineAsyncComponent } from 'vue'
 /* import DataType from "./DataType";
@@ -153,17 +156,14 @@ const requestcolumns = [
   {
     title: "请求类型",
     dataIndex: "in",
-    scopedSlots: { customRender: "typeTemplate" }
   },
   {
     title: "是否必须",
-    dataIndex: "require",
-    scopedSlots: { customRender: "requireTemplate" }
+    dataIndex: "require"
   },
   {
     title: "数据类型",
-    dataIndex: "type",
-    scopedSlots: { customRender: "datatypeTemplate" }
+    dataIndex: "type"
   },
   {
     title: "schema",
@@ -182,7 +182,6 @@ const responseStatuscolumns = [
     title: "说明",
     dataIndex: "description",
     width: "55%",
-    scopedSlots: { customRender: "descriptionTemplate" }
   },
   {
     title: "schema",
@@ -358,7 +357,7 @@ export default {
     },
     storeCacheModels(val) {
       var key = Constants.globalTreeTableModelParams + this.api.instanceId;
-      this.$localStore.setItem(key, val);
+      localStore.setItem(key, val);
     },
     deepTreeTableSchemaModel(param, treeTableModel, rootParam) {
       var that = this;

--- a/knife4j-vue3/src/views/othermarkdown/index.vue
+++ b/knife4j-vue3/src/views/othermarkdown/index.vue
@@ -1,13 +1,43 @@
 <template>
-
+  <a-layout-content class="knife4j-body-content">
+    <a-row class="markdown-body editormd-preview-container">
+      <Markdown :source="content" />
+    </a-row>
+  </a-layout-content>
 </template>
-
 <script>
+import "@/assets/css/editormd.css";
+import KUtils from "@/core/utils";
+import localStore from "@/store/local.js";
+import Markdown from "@/components/Markdown/index.vue";
+
 export default {
-  name: "index"
-}
+  props: {
+    data: {
+      type: Object
+    }
+  },
+  components: {
+    Markdown
+  },
+  data() {
+    return {
+      content: ""
+    };
+  },
+  created() {
+    // 获取当前地址的id
+    var that = this;
+    var id = this.$route.params.id;
+    var key = this.data.instance.id + 'markdownFiles';
+    localStore.getItem(key).then(mdfileMap => {
+      if (KUtils.checkUndefined(mdfileMap)) {
+        var content = mdfileMap[id];
+        if (KUtils.strNotBlank(content)) {
+          that.content = content;
+        }
+      }
+    })
+  }
+};
 </script>
-
-<style scoped>
-
-</style>

--- a/knife4j-vue3/src/views/settings/GlobalParameters.vue
+++ b/knife4j-vue3/src/views/settings/GlobalParameters.vue
@@ -12,19 +12,21 @@
     <div class="globalparameters">
       <a-table :columns="columns" rowKey="pkid" size="small" :dataSource="globalParameters" :pagination="pagination"
                bordered>
-        <a-row slot="operation" slot-scope="text,record">
-          <a-button icon="delete" type="danger" @click="deleteParam(record)" style="margin-left:10px;"
-          >{{ $t('global.delete') }}</a-button>
-        </a-row>
-        <template slot="paramContentLabel" slot-scope="text,record">
-          <a-textarea @change="headerContentChange" :data-key="record.pkid" :defaultValue="text"
-                      :autoSize="{ minRows: 2, maxRows: 6 }" allowClear />
-        </template>
-        <template slot="paramTypeLable" slot-scope="text,record">
-          <a-select :defaultValue="text" @change="globalParamTypeChange">
-            <a-select-option :data-name="record.name" :data-key="record.pkid" value="header">header</a-select-option>
-            <a-select-option :data-name="record.name" :data-key="record.pkid" value="query">query</a-select-option>
-          </a-select>
+        <template #bodyCell="{ column, text, record }">
+          <template v-if="column.dataIndex === 'operation'">
+            <a-button icon="delete" type="danger" @click="deleteParam(record)" style="margin-left:10px;"
+            >{{ $t('global.delete') }}</a-button>
+          </template>
+          <template v-else-if="column.dataIndex === 'paramContentLabel'">
+            <a-textarea @change="headerContentChange" :data-key="record.pkid" :defaultValue="text"
+                        :autoSize="{ minRows: 2, maxRows: 6 }" allowClear />
+          </template>
+          <template v-else-if="column.dataIndex === 'paramTypeLable'">
+            <a-select :defaultValue="text" @change="globalParamTypeChange">
+              <a-select-option :data-name="record.name" :data-key="record.pkid" value="header">header</a-select-option>
+              <a-select-option :data-name="record.name" :data-key="record.pkid" value="query">query</a-select-option>
+            </a-select>
+          </template>
         </template>
       </a-table>
     </div>

--- a/knife4j-vue3/src/views/settings/SwaggerModels.vue
+++ b/knife4j-vue3/src/views/settings/SwaggerModels.vue
@@ -3,11 +3,13 @@
     <div class="swaggermododel">
       <a-collapse @change="modelChange">
         <a-collapse-panel v-for="model in modelNames" :header="model.name" :key="model.id" :class="model.modelClass()">
-          <a-table v-if="model.load" :columns="columns" :dataSource="model.data"
+          <a-table v-if="model.load" :defaultExpandAllRows="expanRows" :columns="columns" :dataSource="model.data"
                    :rowKey="(r) => r.id + r.name" size="middle" :pagination="page">
-<!--            <template #expandedRowRender="{ column, record }">-->
-<!--              {{ `column` + column}}-->
-<!--            </template>-->
+            <template #bodyCell="{ column, text }">
+              <template v-if="column.dataIndex === 'description'">
+                <span v-html="text"></span>
+              </template>
+            </template>
           </a-table>
         </a-collapse-panel>
       </a-collapse>


### PR DESCRIPTION
对齐 Vue3 前端与 Vue2 版本的功能差异,修复 Issue #184。变更包括: 1)插槽语法迁移(SubMenu/DataType/DebugResponse); 2)表格自定义列迁移至#bodyCell(GlobalParameters/OnlineDocument/Document); 3)SwaggerModels补齐defaultExpandAllRows+v-html; 4)新建Markdown组件+填充othermarkdown; 5)全面移除scopedSlots(zh/en/jp/constants/officeDocTemplate)。vite build通过,grep确认无残留。Closes #184