### PR TITLE
[P1] React UI: API 详情页 Script Tab（代码生成）, closes #207

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -93,12 +93,20 @@ const enUS = {
   'operation.tab.doc': 'Doc',
   'operation.tab.debug': 'Debug',
   'operation.tab.openapi': 'OpenAPI',
+  'operation.tab.script': 'Script',
 
   // ApiOpenApi (ISSUE-206)
   'apiOpenApi.notFound.title': 'API doc not found',
   'apiOpenApi.notFound.desc': 'No OpenAPI operation matched the current route. Please reopen from the left API list.',
   'apiOpenApi.copied': 'OpenAPI JSON copied',
   'apiOpenApi.noData': 'No OpenAPI data available for this operation',
+
+  // ApiScript (ISSUE-207)
+  'apiScript.notFound.title': 'API doc not found',
+  'apiScript.notFound.desc': 'No OpenAPI operation matched the current route. Please reopen from the left API list.',
+  'apiScript.title': 'Code Generation',
+  'apiScript.copied': 'Code copied',
+  'apiScript.noCode': 'No code can be generated for this operation',
 
   // ApiDebug
   'apiDebug.notFound.title': 'Debug interface not found',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -93,12 +93,20 @@ const zhCN = {
   'operation.tab.doc': '文档',
   'operation.tab.debug': '调试',
   'operation.tab.openapi': 'OpenAPI',
+  'operation.tab.script': '代码',
 
   // ApiOpenApi (ISSUE-206)
   'apiOpenApi.notFound.title': '未找到接口文档',
   'apiOpenApi.notFound.desc': '当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。',
   'apiOpenApi.copied': 'OpenAPI JSON 已复制',
   'apiOpenApi.noData': '当前接口暂无 OpenAPI 数据',
+
+  // ApiScript (ISSUE-207)
+  'apiScript.notFound.title': '未找到接口文档',
+  'apiScript.notFound.desc': '当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。',
+  'apiScript.title': '代码生成',
+  'apiScript.copied': '代码已复制',
+  'apiScript.noCode': '当前接口暂无可生成的代码',
 
   // ApiDebug
   'apiDebug.notFound.title': '未找到调试接口',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
@@ -1,0 +1,336 @@
+import { useMemo, useState } from 'react';
+import { Alert, Radio, Space, Spin, Typography, message } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { useCurrentOperation } from './useCurrentOperation';
+import { OperationModeTabs } from './useCurrentOperation';
+import CodeBlock from './CodeBlock';
+import { copyToClipboard } from '../../utils/clipboard';
+import type { ParameterObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
+
+const { Title } = Typography;
+
+// ---------------------------------------------------------------------------
+// OAS3-aware code generator (pure TypeScript, no AST library needed)
+// ---------------------------------------------------------------------------
+
+type Lang = 'js' | 'ts';
+
+interface ParamInfo {
+  name: string;
+  in: 'path' | 'query' | 'header' | 'cookie' | 'body' | 'formData' | string;
+  required?: boolean;
+  schema?: SchemaObject;
+  description?: string;
+}
+
+function resolveSchema(
+  schema: SchemaObject | undefined,
+  doc: Pick<SwaggerDoc, 'components' | 'definitions'>,
+  depth = 0,
+): SchemaObject | undefined {
+  if (!schema || depth > 8) return schema;
+  if (schema.$ref) {
+    const match = schema.$ref.match(/^#\/components\/schemas\/(.+)$/) ?? schema.$ref.match(/^#\/definitions\/(.+)$/);
+    if (match) {
+      const resolved = (doc.components?.schemas ?? doc.definitions ?? {})[match[1]];
+      return resolveSchema(resolved, doc, depth + 1);
+    }
+  }
+  return schema;
+}
+
+function schemaToTsType(
+  schema: SchemaObject | undefined,
+  doc: Pick<SwaggerDoc, 'components' | 'definitions'>,
+  depth = 0,
+): string {
+  if (!schema || depth > 6) return 'unknown';
+  const resolved = resolveSchema(schema, doc, 0);
+  if (!resolved) return 'unknown';
+
+  if (resolved.$ref) {
+    const name = resolved.$ref.split('/').pop();
+    return name ?? 'unknown';
+  }
+
+  const type = resolved.type;
+  if (type === 'string') return resolved.format === 'date-time' ? 'string /* date-time */' : 'string';
+  if (type === 'integer' || type === 'number') return 'number';
+  if (type === 'boolean') return 'boolean';
+  if (type === 'array') {
+    const itemType = schemaToTsType(resolved.items, doc, depth + 1);
+    return `${itemType}[]`;
+  }
+  if (type === 'object' || resolved.properties) {
+    if (!resolved.properties) return 'Record<string, unknown>';
+    const props = Object.entries(resolved.properties)
+      .map(([k, v]) => {
+        const required = Array.isArray(resolved.required) && resolved.required.includes(k);
+        return `  ${k}${required ? '' : '?'}: ${schemaToTsType(v, doc, depth + 1)};`;
+      })
+      .join('\n');
+    return `{\n${props}\n}`;
+  }
+  return 'unknown';
+}
+
+function upperFirst(str: string): string {
+  if (!str) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/** Derive a camelCase function name from operationId or method+path */
+function deriveFunctionName(operationId: string | undefined, method: string, path: string): string {
+  if (operationId) {
+    // strip common suffixes like "UsingGET", "UsingPOST"
+    return operationId.replace(/Using(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)(_\d+)?$/i, '');
+  }
+  // fallback: methodPathSegments
+  const segments = path
+    .split('/')
+    .filter(Boolean)
+    .map((s) => s.replace(/[{}]/g, '').replace(/[^a-zA-Z0-9]/g, '_'))
+    .filter(Boolean);
+  return method.toLowerCase() + segments.map(upperFirst).join('');
+}
+
+/** Build a template-literal URL string for JS/TS */
+function buildUrlExpression(path: string, pathParams: ParamInfo[]): string {
+  if (pathParams.length === 0) return `'${path}'`;
+  // replace {param} with ${param}
+  const tpl = path.replace(/\{([^}]+)\}/g, '${$1}');
+  return `\`${tpl}\``;
+}
+
+interface GeneratedCode {
+  js: string;
+  ts: string;
+}
+
+function generateCode(
+  method: string,
+  path: string,
+  operationId: string | undefined,
+  summary: string | undefined,
+  parameters: ParameterObject[],
+  requestBodySchema: SchemaObject | undefined,
+  responseSchema: SchemaObject | undefined,
+  doc: SwaggerDoc,
+): GeneratedCode {
+  const fnName = deriveFunctionName(operationId, method, path);
+  const interfaceName = upperFirst(fnName);
+
+  const pathParams = parameters.filter((p) => p.in === 'path');
+  const queryParams = parameters.filter((p) => p.in === 'query');
+  const hasBody = !!requestBodySchema;
+
+  // ---- JS ----
+  const jsParamList: string[] = [
+    ...pathParams.map((p) => p.name),
+    ...queryParams.map((p) => p.name),
+    ...(hasBody ? ['params'] : []),
+  ];
+
+  const jsQueryStr =
+    queryParams.length > 0 ? `\n  const query = { ${queryParams.map((p) => p.name).join(', ')} };` : '';
+
+  const jsRequestArgs: string[] = [buildUrlExpression(path, pathParams)];
+  if (queryParams.length > 0) jsRequestArgs.push('query');
+  if (hasBody) jsRequestArgs.push('params');
+
+  const jsComment = [
+    `/**`,
+    ` * ${summary ?? fnName}`,
+    ...pathParams.map((p) => ` * @param {string} ${p.name} ${p.description ?? ''}`),
+    ...queryParams.map((p) => ` * @param {string} ${p.name} ${p.description ?? ''}`),
+    ...(hasBody ? [` * @param {object} params request body`] : []),
+    ` * @returns {Promise}`,
+    ` */`,
+  ].join('\n');
+
+  const jsBody = [
+    jsComment,
+    `export function ${fnName}(${jsParamList.join(', ')}) {${jsQueryStr}`,
+    `  return request.${method.toLowerCase()}(${jsRequestArgs.join(', ')});`,
+    `}`,
+  ].join('\n');
+
+  // ---- TS interfaces ----
+  let tsParamsInterface = '';
+  if (hasBody && requestBodySchema) {
+    const resolved = resolveSchema(requestBodySchema, doc);
+    if (resolved?.type === 'object' || resolved?.properties) {
+      const props = Object.entries(resolved?.properties ?? {})
+        .map(([k, v]) => {
+          const req = Array.isArray(resolved?.required) && resolved.required.includes(k);
+          return `  ${k}${req ? '' : '?'}: ${schemaToTsType(v, doc)};`;
+        })
+        .join('\n');
+      tsParamsInterface = `// 请求参数接口\nexport interface ${interfaceName}Params {\n${props}\n}\n\n`;
+    } else if (resolved?.type === 'array') {
+      tsParamsInterface = `// 请求参数类型\nexport type ${interfaceName}Params = ${schemaToTsType(resolved, doc)};\n\n`;
+    }
+  }
+
+  let tsResInterface = '';
+  if (responseSchema) {
+    const resolved = resolveSchema(responseSchema, doc);
+    if (resolved?.type === 'object' || resolved?.properties) {
+      const props = Object.entries(resolved?.properties ?? {})
+        .map(([k, v]) => {
+          const req = Array.isArray(resolved?.required) && resolved.required.includes(k);
+          return `  ${k}${req ? '' : '?'}: ${schemaToTsType(v, doc)};`;
+        })
+        .join('\n');
+      tsResInterface = `// 响应接口\nexport interface ${interfaceName}Res {\n${props}\n}\n\n`;
+    } else if (resolved?.type === 'array') {
+      tsResInterface = `// 响应类型\nexport type ${interfaceName}Res = ${schemaToTsType(resolved, doc)};\n\n`;
+    }
+  }
+
+  // TS function params with type annotations
+  const tsParamList: string[] = [
+    ...pathParams.map((p) => `${p.name}: string`),
+    ...queryParams.map((p) => {
+      const t = schemaToTsType(p.schema, doc);
+      return `${p.name}${p.required ? '' : '?'}: ${t}`;
+    }),
+    ...(hasBody ? [`params: ${tsParamsInterface ? `${interfaceName}Params` : 'Record<string, unknown>'}`] : []),
+  ];
+
+  const resType = tsResInterface ? `${interfaceName}Res` : 'unknown';
+  const tsQueryStr =
+    queryParams.length > 0
+      ? `\n  const query: Record<string, unknown> = { ${queryParams.map((p) => p.name).join(', ')} };`
+      : '';
+
+  const tsComment = [
+    `/**`,
+    ` * ${summary ?? fnName}`,
+    ...pathParams.map((p) => ` * @param ${p.name} ${p.description ?? ''}`),
+    ...queryParams.map((p) => ` * @param ${p.name} ${p.description ?? ''}`),
+    ...(hasBody ? [` * @param params request body`] : []),
+    ` * @returns Promise<${resType}>`,
+    ` */`,
+  ].join('\n');
+
+  const tsBody = [
+    tsParamsInterface + tsResInterface + tsComment,
+    `export function ${fnName}(${tsParamList.join(', ')}): Promise<${resType}> {${tsQueryStr}`,
+    `  return request.${method.toLowerCase()}(${jsRequestArgs.join(', ')});`,
+    `}`,
+  ].join('\n');
+
+  return { js: jsBody, ts: tsBody };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function ScriptView() {
+  const { t } = useTranslation();
+  const { loading, swaggerDoc, operation } = useCurrentOperation();
+  const [lang, setLang] = useState<Lang>('ts');
+
+  const code = useMemo(() => {
+    if (!swaggerDoc || !operation) return null;
+    const op = operation.operation;
+    const method = operation.method.toUpperCase();
+
+    const parameters: ParameterObject[] = (op.parameters ?? []) as ParameterObject[];
+
+    // resolve request body schema
+    let requestBodySchema: SchemaObject | undefined;
+    if (op.requestBody?.content) {
+      requestBodySchema =
+        op.requestBody.content['application/json']?.schema ?? Object.values(op.requestBody.content)[0]?.schema;
+    } else {
+      // OAS2 body parameter
+      const bodyParam = parameters.find((p) => p.in === 'body');
+      requestBodySchema = bodyParam?.schema;
+    }
+
+    // resolve first 2xx response schema
+    let responseSchema: SchemaObject | undefined;
+    const responses = op.responses ?? {};
+    const successCode = Object.keys(responses).find((k) => k.startsWith('2')) ?? Object.keys(responses)[0];
+    if (successCode) {
+      const resp = responses[successCode];
+      responseSchema =
+        resp.content?.['application/json']?.schema ??
+        resp.schema ??
+        (resp.content ? Object.values(resp.content)[0]?.schema : undefined);
+    }
+
+    try {
+      return generateCode(
+        method,
+        operation.path,
+        op.operationId,
+        op.summary,
+        parameters,
+        requestBodySchema,
+        responseSchema,
+        swaggerDoc,
+      );
+    } catch {
+      return null;
+    }
+  }, [swaggerDoc, operation]);
+
+  if (loading) {
+    return <Spin style={{ display: 'block', margin: '80px auto' }} />;
+  }
+
+  if (!swaggerDoc || !operation) {
+    return (
+      <Alert
+        type="warning"
+        showIcon
+        message={t('apiScript.notFound.title')}
+        description={t('apiScript.notFound.desc')}
+      />
+    );
+  }
+
+  const currentCode = lang === 'js' ? code?.js : code?.ts;
+
+  const handleCopy = () => {
+    if (!currentCode) return;
+    copyToClipboard(
+      currentCode,
+      () => message.success(t('apiScript.copied')),
+      () => message.error(t('apiDoc.copy.failed')),
+    );
+  };
+
+  return (
+    <div style={{ padding: '0 24px 24px', maxWidth: 1080 }}>
+      <OperationModeTabs activeKey="script" />
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+        <Title level={5} style={{ margin: 0 }}>
+          {t('apiScript.title')}
+        </Title>
+        <Space>
+          <Radio.Group value={lang} onChange={(e) => setLang(e.target.value as Lang)} size="small">
+            <Radio.Button value="ts">TypeScript</Radio.Button>
+            <Radio.Button value="js">JavaScript</Radio.Button>
+          </Radio.Group>
+        </Space>
+      </div>
+
+      {code ? (
+        <CodeBlock
+          code={currentCode ?? ''}
+          language={lang === 'ts' ? 'typescript' : 'javascript'}
+          maxHeight={600}
+          onCopy={handleCopy}
+        />
+      ) : (
+        <Alert type="info" showIcon message={t('apiScript.noCode')} />
+      )}
+    </div>
+  );
+}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
@@ -37,7 +37,7 @@ export function useCurrentOperation(): CurrentOperation {
 }
 
 interface OperationModeTabsProps {
-  activeKey: 'doc' | 'debug' | 'openapi';
+  activeKey: 'doc' | 'debug' | 'openapi' | 'script';
 }
 
 export function OperationModeTabs({ activeKey }: OperationModeTabsProps) {
@@ -56,6 +56,7 @@ export function OperationModeTabs({ activeKey }: OperationModeTabsProps) {
         { key: 'doc', label: t('operation.tab.doc') },
         { key: 'debug', label: t('operation.tab.debug') },
         { key: 'openapi', label: t('operation.tab.openapi') },
+        { key: 'script', label: t('operation.tab.script') },
       ]}
     />
   );

--- a/knife4j-front/knife4j-ui-react/src/routes/router.tsx
+++ b/knife4j-front/knife4j-ui-react/src/routes/router.tsx
@@ -12,6 +12,7 @@ import ApiHome from '../pages/api/ApiHome.tsx';
 import ApiDoc from '../pages/api/ApiDoc.tsx';
 import ApiDebug from '../pages/api/ApiDebug.tsx';
 import OpenApiView from '../pages/api/OpenApiView.tsx';
+import ScriptView from '../pages/api/ScriptView.tsx';
 
 const router = createHashRouter([
   {
@@ -65,6 +66,10 @@ const router = createHashRouter([
       {
         path: ':group/:tag/:operaterId/openapi',
         element: <OpenApiView />,
+      },
+      {
+        path: ':group/:tag/:operaterId/script',
+        element: <ScriptView />,
       },
     ],
   },


### PR DESCRIPTION
Closes #207

## Worker Handoff

```
---

```
task: issue-207
scope: knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx (new),
       knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx,
       knife4j-front/knife4j-ui-react/src/routes/router.tsx,
       knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts,
       knife4j-front/knife4j-ui-react/src/locales/en-US.ts
changed_files:
- knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
- knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
- knife4j-front/knife4j-ui-react/src/routes/router.tsx
- knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
- knife4j-front/knife4j-ui-react/src/locales/en-US.ts
summary:
- ScriptView.tsx (336 lines): OAS3-native code generator (no AST deps). Resolves $ref chains, derives function name from operationId (strips UsingGET/POST suffixes), builds path/query params, request body schema, and first 2xx response schema. Generates JS (JSDoc comments + request.method() call) and TS (typed interfaces + typed function signature). Radio.Group toggles JS/TS; CodeBlock renders with copy button.
- useCurrentOperation.tsx: OperationModeTabs activeKey union extended to include 'script'; 'script' tab item added to Tabs items array.
- router.tsx: added :group/:tag/:operaterId/script route pointing to ScriptView.
- i18n: added operation.tab.script, apiScript.notFound.title/desc, apiScript.title, apiScript.copied, apiScript.noCode keys in both zh-CN and en-US.
validation:
- command: "cd /tmp/knife4j-211/knife4j-front/knife4j-ui-react && npm run build"
  result: "✓ 3377 modules transformed. Built in 19.57s — success (note: run from knife4j-211 worktree which has writable node_modules; the worktree-issue-207 files are root-owned and node_modules absent)"
risks:
- The worktree at /tmp/worktree-issue-207 has root-owned files; the commit was created via git plumbing (write-tree + commit-tree + update-ref) rather than a normal git commit. The commit object is correct and the branch ref points to it, but the worktree working tree and index still show the old state (they will be correct after a git checkout or reset by the coordinator).
- Build was validated in /tmp/knife4j-211 (a claude-worker-owned copy of the repo with node_modules) rather than the worktree itself, because the worktree lacks node_modules and its directories are root-owned.
follow_up:
- Consider adding syntax highlighting (e.g. highlight.js or prism) to CodeBlock for JS/TS output — currently CodeBlock renders plain text.
- The generated code uses a generic `request` object; a follow-up could add an import statement or a configurable base URL comment at the top of the generated code.
- Prettier was not run on ScriptView.tsx before commit (worktree files are root-owned); coordinator should run prettier on the committed files if needed.
```
```

## Reviewer Findings

```
[2026-05-01T07:12:51Z] [INFO] 推送 branch agent/issue-207-1777618937 到远端供 reviewer 使用...
remote: 
remote: Create a pull request for 'agent/issue-207-1777618937' on GitHub by visiting:        
remote:      https://github.com/songxychn/knife4j-next/pull/new/agent/issue-207-1777618937        
remote: 
To github-knife4j-next:songxychn/knife4j-next.git
 * [new branch]        agent/issue-207-1777618937 -> agent/issue-207-1777618937
branch 'agent/issue-207-1777618937' set up to track 'origin/agent/issue-207-1777618937'.
I have all the information needed. Here is the review:

---

```
task: issue-207
reviewed_scope:
  - knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx (new, 336 lines)
  - knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
  - knife4j-front/knife4j-ui-react/src/routes/router.tsx
  - knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
  - knife4j-front/knife4j-ui-react/src/locales/en-US.ts

findings:
  - severity: MEDIUM
    file: knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
    line: 48, 161, 166, 171, 177, 182, 187, 195
    explanation: >
      `schemaToTsType` resets depth to 0 when it calls `resolveSchema(schema, doc, 0)` (line 48),
      and the inline property-expansion calls in `generateCode()` (lines 166, 171, 182, 187, 195)
      pass no depth argument (defaults to 0). This means a deeply nested or self-referential schema
      can re-enter the full recursion budget on every property expansion, effectively bypassing the
      depth guard. For a circular schema (A → B → A) the guard in `resolveSchema` (depth > 8) will
      catch the $ref chain, but `schemaToTsType` itself can still recurse unboundedly through
      `properties` because each call restarts at depth 0. In practice this is unlikely to cause a
      hang (the catch block in `useMemo` swallows exceptions), but it can produce very large strings
      for deeply nested schemas before the guard fires.

  - severity: LOW
    file: knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
    line: 313
    explanation: >
      `handleCopy` uses `t('apiDoc.copy.failed')` for the error callback. The key exists in both
      locale files and is shared with ApiDoc, so there is no missing-key risk. However, the pattern
      is inconsistent with the component-specific `apiScript.*` namespace used for all other strings
      in this component. This is a minor style inconsistency, not a bug — the previous reviewer
      flagged it as MEDIUM but the key is present and functional.

  - severity: LOW
    file: knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
    line: 193-196
    explanation: >
      Path parameters are always typed as `string` in the TS output regardless of their actual
      schema type (e.g. integer IDs). This matches the JS fallback behavior but produces slightly
      inaccurate TypeScript for numeric path params. Acceptable for a v1 implementation but worth
      noting as a known limitation.

  - severity: LOW
    file: knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
    line: 1-336
    explanation: >
      The issue spec says "代码生成逻辑应与 knife4j-core 中已有的 TypeScript/JavaScript 生成器对齐"
      (align with existing generators in knife4j-core). No such generator exists in knife4j-core
      (confirmed by search), so the worker implemented the logic inline in ScriptView.tsx. This is
      acceptable given the absence of a shared generator, but the issue requirement cannot be
      verified as satisfied. No scope drift — the inline approach is the only viable path.

  - severity: INFO
    file: knife4j-front/knife4j-ui-react/src/pages/api/ScriptView.tsx
    line: 240-260
    explanation: >
      The generated JS/TS code references a bare `request` object with no import statement or
      comment explaining where it comes from. Users copying the generated code will need to know
      to supply their own HTTP client. The worker noted this as a follow-up item; it is not a
      blocker but reduces the out-of-box usability of the generated code.

validation_gaps:
  - Build was validated in a separate worktree copy (/tmp/knife4j-211) rather than the actual
    branch worktree, because the branch worktree has root-owned files and no node_modules. The
    build result is credible but not reproducible from the branch directly.
  - No runtime/browser testing was performed. The tab navigation (OperationModeTabs → script route)
    and copy-to-clipboard flow were not exercised.
  - The RUNBOOK.md specifies `./scripts/test-front-core.sh` (which includes lint and type-check),
    but the worker only ran `npm run build`. It is unknown whether `tsc --noEmit` or ESLint pass
    on the branch.

scope_drift:
  - none. The branch contains exactly 5 files, all within the issue-207 scope. No Java, no
    OpenApiView, no unrelated changes. The previous block recommendation (comment #5 on the issue)
    was for a different branch/iteration that included issue-206 and Java changes. This branch
    (agent/issue-207-1777618937) is clean.

recommendation: approve
```

**Summary**: The branch is clean and in-scope. The implementation satisfies all completion criteria from the issue: Script tab present, JS/TS toggle, function signature + type interfaces, copy button, build passes. The MEDIUM finding (depth reset in recursive schema traversal) is a correctness edge case that is mitigated by the `try/catch` in `useMemo` and the depth guard in `resolveSchema` — it won't crash the UI. The LOW findings are style/accuracy issues, not regressions. The main validation gap is that `test-front-core.sh` (lint + typecheck) was not run; coordinator should verify this before merge.
```