### PR TITLE
docs(agent): add pitfall on reviewer misreading stash diff (#198)

### DIFF
--- a/.agent/KNOWN_PITFALLS.md
+++ b/.agent/KNOWN_PITFALLS.md
@@ -28,3 +28,4 @@
 - 不要让任务存在理由只保存在临时聊天上下文里。
 - 不要把“修一个点”静默扩大成“顺手清理相关区域”。
 - 不确定时，把不确定性写下来，并停在安全检查点。
+- **Reviewer 声称某改动 "revert 了 X" / "删除了 Y" 时，coordinator 必须在接受结论前用 `git show <commit> -- <file>` 核对真实 diff**。历史案例：#198 三次 reviewer `block` 指控 commit `8f0d3b6f` 把 `ProductionSecurityFilter` revert 回 `sendError`、默认值 `knife4j.basic.enable` 翻转、删除 `addCustomApiDocsPathRule`，经人工复核**全部与 master 实际代码相反**；推测 reviewer 对照了 worker 未提交的 stash 或错误 base。不先核对 diff 就按 reviewer 描述动代码，会把正确修复改回 bug。


### PR DESCRIPTION
## 背景

#198 三次 reviewer `block` 的核心指控（"filter revert 回 sendError"、"knife4j.basic.enable 默认值翻转"、"addCustomApiDocsPathRule 被删"）经 `git show 8f0d3b6f` 核对，**与 master 实际代码全部相反**。推测 reviewer 对照了 worker 未提交的 stash。

## 改动

仅追加 `.agent/KNOWN_PITFALLS.md` 的一条 agent 工作流规则，要求 coordinator 在接受 reviewer "revert / 删除" 类结论前用 `git show <commit> -- <file>` 核对真实 diff。

## 验证

纯文档。无需跑测试。

## 相关

- 配合 #198 关闭

