### PR TITLE
test(smoke): automate OAS2 vue3 ui assets + swagger-resources (#173 PR-6a)

### DIFF
--- a/knife4j/knife4j-smoke-tests/boot2-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2/Boot2DocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot2-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2/Boot2DocHttpSmokeTest.java
@@ -40,6 +40,10 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Boot2DocHttpSmokeTest {
 
@@ -68,12 +72,92 @@ public class Boot2DocHttpSmokeTest {
 
         HttpResponse docHtml = get(port, "/doc.html");
         Assert.assertEquals(200, docHtml.statusCode);
-        Assert.assertTrue(docHtml.body.contains("webjars/js/"));
+        // Vue 3 production bundle entry is hashed under webjars/js/ (see knife4j-vue3/vite.config.js
+        // rollupOptions output.entryFileNames).
+        Assert.assertTrue(
+                "doc.html should reference a hashed webjars/js/ entry produced by the Vue 3 vite build",
+                docHtml.body.contains("webjars/js/"));
 
         HttpResponse apiDocs = get(port, "/v2/api-docs");
         Assert.assertEquals(200, apiDocs.statusCode);
         Assert.assertTrue(apiDocs.body.contains("\"swagger\":\"2.0\""));
         Assert.assertTrue(apiDocs.body.contains("/hello"));
+    }
+
+    /**
+     * Lock the fact that {@code knife4j-openapi2-ui} serves the Vue 3 bundle built from
+     * {@code knife4j-vue3/}, not the legacy Vue 2 upstream bundle. If someone accidentally
+     * reverts PR-5 or wires a different UI into the webjar, these markers disappear and the
+     * test fails.
+     *
+     * <p>This also exercises one more layer than the basic doc.html smoke: it fetches the
+     * first hashed JS entry referenced by doc.html to catch webjar packaging regressions
+     * (e.g. dist copy missing) that would leave doc.html served but JS 404.
+     */
+    @Test
+    public void shouldServeVue3UiAssetsAndSwaggerResources() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "spring.mvc.pathmatch.matching-strategy=ant_path_matcher",
+                        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+
+        // Vue 3 product markers: title text and the knife4j-next favicon reference both come from
+        // knife4j-vue3/doc.html. Neither exists in the upstream Vue 2 template.
+        Assert.assertTrue(
+                "doc.html should carry the Vue 3 Knife4j Next title (see knife4j-vue3/doc.html)",
+                docHtml.body.contains("<title>Knife4j Next</title>"));
+        Assert.assertTrue(
+                "doc.html should reference knife4j-next-mark.svg favicon (Vue 3 template only)",
+                docHtml.body.contains("knife4j-next-mark.svg"));
+
+        // Fetch the first hashed JS entry referenced from doc.html and assert it is actually
+        // served. This catches packaging regressions where vite dist wasn't copied into
+        // META-INF/resources/webjars/.
+        List<String> jsAssets = extractAssetPaths(docHtml.body);
+        Assert.assertFalse(
+                "doc.html should reference at least one webjars/js/ bundle",
+                jsAssets.isEmpty());
+        String firstAsset = jsAssets.get(0);
+        HttpResponse assetResponse = get(port, "/" + firstAsset);
+        Assert.assertEquals(
+                "First JS asset referenced by doc.html (" + firstAsset + ") must be reachable",
+                200, assetResponse.statusCode);
+
+        // /swagger-resources is the group listing endpoint that knife4j-aggregation-spring-boot-starter
+        // and the Vue 3 UI both rely on. Lock it down to a 200 + JSON array shape.
+        HttpResponse swaggerResources = get(port, "/swagger-resources");
+        Assert.assertEquals(200, swaggerResources.statusCode);
+        Assert.assertTrue(
+                "swagger-resources should return a JSON array",
+                swaggerResources.body.trim().startsWith("["));
+    }
+
+    /**
+     * Extract webjars/js/*.js asset paths referenced from a doc.html body. Only captures
+     * relative paths starting with {@code webjars/js/} to avoid matching external CDNs.
+     */
+    private static List<String> extractAssetPaths(String html) {
+        List<String> result = new ArrayList<>();
+        Pattern pattern = Pattern.compile("(?:src|href)=\"((?:\\./)?webjars/js/[^\"]+\\.js)\"");
+        Matcher matcher = pattern.matcher(html);
+        while (matcher.find()) {
+            String path = matcher.group(1);
+            if (path.startsWith("./")) {
+                path = path.substring(2);
+            }
+            result.add(path);
+        }
+        return result;
     }
 
     @Test


### PR DESCRIPTION
## 关联 Issue

- Part of #173（PR-6a，自动化子集）
- 依赖 #171（PR-5 vue3 Maven 集成，已合并）

## 变更内容

扩展 `knife4j-smoke-tests/boot2-app` 的 `Boot2DocHttpSmokeTest`，新增 `@Test shouldServeVue3UiAssetsAndSwaggerResources`，把 PR-5 切换到 Vue 3 产物的事实落到 CI 守护：

- `doc.html` 必须带 Vue 3 产物标记（`<title>Knife4j Next</title>`、`knife4j-next-mark.svg` 引用），这些 upstream Vue 2 模板里都没有
- `doc.html` 里引用的第一个 `webjars/js/*.js` 必须实际可 200 加载（抓 vite dist 未拷进 `META-INF/resources/webjars/` 这类打包回归）
- `/swagger-resources` 必须 200 且返回 JSON 数组（aggregation starter 与 Vue 3 UI 共同依赖）

同时给原有 `webjars/js/` 断言加了来源注释指向 `knife4j-vue3/vite.config.js`。

## 为什么是"子集"

原 #173 列了 10 条回归项，其中 1–9 大量依赖浏览器行为（搜索、调试、Authorize、i18n、Markdown、console 干净等）。本 PR 只处理能在 JUnit + 真实 Spring Boot + HttpURLConnection 层面验证的子集，覆盖"PR-5 的前端产物切换是否真的被打包进了 jar"这一类核心回归。其余浏览器相关条目继续保留在 #173 的 issue 评论里作为人工回归清单。

## 验证

```bash
./scripts/test-java.sh
```

本地结果：

- Maven reactor `BUILD SUCCESS`
- `boot2-app` surefire: `tests=3 failures=0 errors=0`
- `==> Smoke-tests evidence OK (5 modules)` — 哨兵通过

## 风险

- 只新增测试，不改产品代码；不影响 runtime 行为
- 断言字符串来自 `knife4j-vue3/doc.html`（title 文案、favicon 文件名），变更时需要同步更新测试
- `extractAssetPaths` 正则只匹配 `webjars/js/` 前缀的相对路径，不会误匹配外部 CDN

## 是否需要人工决策

否。是自动化子集，不试图替代人工浏览器回归。

