### PR TITLE
fix(oas2): fix unreachable null-guard in productionSecurityFilter (#239)

### DIFF
--- a/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -194,16 +194,13 @@ public class Knife4jAutoConfiguration {
     @ConditionalOnMissingBean(ProductionSecurityFilter.class)
     @ConditionalOnProperty(name = "knife4j.production", havingValue = "true")
     public ProductionSecurityFilter productionSecurityFilter(Knife4jProperties knife4jProperties) {
-        Knife4jSetting setting = knife4jProperties.getSetting() != null ? knife4jProperties.getSetting() : new Knife4jSetting();
-        ProductionSecurityFilter p = null;
         if (knife4jProperties == null) {
             int customCode = EnvironmentUtils.resolveInt(environment, "knife4j.setting.custom-code", 200);
             boolean prod = EnvironmentUtils.resolveBool(environment, "knife4j.production", Boolean.FALSE);
-            p = new ProductionSecurityFilter(prod, customCode);
-        } else {
-            p = new ProductionSecurityFilter(knife4jProperties.isProduction(), setting.getCustomCode());
+            return new ProductionSecurityFilter(prod, customCode);
         }
-        return p;
+        Knife4jSetting setting = knife4jProperties.getSetting() != null ? knife4jProperties.getSetting() : new Knife4jSetting();
+        return new ProductionSecurityFilter(knife4jProperties.isProduction(), setting.getCustomCode());
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes unreachable null-guard in `Knife4jAutoConfiguration.productionSecurityFilter`.

**Problem**: The original code dereferenced `knife4jProperties` on line 197 before checking `knife4jProperties == null` on line 199, making the null branch dead code (any null value would have already caused NPE).

**Fix (option 1 from issue)**: Move the null-guard to the top of the method so the environment-variable fallback path is reachable again.

**Change is a pure refactor**: runtime behaviour for non-null `knife4jProperties` is unchanged.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)