### PR TITLE
docs(agent): clarify OAS2 type fields in knife4j-ui-react (closes #218)

### DIFF
--- a/.agent/PROJECT.md
+++ b/.agent/PROJECT.md
@@ -47,6 +47,16 @@
 
 触碰这些边界必须停下来找维护者确认。
 
+### 关于 `knife4j-ui-react` 中已存在的 OAS2 类型字段
+
+`knife4j-front/knife4j-ui-react/src/types/swagger.ts` 目前保留了若干 OAS2 字段：`definitions`、`securityDefinitions`、`host`、`basePath`、`schemes`、`in: 'body'` 等。少数渲染代码也为这些字段写了回退分支（例如 `Home.tsx` 的 servers 回退、`ApiDoc.tsx` 的 `$ref` 双正则）。
+
+这些是 React UI 早期开发时遗留的**类型兼容**，**不构成对 OAS2 的功能承诺**：
+
+- 入口层 `knife4jClient.fetchGroups()` 只请求 `v3/api-docs/swagger-config` 和 `swagger-resources`，不会主动拉 `v2/api-docs`；真实 springfox 后端从未在 React UI 上跑过端到端回归。
+- 当前决议是**不主动清理也不主动扩展**这些字段：清理会触发连锁改动且无收益，扩展则属于上述硬约束禁止范围。
+- 任何"顺手让 React 也支持一下 OAS2"的改动（新增数据源、补 `v2/api-docs` fallback、加 OAS2 专有解析逻辑等）都按 OAS2 兼容层处理，需维护者明确批准。
+
 ## 主要区域
 
 ### `knife4j`


### PR DESCRIPTION
Closes #218

## 背景

2026-04-29 决议：`knife4j-ui-react` 不计划支持 OAS2；相关边界已写入 `.agent/PROJECT.md`（#216 / #217）。

但 React 代码里仍存在早期遗留的 OAS2 类型字段（`types/swagger.ts` 的 `definitions`、`securityDefinitions`、`host`、`basePath`、`schemes`、`in: 'body'`）和少量回退渲染分支（`Home.tsx` servers 回退、`ApiDoc.tsx` `$ref` 双正则）。这些字段容易被后来者误读为"项目计划支持 OAS2"，需要一条措辞澄清。

## 变更

`.agent/PROJECT.md` 在"不允许 Agent 自主推翻的边界"段之后**新增一段**「关于 `knife4j-ui-react` 中已存在的 OAS2 类型字段」：

- 明确这些字段是**类型兼容**，不是**功能承诺**
- 声明当前策略：**不主动清理也不主动扩展**
- 任何扩展 OAS2 运行时逻辑的改动都按 OAS2 兼容层处理，需维护者批准

不修改其他任何段落，diff 仅 +10 行。

## 验证

- 纯 `.agent/` 文档改动，无构建/运行时影响
- 人工 review diff 即可

## 关联

- 决议来源：#200（评论 2026-04-29）、#216 / #217
- 扫描记录：无 issue 关联 PR 扫描发现 #75 在 `types/swagger.ts` 中"顺手预留"OAS2 字段，这次澄清正是为此类遗留定义语义边界

