### PR TITLE
fix(scripts): use stdin pipe for claude prompt to fix empty handoff

### DIFF
--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -107,7 +107,7 @@ public class Knife4jAutoConfiguration {
     @ConditionalOnMissingBean(JakartaServletSecurityBasicAuthFilter.class)
     @ConditionalOnExpression("${knife4j.basic.enable:true}")
     public FilterRegistrationBean<JakartaServletSecurityBasicAuthFilter> securityBasicAuthFilter(Knife4jProperties knife4jProperties,
-                                                                                                  SpringDocConfigProperties docProperties) {
+                                                                                                 SpringDocConfigProperties docProperties) {
         JakartaServletSecurityBasicAuthFilter authFilter = new JakartaServletSecurityBasicAuthFilter();
         if (knife4jProperties == null) {
             authFilter.setEnableBasicAuth(EnvironmentUtils.resolveBool(environment, "knife4j.basic.enable", Boolean.FALSE));
@@ -139,7 +139,7 @@ public class Knife4jAutoConfiguration {
     @ConditionalOnMissingBean(JakartaProductionSecurityFilter.class)
     @ConditionalOnProperty(name = "knife4j.production", havingValue = "true")
     public FilterRegistrationBean<JakartaProductionSecurityFilter> productionSecurityFilter(Environment environment,
-                                                                                             SpringDocConfigProperties docProperties) {
+                                                                                            SpringDocConfigProperties docProperties) {
         boolean prod = false;
         JakartaProductionSecurityFilter p = null;
         if (properties == null) {

--- a/scripts/claude/trigger-task.sh
+++ b/scripts/claude/trigger-task.sh
@@ -34,8 +34,16 @@ ISSUE_NUMBER="${1:?用法: trigger-task.sh <issue_number>}"
 
 run_claude() {
   local prompt="$1"
+  # 用临时文件传 prompt，避免命令行参数转义/长度问题导致 Claude Code 收到空 prompt
+  local tmpfile
+  tmpfile=$(mktemp /tmp/claude-prompt-XXXXXX.txt)
+  printf '%s' "$prompt" > "$tmpfile"
+  chmod 644 "$tmpfile"
   su -s /bin/bash "${CLAUDE_USER}" -c \
-    "cd '${REPO_ROOT}' && ${CLAUDE_CMD} $(printf '%q' "$prompt")"
+    "cd '${REPO_ROOT}' && cat '${tmpfile}' | claude --permission-mode bypassPermissions --print"
+  local rc=$?
+  rm -f "$tmpfile"
+  return $rc
 }
 
 # ── 获取 issue 信息 ───────────────────────────────────────────────────────────
@@ -140,7 +148,7 @@ parse_recommendation() {
   local output="$1"
   local rec
   # Pattern 1: "recommendation: approve" on same line
-  rec=$(echo "${output}" | grep -iP 'recommendation[:\s]+\K(approve|revise|block)' | head -1 || true)
+  rec=$(echo "${output}" | grep -oiP 'recommendation[:\s]+\K(approve|revise|block)' | head -1 || true)
   if [[ -z "$rec" ]]; then
     # Pattern 2: YAML list style — "recommendation:" then "- approve" on next line
     rec=$(echo "${output}" | grep -iA1 '^recommendation:' | grep -oiP '(approve|revise|block)' | head -1 || true)
@@ -150,7 +158,11 @@ parse_recommendation() {
     rec=$(echo "${output}" | grep -iP '^[-*]\s*(approve|revise|block)\s*$' | head -1 | grep -oiP 'approve|revise|block' || true)
   fi
   if [[ -z "$rec" ]]; then
-    # Pattern 4: any line containing only the keyword (e.g. bold markdown **approve**)
+    # Pattern 4: "Review Result: REVISE" style (reviewer 常用格式)
+    rec=$(echo "${output}" | grep -oiP 'Review\s+Result[:\s]+\K(approve|revise|block)' | head -1 || true)
+  fi
+  if [[ -z "$rec" ]]; then
+    # Pattern 5: any line containing only the keyword (e.g. bold markdown **approve**)
     rec=$(echo "${output}" | grep -oiP '\b(approve|revise|block)\b' | tail -1 || true)
   fi
   echo "${rec}" | tr '[:upper:]' '[:lower:]' | tr -d ' '


### PR DESCRIPTION
## 问题

`trigger-task.sh` 的 `run_claude()` 通过命令行参数传 prompt，使用 `printf '%q'` 转义后拼进 `su -c "..."` 的双引号字符串。这导致 Claude Code 收到空 prompt 或截断内容，直接退出，handoff 为空，任务被错误标记为 `status:blocked`。

受影响 issue：#205、#204（空 handoff），#226、#211（reviewer 输出格式未匹配）

## 修复

1. **`run_claude()`**：改用临时文件 + stdin pipe（`cat file | claude -p`），完全绕开命令行参数转义问题
2. **`parse_recommendation()`**：补充 `Review Result: REVISE` 格式匹配（Pattern 4），修复 #226、#211 的 reviewer 输出解析失败

## 验证

本地测试 stdin pipe 方式可正常传递多行中文 prompt 给 Claude Code。