### PR TITLE
cleanup: OAS2 Knife4jAutoConfiguration.productionSecurityFilter 不可达 null-guard (#198 FU-1), closes #239

### DIFF
--- a/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -194,16 +194,13 @@ public class Knife4jAutoConfiguration {
     @ConditionalOnMissingBean(ProductionSecurityFilter.class)
     @ConditionalOnProperty(name = "knife4j.production", havingValue = "true")
     public ProductionSecurityFilter productionSecurityFilter(Knife4jProperties knife4jProperties) {
-        Knife4jSetting setting = knife4jProperties.getSetting() != null ? knife4jProperties.getSetting() : new Knife4jSetting();
-        ProductionSecurityFilter p = null;
         if (knife4jProperties == null) {
             int customCode = EnvironmentUtils.resolveInt(environment, "knife4j.setting.custom-code", 200);
             boolean prod = EnvironmentUtils.resolveBool(environment, "knife4j.production", Boolean.FALSE);
-            p = new ProductionSecurityFilter(prod, customCode);
-        } else {
-            p = new ProductionSecurityFilter(knife4jProperties.isProduction(), setting.getCustomCode());
+            return new ProductionSecurityFilter(prod, customCode);
         }
-        return p;
+        Knife4jSetting setting = knife4jProperties.getSetting() != null ? knife4jProperties.getSetting() : new Knife4jSetting();
+        return new ProductionSecurityFilter(knife4jProperties.isProduction(), setting.getCustomCode());
     }
 
 }


### PR DESCRIPTION
Closes #239

## Worker Handoff

```
Branch pushed successfully. Here is the handoff:

---

```
task: issue-239
scope: knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java — productionSecurityFilter method only
changed_files:
- knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java

summary:
- Applied option 1: moved null-guard (`if (knife4jProperties == null)`) to the top of productionSecurityFilter, before the first dereference of knife4jProperties
- Eliminated the unreachable branch: previously `knife4jProperties.getSetting()` was called on line 1, so the `== null` check 4 lines later was dead code (would have already NPE'd)
- Preserved the environment-variable fallback path for backward compatibility
- Removed the intermediate `ProductionSecurityFilter p = null` variable, using early-return idiom for clarity
- Spotless check passed (0 files flagged for formatting changes) with BUILD SUCCESS

validation:
- command: cd /root/.openclaw/workspaces/knife4j-next-bot/knife4j-next && ./scripts/test-java.sh
  result: BUILD SUCCESS — Spotless.Java 0 needs changes; unrelated failure knife4j-openapi2-ui (missing `bun` binary in CI environment, not related to this change)

risks:
- The `knife4j-openapi2-ui` module fails due to missing `bun` binary in the worktree environment — this is a pre-existing environment issue, not caused by this change
- Worktree files were root-owned, so git operations required low-level plumbing (fast-import + manual ref update); the resulting commit is structurally correct as verified by `git show`

follow_up:
- The `securityBasicAuthFilter` method (lines 171-191) has an identical pattern: it dereferences knife4jProperties before the null check. That is also unreachable dead code but is out of scope for this issue — should be tracked as a separate follow-up cleanup
```
```

## Reviewer Findings

```
[2026-05-05T14:01:42Z] [INFO] 推送 branch agent/issue-239-1777988869 到远端供 reviewer 使用...
Everything up-to-date
branch 'agent/issue-239-1777988869' set up to track 'origin/agent/issue-239-1777988869'.
**Review result for issue-239 / branch `agent/issue-239-1777988869`:**

---

**task:** issue-239
**reviewed_scope:** `productionSecurityFilter` method only in `Knife4jAutoConfiguration.java`

**findings:**
- INFO, `Knife4jAutoConfiguration.java`, ~196-207 — The null branch is now syntactically reachable but remains effectively dead in production: Spring DI never injects a null bean under `@ConditionalOnProperty`. This is acceptable per issue option (1) and introduces no regression risk.
- INFO, `Knife4jAutoConfiguration.java`, ~171-190 — Sibling method `securityBasicAuthFilter` has the same anti-pattern. Out of scope for this issue; should be tracked as a follow-up.
- INFO, no new test — The null-guard path has no unit test. Given this is a pure refactor with no behavioral change in the normal path and the null path is unreachable under Spring DI, this is acceptable but is a coverage gap.

**validation_gaps:**
- `./scripts/test-java.sh` confirmed Spotless passed (BUILD SUCCESS), but `mvn verify` aborted on a pre-existing `bun`-missing infra gap in the `knife4j-openapi2-ui` module. The Java-only change cannot have caused this. Coordinator should confirm CI is green on the remote branch via `gh pr checks --watch` before merging.

**scope_drift:**
- none

**recommendation:** approve

The change is correct, minimal, and exactly scoped to issue-239 option (1): null-guard moved before first dereference, environment-variable fallback preserved. No behavioral change in any reachable code path.
```