### PR TITLE
fix(openhands): fix API field, add finish instruction, add host.docker.internal

### DIFF
--- a/.agent/prompts/reviewer.md
+++ b/.agent/prompts/reviewer.md
@@ -41,6 +41,8 @@ scope_drift:
 - drift or none
 recommendation:
 - approve | revise | block
+
+完成后，调用 finish 工具结束会话。不要等待用户回复。
 ```
 
 ## Coordinator 追加的审查分配

--- a/.agent/prompts/worker.md
+++ b/.agent/prompts/worker.md
@@ -46,6 +46,8 @@ risks:
 - risk or none
 follow_up:
 - item or none
+
+完成后，调用 finish 工具结束会话。不要等待用户回复。
 ```
 
 ## Coordinator 追加的任务分配

--- a/scripts/openhands/docker-compose.yml
+++ b/scripts/openhands/docker-compose.yml
@@ -11,4 +11,6 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       TG_BOT_TOKEN: ${TG_BOT_TOKEN}
       GH_TOKEN: ${GH_TOKEN}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped

--- a/scripts/openhands/trigger-task.sh
+++ b/scripts/openhands/trigger-task.sh
@@ -54,7 +54,7 @@ oh_get() {
 create_conversation() {
   local message="$1"
   local resp
-  resp="$(oh_post "/api/conversations" "$(jq -n --arg m "$message" '{"initial_message":$m}')")"
+  resp="$(oh_post "/api/conversations" "$(jq -n --arg m "$message" '{"initial_user_msg":$m}')")"
   echo "$resp" | jq -r '.conversation_id // empty'
 }
 


### PR DESCRIPTION
## 问题

OpenHands 1.6 集成有三个 bug 导致所有任务卡死：

1. trigger-task.sh 用了错误的 API 字段名 `initial_message`，正确是 `initial_user_msg`
2. worker/reviewer prompt 没有 finish 指令，agent 完成后不会自动退出，对话永远 RUNNING
3. docker-compose.yml 缺少 `extra_hosts: host.docker.internal:host-gateway`，Linux 上主容器无法连接 runtime 容器

## 修复

- trigger-task.sh: `initial_message` → `initial_user_msg`
- worker.md / reviewer.md: 末尾加 finish 工具调用指令
- docker-compose.yml: 加 `extra_hosts: host.docker.internal:host-gateway`

## 已验证

- OpenHands 重启后 `host.docker.internal` 解析正常
- 测试对话 60s 内从 STARTING 到 RUNNING（无 build 过程）
- config.toml 已手动加 `runtime_container_image` 跳过每次 rebuild（不在本 PR 内，已直接应用）