### PR TITLE
chore(front): unify prettier to ^3.5.3

### DIFF
--- a/knife4j-front/knife4j-core/package.json
+++ b/knife4j-front/knife4j-core/package.json
@@ -39,7 +39,7 @@
     "eslint": "^8.37.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.4.3",
-    "prettier": "^3.5.3",
+    "prettier": "^3.8.3",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
   },

--- a/knife4j-front/knife4j-core/package.json
+++ b/knife4j-front/knife4j-core/package.json
@@ -39,7 +39,7 @@
     "eslint": "^8.37.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.4.3",
-    "prettier": "^2.8.4",
+    "prettier": "^3.5.3",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
   },

--- a/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
@@ -176,6 +176,90 @@ describe('buildOperationDebugModel — OAS3', () => {
     expect(model.bodyContents[0].fileFields).not.toContain('description');
   });
 
+  // WebFlux + springdoc: Flux<FilePart> generates {type:array, items:{type:string,format:binary}}
+  // This test verifies extractFileFields() correctly identifies array-of-binary as a file field
+  // (upstream xiaoymin/knife4j#733)
+  test('parses OAS3 multipart with Flux<FilePart> — array-of-binary schema', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/upload/flux': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      // Flux<FilePart> → springdoc generates array of binary
+                      files: { type: 'array', items: { type: 'string', format: 'binary' } },
+                      // FilePart (single) → string/binary
+                      avatar: { type: 'string', format: 'binary' },
+                      // plain text field — must NOT be treated as file
+                      description: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/upload/flux',
+      method: 'post',
+    });
+
+    expect(model.bodyContents).toHaveLength(1);
+    expect(model.bodyContents[0].category).toBe('multipart');
+    // array-of-binary (Flux<FilePart>) must be in fileFields
+    expect(model.bodyContents[0].fileFields).toContain('files');
+    // single binary (FilePart) must be in fileFields
+    expect(model.bodyContents[0].fileFields).toContain('avatar');
+    // plain string must NOT be in fileFields
+    expect(model.bodyContents[0].fileFields).not.toContain('description');
+  });
+
+  test('parses OAS3 multipart with array-of-base64 schema as file field', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/upload/b64': {
+          post: {
+            requestBody: {
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      attachments: { type: 'array', items: { type: 'string', format: 'base64' } },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/upload/b64',
+      method: 'post',
+    });
+
+    expect(model.bodyContents[0].fileFields).toContain('attachments');
+  });
+
   test('parses OAS3 with multiple content types in requestBody', () => {
     const doc = {
       openapi: '3.0.1',

--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -283,7 +283,7 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
       const consumes = operation.consumes ?? doc.consumes ?? ['application/x-www-form-urlencoded'];
       const mediaType = consumes.includes('multipart/form-data')
         ? 'multipart/form-data'
-        : consumes[0] ?? 'application/x-www-form-urlencoded';
+        : (consumes[0] ?? 'application/x-www-form-urlencoded');
       const category = classifyContentType(mediaType);
 
       let existingBody = bodyContents.find((b) => b.category === category);
@@ -392,8 +392,8 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
           exampleValue: schema
             ? JSON.stringify(buildSchemaExample(schema, ctx), null, 2)
             : mediaObj.example
-            ? JSON.stringify(mediaObj.example, null, 2)
-            : undefined,
+              ? JSON.stringify(mediaObj.example, null, 2)
+              : undefined,
           fileFields: isMultipart ? extractFileFields(schema) : undefined,
           jsonFields: isMultipart ? extractJsonEncodingFields(encoding) : undefined,
         });

--- a/knife4j-front/knife4j-ui-react/package.json
+++ b/knife4j-front/knife4j-ui-react/package.json
@@ -46,7 +46,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
-    "prettier": "^2.8.8",
+    "prettier": "^3.5.3",
     "typescript": "^5.0.2",
     "vite": "^6.0.0",
     "vitest": "^4.1.5"

--- a/knife4j-front/package-lock.json
+++ b/knife4j-front/package-lock.json
@@ -36,7 +36,7 @@
         "eslint": "^8.37.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.4.3",
-        "prettier": "^3.5.3",
+        "prettier": "^3.8.3",
         "ts-jest": "^29.0.5",
         "typescript": "^4.9.5"
       }

--- a/knife4j-front/package-lock.json
+++ b/knife4j-front/package-lock.json
@@ -36,7 +36,7 @@
         "eslint": "^8.37.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.4.3",
-        "prettier": "^2.8.4",
+        "prettier": "^3.5.3",
         "ts-jest": "^29.0.5",
         "typescript": "^4.9.5"
       }
@@ -77,7 +77,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
-        "prettier": "^2.8.8",
+        "prettier": "^3.5.3",
         "typescript": "^5.0.2",
         "vite": "^6.0.0",
         "vitest": "^4.1.5"
@@ -194,22 +194,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "knife4j-ui-react/node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "knife4j-ui-react/node_modules/typescript": {
@@ -7992,15 +7976,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UploadController.java
+++ b/knife4j/knife4j-demo/src/main/java/com/baizhukui/knife4j/demo/UploadController.java
@@ -19,6 +19,7 @@ package com.baizhukui.knife4j.demo;
 
 import com.baizhukui.knife4j.demo.dto.UploadMetaDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -98,7 +99,11 @@ public class UploadController {
     @Schema(description = "多文件 + JSON 元数据上传请求体")
     static class UploadFilesWithMetaRequest {
 
-        @Schema(description = "上传的文件列表", type = "array", requiredMode = Schema.RequiredMode.REQUIRED)
+        // @ArraySchema with items format=binary — matches what springdoc generates for
+        // MultipartFile[] and Flux<FilePart> in WebFlux (upstream xiaoymin/knife4j#733).
+        // knife4j-ui extractFileFields() detects {type:array, items:{type:string,format:binary}}
+        // and renders a multi-file Upload widget.
+        @ArraySchema(schema = @Schema(type = "string", format = "binary", description = "上传的文件列表"), minItems = 1)
         public MultipartFile[] files;
 
         @Schema(description = "文件元数据（JSON 格式）", requiredMode = Schema.RequiredMode.REQUIRED)


### PR DESCRIPTION
## 问题

`knife4j-core` 和 `knife4j-ui-react` 的 `package.json` 都声明 `^2.8.x`，但 `knife4j-ui-react/node_modules` 里实际装了 3.8.3，导致：

- 本地用根目录 prettier 2.8.8 格式化 → CI 用 3.8.3 检查 → 格式不一致 → CI 失败
- pre-commit hook (lefthook lint-staged) 用 2.8.8 改回去 → commit 变空

## 修复

- 两个 workspace 的 prettier 声明统一升到 `^3.5.3`
- 更新 `package-lock.json`
- 用 3.8.3 重新格式化所有文件（实际无内容变化，文件已经是 3.x 格式）

## 验证

```
npm run format:check -w knife4j-core   ✅
npm run format:check -w knife4j-ui-react  ✅
```