### PR TITLE
test(smoke): lock springdoc array-of-binary schema contract for multipart upload (#227 PR-227a)

### DIFF
--- a/knife4j/knife4j-smoke-tests/boot3-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3JakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot3-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3JakartaDocHttpSmokeTest.java
@@ -18,6 +18,8 @@
 package com.github.xiaoymin.knife4j.smoke.boot3;
 
 import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,7 +28,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,6 +39,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
 
 public class Boot3JakartaDocHttpSmokeTest {
 
@@ -92,6 +98,58 @@ public class Boot3JakartaDocHttpSmokeTest {
         HttpResponse docHtml = get(port, "/doc.html");
         Assert.assertFalse("doc.html should not return HTML content when production=true",
                 docHtml.body.contains("webjars/knife4j-ui-react/"));
+    }
+
+    /**
+     * Lock the springdoc schema contract that
+     * {@code @ArraySchema(schema = @Schema(type = "string", format = "binary"))} on a
+     * {@link MultipartFile}[] field (the canonical way to declare a multi-file upload, equivalent
+     * to what springdoc emits for WebFlux {@code Flux<FilePart>}) produces the
+     * {@code {"type":"array","items":{"type":"string","format":"binary"}}} OAS3 schema consumed by
+     * {@code knife4j-core}'s {@code extractFileFields()} (upstream xiaoymin/knife4j#733).
+     *
+     * <p>This closes the loop for issue #227: the front-end unit tests in
+     * {@code knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts} assert the
+     * parser side of this schema; this smoke assertion guarantees springdoc on the server side
+     * actually emits that shape.
+     */
+    @Test
+    public void shouldExposeArrayOfBinarySchemaForMultipartArrayUpload() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+
+        String body = apiDocs.body;
+        // The upload endpoint must be present.
+        Assert.assertTrue("api-docs should contain /upload-array path (#227)", body.contains("/upload-array"));
+        // The 'files' property must be an array whose items carry format:"binary".
+        //
+        // Important: springdoc 2.x (3.1 OAS) collapses @ArraySchema(schema=@Schema(type="string",
+        // format="binary")) to {items:{format:"binary", description:...}}, i.e. it drops an explicit
+        // type:"string" inside items. knife4j-core's extractFileFields() treats any items with
+        // format:"binary" as a file field, so this shape is still the upload schema contract the
+        // front-end consumes (upstream xiaoymin/knife4j#733).
+        //
+        // The regex matches the property declaration on one line, tolerating any field order inside
+        // items but requiring the array+binary+files-property triple to be co-located. DOTALL lets
+        // '.' span whatever whitespace springdoc emits.
+        Pattern filesArrayOfBinary = Pattern.compile(
+                "\"files\"\\s*:\\s*\\{[^{}]*\"type\"\\s*:\\s*\"array\"[^{}]*\"items\"\\s*:\\s*\\{[^{}]*\"format\"\\s*:\\s*\"binary\"",
+                Pattern.DOTALL);
+        Assert.assertTrue(
+                "springdoc should emit array-of-binary schema for the 'files' property annotated with "
+                        + "@ArraySchema(schema=@Schema(type=\"string\",format=\"binary\")). Full api-docs excerpt:\n"
+                        + body,
+                filesArrayOfBinary.matcher(body).find());
     }
 
     @Test
@@ -161,5 +219,27 @@ public class Boot3JakartaDocHttpSmokeTest {
         public String hello() {
             return "hello";
         }
+
+        /**
+         * Multi-file upload endpoint used to assert the springdoc schema contract in
+         * {@link #shouldExposeArrayOfBinarySchemaForMultipartArrayUpload()}. The
+         * {@code @ArraySchema(schema = @Schema(type = "string", format = "binary"))} annotation is
+         * the canonical pattern for declaring a multi-file upload and produces the OAS3 schema that
+         * {@code knife4j-core}'s {@code extractFileFields()} detects as a file field.
+         *
+         * <p>The actual request handling is irrelevant for a schema-only smoke; the method only
+         * needs to be reachable to springdoc's class scan.
+         */
+        @PostMapping(path = "/upload-array", consumes = "multipart/form-data")
+        public String uploadArray(@RequestBody UploadArrayRequest request) {
+            return "ok";
+        }
+    }
+
+    @Schema(description = "Multipart request body with an array of files")
+    public static class UploadArrayRequest {
+
+        @ArraySchema(schema = @Schema(type = "string", format = "binary", description = "Files to upload"))
+        public MultipartFile[] files;
     }
 }


### PR DESCRIPTION
## 背景

Part of #227 (upstream xiaoymin/knife4j#733). The two upstream loops for #227 — front-end parser `extractFileFields()` in `knife4j-core` and the demo-app `@ArraySchema` annotation fix in `UploadController.java` — are already on `master` via commit `cb029c5f`. What the previous review flagged and what was still missing is a CI-enforced guarantee that **springdoc 2.x actually emits the `{type:array, items:{format:"binary"}}` shape** for the canonical `MultipartFile[]` declaration, so the front-end and server contract can't drift silently.

This PR (PR-227a) is the minimum change that closes that gap.

## 改动

- `knife4j/knife4j-smoke-tests/boot3-jakarta-app/.../Boot3JakartaDocHttpSmokeTest.java`:
  - New `@Test shouldExposeArrayOfBinarySchemaForMultipartArrayUpload`:
    - Boots the existing smoke `TestApplication`
    - Calls `/v3/api-docs`
    - Asserts (a) the path `/upload-array` exists, (b) the `files` property is declared as `type:"array"` with `items.format:"binary"` co-located (regex to tolerate springdoc's field-ordering quirks)
  - New `@PostMapping("/upload-array")` in `TestController` backed by `UploadArrayRequest` DTO with a `MultipartFile[] files` field annotated `@ArraySchema(schema = @Schema(type = "string", format = "binary"))`.
  - Added imports: `ArraySchema`, `Schema`, `PostMapping`, `RequestBody`, `MultipartFile`, `java.util.regex.Pattern`.
- **No** new smoke module, **no** new WebFlux/netty dependency, **no** prettier/format churn. Intentionally narrow to avoid the scope-drift flagged in the previous #227 review round.

## 为什么正则而不是字符串匹配

springdoc 2.x (OAS 3.1) collapses `@ArraySchema(schema=@Schema(type="string", format="binary"))` down to `{items:{format:"binary", description:...}}`, i.e. it drops the explicit `type:"string"` inside `items` (description field ordering also varies). `knife4j-core`'s `extractFileFields()` treats **any** items with `format:"binary"` as a file field, so the regex asserts the exact invariant the front-end actually consumes: `"files"` co-located with `type:"array"` and `format:"binary"`. DOTALL lets the pattern span whatever whitespace springdoc emits.

## 验证

```
export JAVA_HOME=$(/usr/libexec/java_home -v 17)
./scripts/test-java.sh
...
==> Verifying smoke-tests evidence (issue #241)
   [OK]      boot2-app: tests=3 failures=0 errors=0
   [OK]      boot2-openapi3-app: tests=3 failures=0 errors=0
   [OK]      boot3-app: tests=1 failures=0 errors=0
   [OK]      boot3-jakarta-app: tests=4 failures=0 errors=0        ← was 3, this PR adds the 4th
   [OK]      boot35-jakarta-app: tests=2 failures=0 errors=0
==> Smoke-tests evidence OK (5 modules)
```

No `knife4j-front/**` changes in this PR, so `./scripts/test-front-core.sh` is not required per RUNBOOK.

## 范围纪律

- #227 itself stays `status:blocked` after this PR merges. The remaining manual item (live browser verification against an actual WebFlux + `Flux<FilePart>` runtime) is explicitly out of scope here and will be handled as PR-227b when the maintainer is ready.
- This PR does **not** touch any prettier config, package.json, or front-end source — the scope drift called out in the previous review round (`67f41196` prettier 2→3 carry) does not repeat here.

Closes (partial) #227

