### PR TITLE
feat(vue3): align brand and logo with react version, closes #191

### DIFF
--- a/knife4j-vue3/doc.html
+++ b/knife4j-vue3/doc.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="/knife4j-next-mark.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title></title>
+    <title>Knife4j Next</title>
   </head>
   <body>
     <div id="app"></div>

--- a/knife4j-vue3/public/knife4j-next-logo.svg
+++ b/knife4j-vue3/public/knife4j-next-logo.svg
@@ -1,0 +1,6 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M17 4.5H31.5L41 14V35.5C41 39.642 37.642 43 33.5 43H17C12.858 43 9.5 39.642 9.5 35.5V12C9.5 7.858 12.858 4.5 17 4.5Z" fill="#F5FAFF" stroke="#D8EAFF" stroke-width="2.2"/>
+  <path d="M31.5 5V12C31.5 13.657 32.843 15 34.5 15H40.5" fill="#D9ECFF"/>
+  <path d="M31.5 5V12C31.5 13.657 32.843 15 34.5 15H40.5" stroke="#D8EAFF" stroke-width="2.2" stroke-linejoin="round"/>
+  <path d="M19 32V18.8L29.8 32V18.8" stroke="#2F8AF4" stroke-width="4.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/knife4j-vue3/public/knife4j-next-mark.svg
+++ b/knife4j-vue3/public/knife4j-next-mark.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M154 52H312L414 154V378C414 416.66 382.66 448 344 448H154C115.34 448 84 416.66 84 378V122C84 83.34 115.34 52 154 52Z" fill="#F5FAFF" stroke="#D8EAFF" stroke-width="18" stroke-linejoin="round"/>
+  <path d="M312 54V132C312 145.255 322.745 156 336 156H412" fill="#D9ECFF"/>
+  <path d="M312 54V132C312 145.255 322.745 156 336 156H412" stroke="#D8EAFF" stroke-width="18" stroke-linejoin="round"/>
+  <path d="M184 340V204L300 340V204" stroke="#2F8AF4" stroke-width="42" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/knife4j-vue3/src/components/GlobalFooter/index.vue
+++ b/knife4j-vue3/src/components/GlobalFooter/index.vue
@@ -5,7 +5,7 @@
     </a-row>
     <div style="text-align: center" v-else-if="settings.enableFooter">
       <div class="copyright">Apache License 2.0 | Copyright
-        <copyright-outlined /> 2019-<a target="_blank" href="https://gitee.com/xiaoym/knife4j">Knife4j</a>
+        <copyright-outlined /> 2019-2026 Knife4j Next Contributors
       </div>
     </div>
   </div>

--- a/knife4j-vue3/src/components/GlobalHeader/index.vue
+++ b/knife4j-vue3/src/components/GlobalHeader/index.vue
@@ -73,7 +73,7 @@ export default {
   props: {
     documentTitle: {
       type: String,
-      default: "Knife4j接口文档",
+      default: "Knife4j Next",
     },
     headerClass: {
       type: String,

--- a/knife4j-vue3/src/core/Knife4jAsync.js
+++ b/knife4j-vue3/src/core/Knife4jAsync.js
@@ -105,7 +105,7 @@ function SwaggerBootstrapUi(options) {
   this.menuData = null;
   this.store = options.store || {};
   this.localStore = options.localStore || {};
-  //  
+  //
   this.plus = options.plus;
   //  文档id
   this.docId = 'content';
@@ -144,7 +144,7 @@ function SwaggerBootstrapUi(options) {
     footerCustomContent: '',// 自定义footer内容
     enableSearch: true,// 是否显示搜索框
     enableOpenApi: true,// 是否显示OpenApi原始规范结构
-    enableHomeCustom: false,//  是否开启主页自定义配置，默认false 
+    enableHomeCustom: false,//  是否开启主页自定义配置，默认false
     homeCustomLocation: '',// 自定义主页的Markdown文档内容
     enableGroup: true,// 是否显示分组下拉框，默认true(即显示)，一般情况下，如果是单个分组的情况下，可以设置该属性为false，即不显示分组，那么也就不用选择了
 
@@ -415,8 +415,11 @@ SwaggerBootstrapUi.prototype.analysisSpringDocOpenApiGroupSuccess = function (da
   } else {
     // https://gitee.com/xiaoym/knife4j/issues/I5L440#note_12238431
     // 如果开发者没有创建bean对象，urls对象为空，取而代之的是直接返回url
+    // 当 swagger-config 只返回单个 url（没有 urls 数组）时，分组名称使用
+    // swagger-config 中的 name 字段；若后端也没有提供 name，则兜底为 'default'，
+    // 避免直接使用 url 作为 name 导致显示为 "-v3-api-docs" 之类被截断的值。
     newGroupData.push({
-      name: KUtils.getValue(groupData, 'url', 'default', true),
+      name: KUtils.getValue(groupData, 'name', 'default', true),
       url: KUtils.getValue(groupData, 'url', '', true),
       location: KUtils.getValue(groupData, 'url', '', true),
       swaggerVersion: '3.0.3'
@@ -2791,7 +2794,7 @@ SwaggerBootstrapUi.prototype.readSecurityContextSchemesCommon = function (securi
                           }
                       }
                   }
-              } 
+              }
           }
           */
           //OAS3 oauth2认证
@@ -3445,7 +3448,7 @@ SwaggerBootstrapUi.prototype.initApiInfoAsync = function (swpinfo) {
 
 /**
  * analysisAllOfOAS2 解析allOf OAS2
- * @param {*} allOf 
+ * @param {*} allOf
  * @returns {string} 返回新的模型名
  */
 SwaggerBootstrapUi.prototype.analysisAllOfOAS2 = function (allOf) {
@@ -3502,9 +3505,9 @@ SwaggerBootstrapUi.prototype.analysisAllOfOAS2 = function (allOf) {
   const patchPropertiesName = patchPropertiesNames.join(',');
   const newModelName = `${originalObjName}<${patchPropertiesName}>`;
   // 检查definitions是否已有
-  if (definitions[newModelName]) 
+  if (definitions[newModelName])
     return newModelName;
-  
+
   // 放入原始definitions
   definitions[newModelName] = originalObjCopy;
   // 放入difarrs对象中

--- a/knife4j-vue3/src/lang/en.js
+++ b/knife4j-vue3/src/lang/en.js
@@ -493,6 +493,10 @@ const langOptions = {
   script: {
     JSExample: 'JSExample',
     TSExample: 'TSExample',
+  },
+  app: {
+    brand: 'Knife4j Next',
+    footer: 'Apache License 2.0 | Copyright 2019-2026 Knife4j Next Contributors'
   }
 };
 

--- a/knife4j-vue3/src/lang/jp.js
+++ b/knife4j-vue3/src/lang/jp.js
@@ -484,6 +484,10 @@ const langOptions = {
   script: {
     JSExample: 'JSテンプレートの例',
     TSExample: 'TSテンプレートの例',
+  },
+  app: {
+    brand: 'Knife4j Next',
+    footer: 'Apache License 2.0 | Copyright 2019-2026 Knife4j Next Contributors'
   }
 }
 

--- a/knife4j-vue3/src/lang/zh.js
+++ b/knife4j-vue3/src/lang/zh.js
@@ -485,6 +485,10 @@ const langOptions = {
   script: {
     JSExample: 'JS模板示例',
     TSExample: 'TS模板示例',
+  },
+  app: {
+    brand: 'Knife4j Next',
+    footer: 'Apache License 2.0 | Copyright 2019-2026 Knife4j Next Contributors'
   }
 }
 

--- a/knife4j-vue3/src/layouts/BasicLayout.vue
+++ b/knife4j-vue3/src/layouts/BasicLayout.vue
@@ -4,17 +4,18 @@
       <a-layout-sider :trigger="null" collapsible :collapsed="state.collapsed" breakpoint="lg"
                       @collapse="handleMenuCollapse"
                       :width="state.menuWidth" class="sider" style="background: #1e282c;">
-        <div class="knife4j-logo-data" key="logo" v-if="!state.collapsed && settings.enableGroup">
-          <a to="/" style="float:left;">
-            <a-select show-search :value="defaultServiceOption" style="width: 300px" :options="serviceOptions"
-                      optionFilterProp="children" @change="serviceChange">
-            </a-select>
-          </a>
+        <!-- Brand: logo + product name, always visible -->
+        <div class="knife4j-brand">
+          <router-link to="/" style="display:flex;align-items:center;justify-content:center;gap:10px;text-decoration:none;">
+            <img :src="state.logo" alt="logo" style="width:28px;height:28px;"/>
+            <span v-if="!state.collapsed" class="knife4j-brand-title">{{ $t('app.brand') }}</span>
+          </router-link>
         </div>
-        <div class="knife4j-logo" key="logo" v-if="state.collapsed && settings.enableGroup">
-          <a to="/" style="float:left;" v-if="state.collapsed">
-            <img :src="state.logo" alt="logo"/>
-          </a>
+        <!-- Group switcher (only when expanded) -->
+        <div class="knife4j-group-select" v-if="!state.collapsed && settings.enableGroup">
+          <a-select show-search :value="defaultServiceOption" style="width: 100%" :options="serviceOptions"
+                    optionFilterProp="children" @change="serviceChange">
+          </a-select>
         </div>
         <div :class="settings.enableGroup ? 'knife4j-menu' : 'knife4j-menu-all'">
           <a-menu key="Menu" theme="dark" mode="inline" :collapsed="state.collapsed"

--- a/knife4j-vue3/src/layouts/BasicLayout.vue
+++ b/knife4j-vue3/src/layouts/BasicLayout.vue
@@ -49,7 +49,7 @@
 </template>
 <script setup>
 //import logo from "@/assets/logo.png";
-import logo from "@/core/logo.js";
+import logo from "/knife4j-next-mark.svg";
 import GlobalHeader from "@/components/GlobalHeader/index.vue";
 import GlobalFooter from "@/components/GlobalFooter/index.vue";
 import KUtils from "@/core/utils";
@@ -534,7 +534,7 @@ watch(() => MenuData.value, () => {
 watch(() => swaggerCurrentInstance.value, () => {
   let title = swaggerCurrentInstance.value.title
   if (!title) {
-    title = "Knife4j 接口文档";
+    title = "Knife4j Next";
   }
   state.documentTitle = title;
   window.document.title = title;

--- a/knife4j-vue3/src/style/knife4j.less
+++ b/knife4j-vue3/src/style/knife4j.less
@@ -180,59 +180,32 @@
 */
 
 
-.knife4j-logo {
-  height: 64px;
-  position: relative;
-  line-height: 64px;
-  padding-left: (@menu-collapsed-width - 32px) / 2;
-  transition: all 0.3s;
+.knife4j-brand {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 56px;
+  padding: 12px 16px;
+  color: #fff;
   background: @GlobalBackgroundColor;
-  overflow: hidden;
-
-  img {
-    display: inline-block;
-    vertical-align: middle;
-    height: 32px;
-  }
-
-  h1 {
-    color: white;
-    display: inline-block;
-    vertical-align: middle;
-    font-size: 20px;
-    margin: 0 0 0 12px;
-    font-family: "Myriad Pro", "Helvetica Neue", Arial, Helvetica,
-    sans-serif;
-    font-weight: 600;
-  }
+  white-space: nowrap;
+  transition: all 0.3s;
 }
 
+.ant-layout-sider-collapsed .knife4j-brand {
+  padding: 12px 0;
+}
 
-.knife4j-logo-data {
-  height: 64px;
-  position: relative;
-  line-height: 64px;
-  padding-left: (@menu-collapsed-width - 48px) / 2;
-  transition: all 0.3s;
+.knife4j-brand-title {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  color: #fff;
+}
+
+.knife4j-group-select {
+  padding: 0 8px 8px;
   background: @GlobalBackgroundColor;
-  overflow: hidden;
-
-  img {
-    display: inline-block;
-    vertical-align: middle;
-    height: 32px;
-  }
-
-  h1 {
-    color: white;
-    display: inline-block;
-    vertical-align: middle;
-    font-size: 20px;
-    margin: 0 0 0 12px;
-    font-family: "Myriad Pro", "Helvetica Neue", Arial, Helvetica,
-    sans-serif;
-    font-weight: 600;
-  }
 }
 
 


### PR DESCRIPTION
## 修复内容

### 1. 侧边栏品牌区域重构

**问题**: Vue3 版本左上角产品名和 logo 被遮挡，展开时无法看到品牌信息，折叠时 logo 偏移。

**修复**:
- 移除旧的 `knife4j-logo` 和 `knife4j-logo-data` 结构
- 新增 `knife4j-brand` 区域：展开时显示 logo + 产品名，折叠时仅显示居中 logo
- 新增 `knife4j-group-select` 区域：展开时独立显示分组下拉选择器
- 折叠状态下自动居中 logo（通过 `.ant-layout-sider-collapsed .knife4j-brand` 控制 padding）

### 2. 分组名称截断问题

**问题**: 当后端 `swagger-config` 没有返回 `urls` 数组时，分组名称被错误地从 `url` 字段获取，经过字符串替换后显示为 `-v3-api-docs` 之类的截断值。

**修复**: 在 `Knife4jAsync.js` 中，将 `name` 字段的取值从 `url` 改为 `name`，并以 `'default'` 作为兜底值。

## 关联 Issue

Closes #191

