### PR TITLE
ci: enforce smoke-tests evidence in test-java.sh and CI (#241)

### DIFF
--- a/.agent/RUNBOOK.md
+++ b/.agent/RUNBOOK.md
@@ -29,6 +29,16 @@
 - 修改 Java 兼容性行为
 - 触碰 starter 模块、UI webjar 打包或发布敏感 Java 代码
 
+> **Smoke 证据要求（issue #241 / #198 FU-3）**：
+> 任何涉及 `knife4j/**` Java 代码，或 `knife4j-*-spring-boot-starter/**`、`knife4j-openapi*-ui/**`、`knife4j-gateway-spring-boot-starter/**` 配置的改动，agent 必须在对应 issue 评论或 PR 描述里附上以下任一证据：
+>
+> - 本地 `./scripts/test-java.sh` 尾部的 `==> Smoke-tests evidence OK (N modules)` 行；或
+> - CI 上 `java-build-test` job 内 `Smoke-tests evidence summary` step 的绿色链接。
+>
+> `scripts/test-java.sh` 结尾包含一个哨兵，若任一 smoke 模块（`boot2-app`、`boot3-app`、`boot3-jakarta-app`、`boot35-jakarta-app`）缺少 surefire 报告、报告为空、或存在 failures/errors，脚本会非零退出。CI 同时会把 smoke 结果写进 job summary，失败时上传 surefire 报告 artifact 便于定位。
+>
+> 如果未来有模块被有意下线，须同步更新 `scripts/test-java.sh` 中的 `SMOKE_MODULES` 列表和 `.github/workflows/build.yml` 里 `Smoke-tests evidence summary` 的循环列表，并在 PR 描述里说明原因。
+
 ### Front Core / UI React
 
 从仓库根目录运行：

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,47 @@ jobs:
       - name: Verify Java modules
         run: scripts/test-java.sh
 
+      # issue #241 / #198 FU-3: make smoke-tests coverage visible in PR checks.
+      # The gate inside scripts/test-java.sh already fails the build if a smoke
+      # module is missing; this step surfaces the per-module counts as a
+      # dedicated summary and persists surefire reports on failure.
+      - name: Smoke-tests evidence summary
+        if: always()
+        run: |
+          set -euo pipefail
+          root="knife4j/knife4j-smoke-tests"
+          {
+            echo "### Smoke-tests evidence"
+            echo ""
+            echo "| module | tests | failures | errors |"
+            echo "| --- | ---: | ---: | ---: |"
+            for module in boot2-app boot3-app boot3-jakarta-app boot35-jakarta-app; do
+              dir="$root/$module/target/surefire-reports"
+              if [ ! -d "$dir" ]; then
+                echo "| $module | (missing) | - | - |"
+                continue
+              fi
+              tests=0; failures=0; errors=0
+              shopt -s nullglob
+              for xml in "$dir"/TEST-*.xml; do
+                t=$(grep -oE 'tests="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || echo 0)
+                f=$(grep -oE 'failures="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || echo 0)
+                e=$(grep -oE 'errors="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || echo 0)
+                tests=$((tests + t)); failures=$((failures + f)); errors=$((errors + e))
+              done
+              shopt -u nullglob
+              echo "| $module | $tests | $failures | $errors |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload smoke-tests surefire reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-tests-surefire-reports
+          path: knife4j/knife4j-smoke-tests/*/target/surefire-reports/**
+          if-no-files-found: ignore
+
   front-core-test:
     runs-on: ubuntu-latest
     defaults:

--- a/scripts/test-java.sh
+++ b/scripts/test-java.sh
@@ -6,7 +6,89 @@ if [ -z "${JAVA_HOME:-}" ]; then
   JAVA_HOME=$(dirname "$(dirname "$(readlink -f "$(which java)")")") && export JAVA_HOME
 fi
 
-cd "$(dirname "$0")/../knife4j"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT/knife4j"
 
 mvn -B -ntp spotless:check
 mvn -B -ntp -Dknife4j-skipTests=false verify
+
+# ---------------------------------------------------------------------------
+# Smoke-tests evidence gate (issue #241 / #198 FU-3)
+#
+# The reactor above already includes `knife4j-smoke-tests/*` because they are
+# declared in `knife4j/pom.xml`'s <modules>. That coverage is implicit, though,
+# so this guard turns it into an explicit, auditable signal:
+#
+#   - every known smoke module must have produced a surefire report
+#   - every produced report must show > 0 tests executed and 0 failures/errors
+#
+# The check is cheap (it only reads XML files already written by surefire) and
+# fails loudly if a future change silently drops a smoke module from the build.
+# ---------------------------------------------------------------------------
+
+SMOKE_MODULES=(
+  "boot2-app"
+  "boot3-app"
+  "boot3-jakarta-app"
+  "boot35-jakarta-app"
+)
+
+SMOKE_ROOT="$REPO_ROOT/knife4j/knife4j-smoke-tests"
+missing=()
+
+echo ""
+echo "==> Verifying smoke-tests evidence (issue #241)"
+for module in "${SMOKE_MODULES[@]}"; do
+  reports_dir="$SMOKE_ROOT/$module/target/surefire-reports"
+  if [ ! -d "$reports_dir" ]; then
+    echo "   [MISSING] $module: no surefire-reports directory at $reports_dir"
+    missing+=("$module")
+    continue
+  fi
+
+  # Any TEST-*.xml counts; summarise tests / failures / errors.
+  shopt -s nullglob
+  xml_files=("$reports_dir"/TEST-*.xml)
+  shopt -u nullglob
+  if [ "${#xml_files[@]}" -eq 0 ]; then
+    echo "   [MISSING] $module: surefire-reports contains no TEST-*.xml"
+    missing+=("$module")
+    continue
+  fi
+
+  tests=0
+  failures=0
+  errors=0
+  for xml in "${xml_files[@]}"; do
+    # Read the <testsuite ... tests=".." failures=".." errors=".."> attributes.
+    t=$(grep -oE 'tests="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || echo 0)
+    f=$(grep -oE 'failures="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || echo 0)
+    e=$(grep -oE 'errors="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || echo 0)
+    tests=$((tests + t))
+    failures=$((failures + f))
+    errors=$((errors + e))
+  done
+
+  if [ "$tests" -eq 0 ]; then
+    echo "   [EMPTY]   $module: surefire ran but reported 0 tests"
+    missing+=("$module")
+    continue
+  fi
+  if [ "$failures" -ne 0 ] || [ "$errors" -ne 0 ]; then
+    echo "   [FAIL]    $module: tests=$tests failures=$failures errors=$errors"
+    missing+=("$module")
+    continue
+  fi
+
+  echo "   [OK]      $module: tests=$tests failures=0 errors=0"
+done
+
+if [ "${#missing[@]}" -ne 0 ]; then
+  echo ""
+  echo "Smoke evidence gate failed for: ${missing[*]}" >&2
+  echo "The main 'mvn verify' must exercise every module under knife4j-smoke-tests/." >&2
+  echo "If a module was intentionally removed, update SMOKE_MODULES in scripts/test-java.sh." >&2
+  exit 1
+fi
+
+echo "==> Smoke-tests evidence OK (${#SMOKE_MODULES[@]} modules)"


### PR DESCRIPTION
## 关联 Issue

- Closes #241
- 承接 #198 FU-3

## 背景

`knife4j/knife4j-smoke-tests/*` 下的 4 个 smoke 模块虽然已经通过父 pom 的 `<modules>` 参与 `mvn verify`，但这种覆盖是**隐式**的：

- reviewer 在 #198 复核里反复以「无 smoke 证据」block
- 一旦以后某次 pom 改动或 `-pl` 过滤不小心把 smoke 挤出 reactor，本地脚本和 CI 都不会报错

这个 PR 把「smoke 真的跑了」变成一条可审计的显式信号。

## 变更内容

- `scripts/test-java.sh`：`mvn verify` 之后新增哨兵段，遍历显式列出的 `SMOKE_MODULES`（`boot2-app` / `boot3-app` / `boot3-jakarta-app` / `boot35-jakarta-app`），断言每个模块都生成了非空 `surefire-reports/TEST-*.xml`，且 `failures=0` / `errors=0`；任一不满足则非零退出并指明模块名。
- `.github/workflows/build.yml`：
  - 新增 `Smoke-tests evidence summary` step（`if: always()`），把每个 smoke 模块的 `tests / failures / errors` 写入 `$GITHUB_STEP_SUMMARY`，在 PR check 界面能直接看到表格。
  - 新增 `Upload smoke-tests surefire reports on failure` step（`if: failure()`），失败时把 surefire 报告作为 artifact 上传，便于定位。
- `.agent/RUNBOOK.md`：在 Java 验证节补一段「Smoke 证据要求」，约定 `knife4j/**` 或 starter 改动须附哨兵输出行或 CI 绿链，并在未来下线 smoke 模块时同步更新脚本/workflow 列表。

## 验证

- 本地 `./scripts/test-java.sh`（JDK17）完整通过，reactor summary 显示 4 个 smoke 模块均 SUCCESS，哨兵结尾输出：

  ```text
  ==> Verifying smoke-tests evidence (issue #241)
     [OK]      boot2-app: tests=2 failures=0 errors=0
     [OK]      boot3-app: tests=1 failures=0 errors=0
     [OK]      boot3-jakarta-app: tests=3 failures=0 errors=0
     [OK]      boot35-jakarta-app: tests=2 failures=0 errors=0
  ==> Smoke-tests evidence OK (4 modules)
  ```

- Negative test：把任一模块的 `target/surefire-reports` 临时移走，哨兵会列出缺失模块并以 `exit 1` 终止；之后恢复，工作区保持干净。

## 当前已知风险

- 纯 CI/脚本改动，不触碰运行时代码、pom 结构或 starter 行为；零回归风险。
- `SMOKE_MODULES` 列表在两处维护（脚本 + workflow）。RUNBOOK 已显式记录同步约定，且模块数量极少，增量成本可接受；未来若希望进一步去重，可在后续任务里提取到公共脚本里，不阻塞本 PR。

## 是否需要人工决策

否。属于 `area:repo` 范围，完全符合 `.agent/AUTONOMY_POLICY.md` 允许自治执行的范畴。

