### PR TITLE
test: add boot2-openapi3-app smoke module for OAS3 starter on SB 2.7 + javax (#240)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
             echo ""
             echo "| module | tests | failures | errors |"
             echo "| --- | ---: | ---: | ---: |"
-            for module in boot2-app boot3-app boot3-jakarta-app boot35-jakarta-app; do
+            for module in boot2-app boot2-openapi3-app boot3-app boot3-jakarta-app boot35-jakarta-app; do
               dir="$root/$module/target/surefire-reports"
               if [ ! -d "$dir" ]; then
                 echo "| $module | (missing) | - | - |"

--- a/knife4j/knife4j-smoke-tests/boot2-openapi3-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-openapi3-app/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-boot2-openapi3-app</artifactId>
+    <name>knife4j-smoke-boot2-openapi3-app</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${knife4j-spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/knife4j/knife4j-smoke-tests/boot2-openapi3-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2openapi3/Boot2OpenApi3DocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot2-openapi3-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2openapi3/Boot2OpenApi3DocHttpSmokeTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot2openapi3;
+
+import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.context.WebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * End-to-end smoke test for the javax-flavored OpenAPI 3 starter (Spring Boot 2.7.x).
+ *
+ * Mirrors {@code Boot3JakartaDocHttpSmokeTest} against knife4j-openapi3-spring-boot-starter
+ * to provide a live regression net for {@code ProductionSecurityFilter} JSON response
+ * handling (#666 / #859) and {@code addCustomApiDocsPathRule} custom path support
+ * (#573 / #849) on the Spring Boot 2 + javax servlet combination.
+ */
+public class Boot2OpenApi3DocHttpSmokeTest {
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void shouldServeDocHtmlAndOpenApiJson() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "spring.mvc.pathmatch.matching-strategy=ant_path_matcher",
+                        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(docHtml.body.contains("webjars/knife4j-ui-react/"));
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+        Assert.assertTrue(apiDocs.body.contains("\"openapi\""));
+        Assert.assertTrue(apiDocs.body.contains("/hello"));
+    }
+
+    @Test
+    public void shouldBlockApiDocsWhenProductionTrue() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "knife4j.production=true",
+                        "spring.mvc.pathmatch.matching-strategy=ant_path_matcher",
+                        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+
+        // production=true should block /v3/api-docs and return JSON (not HTML) (#666, #859)
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertFalse("Response should not be HTML when production=true (#666, #859)",
+                apiDocs.body.contains("<!DOCTYPE"));
+        Assert.assertTrue("Response should be JSON when production=true (#666, #859)",
+                apiDocs.body.contains("\"code\"") || apiDocs.body.contains("\"message\""));
+
+        // doc.html should also be blocked
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertFalse("doc.html should not return HTML content when production=true",
+                docHtml.body.contains("webjars/knife4j-ui-react/"));
+    }
+
+    @Test
+    public void shouldServeCustomApiDocsPath() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "springdoc.api-docs.path=/api/openapi",
+                        "spring.mvc.pathmatch.matching-strategy=ant_path_matcher",
+                        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+
+        // Custom springdoc.api-docs.path should be accessible (#573, #849)
+        HttpResponse apiDocs = get(port, "/api/openapi");
+        Assert.assertEquals(200, apiDocs.statusCode);
+        Assert.assertTrue("Custom api-docs path should return OpenAPI JSON (#573, #849)",
+                apiDocs.body.contains("\"openapi\""));
+    }
+
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static class HttpResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+
+    @EnableKnife4j
+    @SpringBootApplication
+    public static class TestApplication {
+    }
+
+    @RestController
+    public static class TestController {
+
+        @GetMapping("/hello")
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -22,6 +22,7 @@
 
     <modules>
         <module>boot2-app</module>
+        <module>boot2-openapi3-app</module>
         <module>boot3-jakarta-app</module>
         <module>boot3-app</module>
         <module>boot35-jakarta-app</module>

--- a/scripts/test-java.sh
+++ b/scripts/test-java.sh
@@ -28,6 +28,7 @@ mvn -B -ntp -Dknife4j-skipTests=false verify
 
 SMOKE_MODULES=(
   "boot2-app"
+  "boot2-openapi3-app"
   "boot3-app"
   "boot3-jakarta-app"
   "boot35-jakarta-app"


### PR DESCRIPTION
## 关联 Issue

- Closes #240
- 承接 #198 FU-2

## 背景

`knife4j-openapi3-spring-boot-starter`（非 jakarta，javax servlet + Spring Boot 2.7.x）此前没有端到端 smoke 覆盖：`ProductionSecurityFilter` 的 JSON 响应（#666 / #859）与 `addCustomApiDocsPathRule` 的自定义路径支持（#573 / #849）在这个组合下只有代码层测试，没有 live 回归。

本 PR 对齐 `boot3-jakarta-app` 的范式，为该 starter 补上一个最小但覆盖三大场景的 smoke 模块。

## 变更内容

- `knife4j/knife4j-smoke-tests/boot2-openapi3-app/pom.xml`：新模块，依赖 `knife4j-openapi3-spring-boot-starter` + `spring-boot-starter-web`（2.7.x）+ JUnit 4，与现有 smoke 模块结构保持一致。
- `Boot2OpenApi3DocHttpSmokeTest.java`：三个场景
  - baseline（`production=false`）：`/doc.html` 返回 200 且含 React UI webjar；`/v3/api-docs` 返回 200 且为含 `/hello` 的 OpenAPI JSON。
  - `knife4j.production=true`：`/v3/api-docs` 响应非 HTML 且为 JSON（`code` / `message`），`/doc.html` 不再返回 React UI 内容。
  - 自定义 `springdoc.api-docs.path=/api/openapi`：`/api/openapi` 返回 200 + OpenAPI JSON。
  - 启动配置遵循 `boot2-app` 范式：`spring.mvc.pathmatch.matching-strategy=ant_path_matcher`、exclude `SecurityAutoConfiguration`、`server.port=0` + `WebServerApplicationContext.getWebServer().getPort()`。
- `knife4j/knife4j-smoke-tests/pom.xml`：将新模块接入聚合 pom。
- `scripts/test-java.sh`：在 `SMOKE_MODULES` 列表里追加 `boot2-openapi3-app`，让 #241 引入的证据哨兵覆盖新模块。
- `.github/workflows/build.yml`：`Smoke-tests evidence summary` step 的迭代列表同步追加 `boot2-openapi3-app`，PR check 摘要会显示它的 tests/failures/errors。

## 验证

本地 JDK17，仓库根目录：

```bash
./scripts/test-java.sh
```

Reactor summary（节选）：

```text
[INFO] knife4j-smoke-boot2-app ............................ SUCCESS [  1.352 s]
[INFO] knife4j-smoke-boot2-openapi3-app ................... SUCCESS [  1.266 s]
[INFO] knife4j-smoke-boot3-jakarta-app .................... SUCCESS [  1.477 s]
[INFO] knife4j-smoke-boot3-app ............................ SUCCESS [  0.997 s]
[INFO] knife4j-smoke-boot35-jakarta-app ................... SUCCESS [  2.358 s]
[INFO] BUILD SUCCESS
```

哨兵输出：

```text
==> Verifying smoke-tests evidence (issue #241)
   [OK]      boot2-app: tests=2 failures=0 errors=0
   [OK]      boot2-openapi3-app: tests=3 failures=0 errors=0
   [OK]      boot3-app: tests=1 failures=0 errors=0
   [OK]      boot3-jakarta-app: tests=3 failures=0 errors=0
   [OK]      boot35-jakarta-app: tests=2 failures=0 errors=0
==> Smoke-tests evidence OK (5 modules)
```

单模块 `mvn -pl knife4j-smoke-tests/boot2-openapi3-app -am -Dknife4j-skipTests=false verify` 同样输出 `Tests run: 3, Failures: 0, Errors: 0`。

## 当前已知风险

- 测试直接启动 Spring Boot + 本地 HTTP 连接，不依赖任何外部服务。
- 新模块沿用 boot2-app 的 `spring.mvc.pathmatch.matching-strategy=ant_path_matcher` 设置，保证 springdoc-openapi-ui 1.x 在 Spring Boot 2.7 上与旧 URL matcher 行为兼容。
- 纯新增测试覆盖，不改动 starter 运行时代码，零回归风险。

## 是否需要人工决策

否。属于 `area:java` 内的新增测试覆盖，符合 `.agent/AUTONOMY_POLICY.md` 允许自治执行的范畴。

