### PR TITLE
docs: record vue2->vue3 migration facts for OAS2 UI (#174 PR-7a)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,39 @@ cd knife4j && mvn -B -ntp verify && cd ..
 
 On a first clone, run `npm install` or `npm ci` in `knife4j-front/`; the root `prepare` script installs Lefthook automatically so staged front-end files are formatted before commit.
 
+## Front-End Layout
+
+There are two independent front-end product lines. Work in the one that matches the issue's `area:*` label:
+
+| Source | Package manager | Build output (webjar) | Downstream starter | OpenAPI |
+|---|---|---|---|---|
+| `knife4j-front/knife4j-ui-react` (React + Vite) | npm workspaces (see `knife4j-front/package.json`) | `knife4j/knife4j-openapi3-ui` | `knife4j-openapi3-spring-boot-starter`, `knife4j-openapi3-jakarta-spring-boot-starter`, `knife4j-gateway-spring-boot-starter`, `knife4j-aggregation-jakarta-spring-boot-starter` | **OAS 3 only — main line** |
+| `knife4j-vue3` (Vue 3 + Vite) | Bun (`packageManager: "bun@1.3.13"`, see `knife4j-vue3/bun.lock`) | `knife4j/knife4j-openapi2-ui` | `knife4j-openapi2-spring-boot-starter`, `knife4j-aggregation-spring-boot-starter` | **Swagger 2 / OAS 2 only — compatibility maintenance** |
+
+The upstream Vue 2 source under `knife4j-vue/` is frozen as of `5.0.0-SNAPSHOT` and is no longer part of any Maven build. See `knife4j-vue/README.md`.
+
+### OAS 3 main line (`knife4j-front/knife4j-ui-react`)
+
+```bash
+cd knife4j-front
+npm ci
+npm run dev -w knife4j-ui-react
+```
+
+Maven pipeline: `knife4j/knife4j-openapi3-ui/pom.xml` drives `npm install` + `npx vite build` during `generate-resources` and copies the dist into `META-INF/resources/`.
+
+### OAS 2 compatibility line (`knife4j-vue3`)
+
+```bash
+cd knife4j-vue3
+bun install --frozen-lockfile
+bun run dev
+```
+
+Maven pipeline: `knife4j/knife4j-openapi2-ui/pom.xml` drives `bun install --frozen-lockfile` + `bun run build --outDir=...` during `generate-resources` and copies the dist into `META-INF/resources/`.
+
+Scope reminder (also in `.agent/PROJECT.md`): the OAS 2 line only takes regression fixes, security patches, and display-layer bugs. New features go to the OAS 3 main line.
+
 ## Code Formatting
 
 The repository enforces consistent formatting through a combination of tool-side and CI-side checks. **All PRs must pass these checks before merge.**

--- a/docs-site/release-notes/index.md
+++ b/docs-site/release-notes/index.md
@@ -24,6 +24,30 @@ title: 发布说明
 - ApiDoc 工具栏：移除 Copy Endpoint，Copy URL 改名为 Copy Page URL
 - GlobalParam：新增按钮与表单控件同行，窄 Drawer 不再溢出
 
+**OAS2 前端产物切换到 Vue 3**
+
+从 5.0.0-SNAPSHOT 起，`knife4j-openapi2-ui` webjar 和
+`knife4j-aggregation-spring-boot-starter` 的 doc.html 产物不再来自 upstream Vue 2 源码
+（仓库内 `knife4j-vue/`），而是由本仓库 `knife4j-vue3/`（Vue 3 + Vite）构建产出。
+
+- 对下游用户：`doc.html` 访问入口、URL 格式（`$` 分隔符保留）、`localStorage` key 保持兼容，
+  默认场景下无感知。
+- 依赖栈升级：Vue 2.6 → Vue 3.3、`ant-design-vue` 1.x → 3.x、Vuex → Pinia、`vue-cli` → Vite、
+  `vue-i18n` 8 → 9.14+、Mermaid 升级至 11.x。
+- Maven 构建：`knife4j/knife4j-openapi2-ui/pom.xml` 通过 `exec-maven-plugin` 调用
+  `bun install --frozen-lockfile` + `bun run build` 生成产物并拷贝至
+  `META-INF/resources/`。构建机需要 [Bun](https://bun.com/) 1.3.13+，Java CI 已启用。
+- `knife4j-vue/` 作为历史参考保留，不再参与任何 Maven 构建，详见 `knife4j-vue/README.md`。
+- 影响范围表：
+
+  | 模块 | 前端产物来源 |
+  | --- | --- |
+  | `knife4j-openapi2-ui`（webjar） | `knife4j-vue3`（本次切换） |
+  | `knife4j-aggregation-spring-boot-starter` | `knife4j-openapi2-ui`，间接切换 |
+  | `knife4j-openapi3-ui`（webjar） | `knife4j-front/knife4j-ui-react`，未变 |
+  | `knife4j-aggregation-jakarta-spring-boot-starter` | `knife4j-openapi3-ui`，未变 |
+  | `knife4j-gateway-spring-boot-starter` | `knife4j-openapi3-ui`，未变 |
+
 **新功能**
 
 - OAuth2 授权码 / 隐式模式弹窗流程（`oauth2-redirect.html` 回跳页面）

--- a/knife4j-vue/README.md
+++ b/knife4j-vue/README.md
@@ -1,29 +1,44 @@
-# knife4j-vue
+# knife4j-vue（已冻结）
 
-## Project setup
-```
+> ⚠️ 此目录是 upstream `xiaoymin/knife4j` 的历史 Vue 2 前端实现，**已在 knife4j-next `5.0.0-SNAPSHOT` 冻结**。
+>
+> OAS2 侧的下一代 UI 维护迁移到了 [`knife4j-vue3`](../knife4j-vue3)（Vue 3 + Vite），最终产物由
+> `knife4j/knife4j-openapi2-ui` 模块的 vite 构建流程写入 webjar，参见 `knife4j/knife4j-openapi2-ui/pom.xml`。
+>
+> 本目录仅作为行为参考留存，**不再接收功能或 bug 修复**，也不参与 Maven 构建。
+>
+> OAS3 主线 UI 请看 [`knife4j-front/knife4j-ui-react`](../knife4j-front/knife4j-ui-react)。
+
+## 项目设置（仅供历史参考）
+
+```bash
 yarn install
 ```
 
-### Compiles and hot-reloads for development
-```
+### 开发（hot-reload）
+
+```bash
 yarn run serve
 ```
 
-### Compiles and minifies for production
-```
+### 生产构建
+
+```bash
 yarn run build
 ```
 
-### Run your tests
-```
+### 运行测试
+
+```bash
 yarn run test
 ```
 
-### Lints and fixes files
-```
+### Lint
+
+```bash
 yarn run lint
 ```
 
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/)!
+### 配置
+
+参见 [Vue CLI 配置参考](https://cli.vuejs.org/config/)。

--- a/knife4j-vue3/README.md
+++ b/knife4j-vue3/README.md
@@ -1,5 +1,52 @@
-# knife4j-vue3（已废弃）
+# knife4j-vue3
 
-> ⚠️ 此目录已废弃，不再维护。
+OAS2 兼容维护 UI（Vue 3 + Vite）。本目录产物被 `knife4j/knife4j-openapi2-ui` 打包为 webjar，供
+`knife4j-openapi2-spring-boot-starter` 与 `knife4j-aggregation-spring-boot-starter` 使用。
 
-下一代前端已切换为 React 技术栈，请参考 [`knife4j-front/knife4j-ui-react`](../knife4j-front/knife4j-ui-react)。
+> 关于职责边界：只接收 OAS2 / Swagger 2 侧的回归修复与显示层 bug 修复，**不做功能扩张**。新功能请求一律
+> 指向 OAS3 主线 `knife4j-front/knife4j-ui-react`。详见 `.agent/PROJECT.md` 的「前端分工策略」一节。
+
+## 包管理器
+
+本目录使用 [Bun](https://bun.com/) 作为包管理器（见 `package.json` 里的 `packageManager: "bun@1.3.13"` 与根目录
+`bun.lock`）。Maven 构建也通过 bun 调用 vite，参见
+`knife4j/knife4j-openapi2-ui/pom.xml` 中的 `exec-maven-plugin` 执行块。
+
+## 本地开发
+
+```bash
+cd knife4j-vue3
+bun install --frozen-lockfile
+bun run dev
+```
+
+## 构建
+
+```bash
+bun run build
+```
+
+构建产物默认写入 `dist/`。在 Maven 流水线里，`knife4j-openapi2-ui` 模块会通过 `--outDir` 把产物重定向到
+`knife4j/knife4j-openapi2-ui/target/knife4j-vue3-dist`，再由 `maven-resources-plugin` 拷贝到
+`META-INF/resources/`（`doc.html`、`webjars/`、`img/icons/`）。
+
+## 与 Java 模块的集成
+
+下游 starter 通过 Maven 依赖 `knife4j-openapi2-ui` 来获取 webjar：
+
+| Starter | 是否打包本目录产物 |
+|---|---|
+| `knife4j-openapi2-spring-boot-starter` | ✅（依赖 `knife4j-openapi2-ui`） |
+| `knife4j-aggregation-spring-boot-starter` | ✅（依赖 `knife4j-openapi2-ui`） |
+| `knife4j-aggregation-jakarta-spring-boot-starter` | ❌（使用 `knife4j-openapi3-ui`，即 React UI） |
+
+## 验证命令
+
+修改 Java 模块或本目录产物集成逻辑后，至少运行：
+
+```bash
+./scripts/test-java.sh
+```
+
+（本目录自身暂未纳入 `./scripts/test-front-core.sh`；若纯改 `knife4j-vue3/src/**` 且未触碰 Java 集成，
+可本地 `bun run build` 验证后再推进 CI。）


### PR DESCRIPTION
## 关联 Issue

- Closes part of #174（PR-7a，事实型文档子集）
- 依赖 #171（PR-5，已合并）

## 变更内容

把 #174 拆成两步，本 PR 只处理不依赖 #173 的事实型文档更新：

- `knife4j-vue/README.md`：加 frozen 声明，明确 OAS2 侧继任者是 `knife4j-vue3`、OAS3 主线是 `knife4j-front/knife4j-ui-react`
- `knife4j-vue3/README.md`：修正陈旧的"已废弃"说法（PR-5 后反而是 OAS2 主线 UI 产物来源），补齐包管理器（bun）、Maven 集成路径、下游 starter 清单
- `CONTRIBUTING.md`：新增 "Front-End Layout" 段落，说明两条前端产物线、包管理器、下游 starter、OpenAPI 版本与本地开发命令
- `docs-site/release-notes/index.md`：在 `5.0.0-SNAPSHOT` 条目下加 "OAS2 前端产物切换到 Vue 3" 子节，记录已合入事实（`knife4j-openapi2-ui` + `knife4j-aggregation-spring-boot-starter` 切到 vue3；`knife4j-aggregation-jakarta-spring-boot-starter` / `knife4j-openapi3-ui` 仍是 React），列依赖升级与 Bun 构建要求

## 拆分说明

原 #174 的 "已知小差异（若有，来自 PR-6 发现）" 真依赖 #173 smoke 回归，留给后续 PR-7b。#174 其他条目在 `master` 上已经是事实，可独立合入。

## 验证

```bash
./scripts/test-docs.sh
```

本地结果：`bun install` 成功、`vitepress build` 成功（build complete in 3.21s）。

## 风险

- 纯文档改动，无运行时或构建行为变化
- 不涉及 Java / 前端源码，不影响 `knife4j-openapi2-ui` / `knife4j-openapi3-ui` webjar 产物
- 无破坏性承诺，仅反映 master 上已存在的事实

## 是否需要人工决策

否。措辞与影响范围表均基于当前 `master` 可验证事实（`knife4j/knife4j-openapi2-ui/pom.xml`、`knife4j-vue3/package.json`、`knife4j/knife4j-aggregation*/pom.xml`）。

