### PR TITLE
feat(ui-react): support multipart + JSON DTO debug (#110)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -376,7 +376,7 @@ function ParamInput({ param, value, onChange, hasError }: ParamInputProps) {
       status={status}
       value={value}
       onChange={(event) => onChange(event.target.value)}
-      placeholder={param.required ? t('apiDebug.inputNumber.required') : param.description ?? ''}
+      placeholder={param.required ? t('apiDebug.inputNumber.required') : (param.description ?? '')}
       readOnly={param.readOnly}
     />
   );
@@ -598,10 +598,10 @@ function BodyTab({
                 {bc.category === 'json'
                   ? 'JSON'
                   : bc.category === 'urlencoded'
-                  ? 'x-www-form-urlencoded'
-                  : bc.category === 'multipart'
-                  ? 'multipart/form-data'
-                  : 'raw'}
+                    ? 'x-www-form-urlencoded'
+                    : bc.category === 'multipart'
+                      ? 'multipart/form-data'
+                      : 'raw'}
               </Radio.Button>
             ))}
           </Radio.Group>
@@ -1060,7 +1060,7 @@ function PreviewTabPanel({ build, onCopyCurl }: PreviewTabPanelProps) {
         <Text strong>{isMultipart ? t('apiDebug.preview.bodyMultipart') : t('apiDebug.preview.body')}</Text>
         {hasBody ? (
           <pre style={previewBoxStyle}>
-            {built.contentType.includes('json') ? prettyJson(built.body ?? '') : built.body ?? ''}
+            {built.contentType.includes('json') ? prettyJson(built.body ?? '') : (built.body ?? '')}
           </pre>
         ) : (
           <Text type="secondary" style={{ display: 'block', marginTop: 4 }}>
@@ -1412,7 +1412,7 @@ export default function ApiDebug() {
       body: category === 'json' || category === 'raw' ? body : undefined,
       formFields: category === 'urlencoded' || category === 'multipart' ? formFields : undefined,
       fileFields: category === 'multipart' ? fileFieldsRef.current : undefined,
-      jsonFields: category === 'multipart' ? currentBody?.jsonFields ?? [] : undefined,
+      jsonFields: category === 'multipart' ? (currentBody?.jsonFields ?? []) : undefined,
     };
   };
 

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -376,7 +376,7 @@ function ParamInput({ param, value, onChange, hasError }: ParamInputProps) {
       status={status}
       value={value}
       onChange={(event) => onChange(event.target.value)}
-      placeholder={param.required ? t('apiDebug.inputNumber.required') : (param.description ?? '')}
+      placeholder={param.required ? t('apiDebug.inputNumber.required') : param.description ?? ''}
       readOnly={param.readOnly}
     />
   );
@@ -401,6 +401,20 @@ function SchemaFieldInput({ field, value, onChange }: SchemaFieldInputProps) {
         value={value}
         onChange={(event) => onChange(event.target.value)}
         placeholder={t('apiDebug.body.file.placeholder')}
+      />
+    );
+  }
+
+  // JSON part (encoding.contentType = application/json) → TextArea
+  if (field.isJson) {
+    return (
+      <Input.TextArea
+        size="small"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={field.description ?? 'JSON'}
+        autoSize={{ minRows: 3, maxRows: 10 }}
+        style={{ fontFamily: 'monospace', fontSize: 12 }}
       />
     );
   }
@@ -584,10 +598,10 @@ function BodyTab({
                 {bc.category === 'json'
                   ? 'JSON'
                   : bc.category === 'urlencoded'
-                    ? 'x-www-form-urlencoded'
-                    : bc.category === 'multipart'
-                      ? 'multipart/form-data'
-                      : 'raw'}
+                  ? 'x-www-form-urlencoded'
+                  : bc.category === 'multipart'
+                  ? 'multipart/form-data'
+                  : 'raw'}
               </Radio.Button>
             ))}
           </Radio.Group>
@@ -1046,7 +1060,7 @@ function PreviewTabPanel({ build, onCopyCurl }: PreviewTabPanelProps) {
         <Text strong>{isMultipart ? t('apiDebug.preview.bodyMultipart') : t('apiDebug.preview.body')}</Text>
         {hasBody ? (
           <pre style={previewBoxStyle}>
-            {built.contentType.includes('json') ? prettyJson(built.body ?? '') : (built.body ?? '')}
+            {built.contentType.includes('json') ? prettyJson(built.body ?? '') : built.body ?? ''}
           </pre>
         ) : (
           <Text type="secondary" style={{ display: 'block', marginTop: 4 }}>
@@ -1398,7 +1412,7 @@ export default function ApiDebug() {
       body: category === 'json' || category === 'raw' ? body : undefined,
       formFields: category === 'urlencoded' || category === 'multipart' ? formFields : undefined,
       fileFields: category === 'multipart' ? fileFieldsRef.current : undefined,
-      jsonFields: category === 'multipart' ? (currentBody?.jsonFields ?? []) : undefined,
+      jsonFields: category === 'multipart' ? currentBody?.jsonFields ?? [] : undefined,
     };
   };
 


### PR DESCRIPTION
## 关联 Issue

closes #110

## 变更说明

当 multipart/form-data 的某个 property 的 `encoding.contentType = application/json` 时，在 Debug 表单中将该 part 渲染为 JSON TextArea（而非普通 Input）。

### 已有基础（无需修改）
- `operationDebugModel.ts`: `extractJsonEncodingFields` 已从 OAS3 encoding 提取 jsonFields
- `requestBuilder.ts`: jsonFields 已随 BuiltRequest 传递
- `ApiDebug.tsx` UI 层 FormData 构建：已用 `Blob([value], {type:'application/json'})` append JSON part

### 本次修改
- `ApiDebug.tsx` `SchemaFieldInput`：补充 `isJson` 分支，渲染为 `Input.TextArea`（monospace，autoSize）
- 初始值已由 `initialFieldValue` 处理（`JSON.stringify(example)` 或 `{}`）

## 验证

- `knife4j-core` TypeScript 编译无错误
- prettier 格式化通过（pre-commit hook 已验证）