### PR TITLE
fix(ui-react): render loading copy while spec loads in MarkdownDocument (#211 follow-up)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -12,6 +12,7 @@ const enUS = {
   // SidebarSearchMenu
   'sidebar.search.placeholder': 'Search API name/path...',
   'markdownDoc.menu.group': 'Markdown Docs',
+  markdownDocLoading: 'Loading document…',
   markdownDocNotFound: 'Document not found',
 
   // Home

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -12,6 +12,7 @@ const zhCN = {
   // SidebarSearchMenu
   'sidebar.search.placeholder': '搜索接口名/路径...',
   'markdownDoc.menu.group': 'Markdown 文档',
+  markdownDocLoading: '文档加载中…',
   markdownDocNotFound: '文档未找到',
 
   // Home

--- a/knife4j-front/knife4j-ui-react/src/pages/document/MarkdownDocument.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/MarkdownDocument.tsx
@@ -10,14 +10,20 @@ const MarkdownDocument: React.FC = () => {
     groupIndex: string;
     itemIndex: string;
   }>();
-  const { markdownDocs } = useGroup();
+  const { markdownDocs, loading } = useGroup();
   const { t } = useTranslation();
 
   const key = `/${group}/markdown/${groupIndex}/${itemIndex}`;
   const doc = markdownDocs.find((d) => d.key === key);
 
   if (!doc) {
-    return <div style={{ padding: 24, color: '#999', textAlign: 'center' }}>{t('markdownDocNotFound')}</div>;
+    // `loading=true` means either the group list or the swaggerDoc for the
+    // active group is still being fetched. In that window `markdownDocs` is
+    // always empty, so rendering the "not found" message would flash on every
+    // page load/refresh. Surface a neutral loading state instead; switch to
+    // the "not found" copy only once loading has completed.
+    const emptyCopy = loading ? t('markdownDocLoading') : t('markdownDocNotFound');
+    return <div style={{ padding: 24, color: '#999', textAlign: 'center' }}>{emptyCopy}</div>;
   }
 
   return (


### PR DESCRIPTION
## 背景

Closes #211 的 follow-up。

PR #233（commit `f51e1559`）已把 Markdown 文档页合入 master，覆盖了 reviewer round 2/3 的绝大多数 findings（`markdownDocsRef` 解耦 / 空态 i18n / markdown 路由深链 tab 恢复）。剩下一个 UX 小缺口没修：

**问题**：直接访问 `/#/<group>/markdown/<gi>/<fi>` 或刷新该路由时，`GroupContext` 仍在抓 group 列表 / `swaggerDoc`，此时 `markdownDocs=[]`。`MarkdownDocument` 当前只根据 `!doc` 渲染 `t('markdownDocNotFound')`，用户会看到"文档未找到"的**闪现**，直到 spec 解析完成才切到真实内容。

## 改动

消费 `GroupContext` 已暴露的 `loading` 标志：
- `loading=true` → 渲染 `t('markdownDocLoading')`（中文 "文档加载中…" / English "Loading document…"）
- `loading=false` → 保持原有 `t('markdownDocNotFound')` 文案

3 文件，10 行新增 / 2 行修改，无依赖改动，无 scope drift。

- `knife4j-front/knife4j-ui-react/src/pages/document/MarkdownDocument.tsx` — 新增 `loading` 解构 + 条件文案
- `knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts` — 新增 `markdownDocLoading: '文档加载中…'`
- `knife4j-front/knife4j-ui-react/src/locales/en-US.ts` — 新增 `markdownDocLoading: 'Loading document…'`

## 验证

`./scripts/test-front-core.sh` 本地全绿：

```
knife4j-core:
  - format:check (prettier)        ✅
  - test (jest)                    ✅ 15 suites / 177 tests passed
  - lint (eslint)                  ✅
  - build (tsc)                    ✅

knife4j-ui-react:
  - format:check (prettier)        ✅
  - build (tsc && vite)            ✅ 3379 modules, 4.42s
  - lint (eslint --max-warnings 0) ✅

exit_code: 0
```

## 相关

- Issue #211（自定义 Markdown 文档页）
- 前序主干 PR #233 (`f51e1559`)
- Coordinator meta: #200

