### PR TITLE
fix(ui-react): distinguish single- vs multi-file multipart schema (#251)

### DIFF
--- a/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
@@ -174,6 +174,10 @@ describe('buildOperationDebugModel — OAS3', () => {
     expect(model.bodyContents[0].category).toBe('multipart');
     expect(model.bodyContents[0].fileFields).toContain('file');
     expect(model.bodyContents[0].fileFields).not.toContain('description');
+    // Single-binary (not array) must NOT appear in fileFieldsMultiple (issue #251).
+    // Without this, the React UI renders <Upload multiple /> for single-file endpoints
+    // and happily sends multiple parts that the server silently drops.
+    expect(model.bodyContents[0].fileFieldsMultiple ?? []).not.toContain('file');
   });
 
   // WebFlux + springdoc: Flux<FilePart> generates {type:array, items:{type:string,format:binary}}
@@ -224,6 +228,14 @@ describe('buildOperationDebugModel — OAS3', () => {
     expect(model.bodyContents[0].fileFields).toContain('avatar');
     // plain string must NOT be in fileFields
     expect(model.bodyContents[0].fileFields).not.toContain('description');
+
+    // issue #251: the array / non-array distinction must be preserved so the UI can
+    // decide between <Upload multiple /> and <Upload /> (single). fileFields alone
+    // cannot carry this (it is string[] consumed by existing callers).
+    const multiple = model.bodyContents[0].fileFieldsMultiple ?? [];
+    expect(multiple).toContain('files'); // Flux<FilePart> / MultipartFile[]
+    expect(multiple).not.toContain('avatar'); // single FilePart / MultipartFile
+    expect(multiple).not.toContain('description'); // not a file field at all
   });
 
   test('parses OAS3 multipart with array-of-base64 schema as file field', () => {
@@ -258,6 +270,8 @@ describe('buildOperationDebugModel — OAS3', () => {
     });
 
     expect(model.bodyContents[0].fileFields).toContain('attachments');
+    // base64 array should also be treated as a multi-file field (issue #251).
+    expect(model.bodyContents[0].fileFieldsMultiple ?? []).toContain('attachments');
   });
 
   test('parses OAS3 with multiple content types in requestBody', () => {

--- a/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
@@ -274,6 +274,106 @@ describe('buildOperationDebugModel — OAS3', () => {
     expect(model.bodyContents[0].fileFieldsMultiple ?? []).toContain('attachments');
   });
 
+  // Regression guard for issue #251 live repro against knife4j-demo:
+  //
+  //   springdoc 2.x (OAS 3.1) emits `@ArraySchema(schema=@Schema(type="string",
+  //   format="binary"))` as `{ items: { format: "binary", description: ... } }` —
+  //   it DROPS `type:"string"` from items. Matching `items.type === 'string'`
+  //   silently fails, the 'files' field falls out of both fileFields and
+  //   fileFieldsMultiple, and the React UI renders a plain text input instead of
+  //   a multi-file Upload widget.
+  //
+  //   This test uses the exact shape produced by `curl /v3/api-docs` against the
+  //   knife4j-demo `POST /upload/files-with-meta` endpoint (UploadController).
+  test('parses OAS3 multipart with items.type omitted (springdoc 2.x reality) — array-of-binary still detected', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/upload/files-with-meta': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      // NOTE: no `type: 'string'` inside items — matches springdoc 2.x output.
+                      files: {
+                        type: 'array',
+                        items: { format: 'binary', description: 'Files to upload' },
+                        minItems: 1,
+                      },
+                      meta: { type: 'object', description: 'JSON meta' },
+                    },
+                    required: ['meta'],
+                  },
+                  encoding: { meta: { contentType: 'application/json' } },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/upload/files-with-meta',
+      method: 'post',
+    });
+
+    expect(model.bodyContents[0].fileFields).toContain('files');
+    expect(model.bodyContents[0].fileFieldsMultiple ?? []).toContain('files');
+    // meta is not a file field.
+    expect(model.bodyContents[0].fileFields).not.toContain('meta');
+  });
+
+  // Negative case to make sure we don't over-trigger: a plain number[] array
+  // must not be mistaken for a file just because the loosened items check no
+  // longer requires type:"string".
+  test('does not mistake non-binary array for file field', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/x': {
+          post: {
+            requestBody: {
+              content: {
+                'multipart/form-data': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      // Explicit non-string items — must stay out of fileFields.
+                      ids: { type: 'array', items: { type: 'integer' } },
+                      // No format — must stay out.
+                      tags: { type: 'array', items: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/x',
+      method: 'post',
+    });
+
+    expect(model.bodyContents[0].fileFields ?? []).not.toContain('ids');
+    expect(model.bodyContents[0].fileFields ?? []).not.toContain('tags');
+    expect(model.bodyContents[0].fileFieldsMultiple ?? []).not.toContain('ids');
+    expect(model.bodyContents[0].fileFieldsMultiple ?? []).not.toContain('tags');
+  });
+
   test('parses OAS3 with multiple content types in requestBody', () => {
     const doc = {
       openapi: '3.0.1',

--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -157,6 +157,32 @@ function extractFileFields(schema: Record<string, unknown> | undefined): string[
   return files;
 }
 
+/**
+ * 从 OAS3 requestBody 中提取「允许多文件」的字段名子集（`fileFields` 的真子集）。
+ *
+ * 识别规则：`type:"array"` 且 `items.format` 为 `"binary"` 或 `"base64"`。这正是
+ * springdoc 为后端 `MultipartFile[]` 和 WebFlux `Flux<FilePart>` 发射的 schema
+ * 形状（参考 boot3-jakarta-app 的 `shouldExposeArrayOfBinarySchemaForMultipartArrayUpload`
+ * smoke 测试）。不在此列表内的文件字段即单文件，UI 层应按 `<Upload multiple={false}>`
+ * 渲染，并在 FormData 组装时只追加 1 份 part。
+ *
+ * 上游参考：xiaoymin/knife4j#733；本仓 issue #227、#251。
+ */
+function extractMultipleFileFields(schema: Record<string, unknown> | undefined): string[] {
+  if (!schema || schema.type !== 'object' || !schema.properties) return [];
+  const props = schema.properties as Record<string, Record<string, unknown>>;
+  const multiple: string[] = [];
+  for (const [name, prop] of Object.entries(props)) {
+    if (prop.type === 'array' && prop.items) {
+      const items = prop.items as Record<string, unknown>;
+      if (items.type === 'string' && (items.format === 'binary' || items.format === 'base64')) {
+        multiple.push(name);
+      }
+    }
+  }
+  return multiple;
+}
+
 /** 从 OAS3 requestBody encoding 中提取 contentType=application/json 的字段名 */
 function extractJsonEncodingFields(encoding: Record<string, unknown> | undefined): string[] {
   if (!encoding) return [];
@@ -395,6 +421,11 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
               ? JSON.stringify(mediaObj.example, null, 2)
               : undefined,
           fileFields: isMultipart ? extractFileFields(schema) : undefined,
+          // 区分「单文件」与「多文件」语义（issue #251）：
+          // fileFields 记录所有文件字段（兼容老消费方），fileFieldsMultiple 仅记录
+          // 其中允许多选的子集。UI 层据此决定 `<Upload multiple>` 和 FormData
+          // 组装时 append 几次。
+          fileFieldsMultiple: isMultipart ? extractMultipleFileFields(schema) : undefined,
           jsonFields: isMultipart ? extractJsonEncodingFields(encoding) : undefined,
         });
       }

--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -135,6 +135,25 @@ function classifyContentType(mediaType: string): BodyContentType {
   return 'raw';
 }
 
+/**
+ * 判断某个 `items` schema 是否代表二进制文件。
+ *
+ * springdoc 2.x（OAS 3.1）对 `@ArraySchema(schema=@Schema(type="string", format="binary"))`
+ * 会 **丢掉 items 里的 `type:"string"`**，实际吐出的是
+ * `{ items: { format: "binary", description: "..." } }`（真实请求参见
+ * `boot3-jakarta-app` 的 `shouldExposeArrayOfBinarySchemaForMultipartArrayUpload`
+ * smoke test 正则，以及 issue #251 的 live 复现）。
+ *
+ * 因此这里只看 `format` 是否为 `binary` / `base64`，不强求 `type === "string"`——
+ * 否则 React UI 会把实际的文件数组字段渲染成普通文本输入框。
+ */
+function isBinaryItems(items: Record<string, unknown>): boolean {
+  if (items.format !== 'binary' && items.format !== 'base64') return false;
+  // 如果 items.type 存在但显式不是 'string'，说明是其他数组（例如 number[]），不算文件。
+  // 没有 type 字段 / type === 'string' 都接受。
+  return items.type === undefined || items.type === 'string';
+}
+
 /** 从 OAS3 requestBody 中提取 file 字段名 */
 function extractFileFields(schema: Record<string, unknown> | undefined): string[] {
   if (!schema || schema.type !== 'object' || !schema.properties) return [];
@@ -144,9 +163,8 @@ function extractFileFields(schema: Record<string, unknown> | undefined): string[
     if (prop.type === 'string' && (prop.format === 'binary' || prop.format === 'base64')) {
       files.push(name);
     }
-    if (prop.type === 'array' && prop.items) {
-      const items = prop.items as Record<string, unknown>;
-      if (items.type === 'string' && (items.format === 'binary' || items.format === 'base64')) {
+    if (prop.type === 'array' && prop.items && typeof prop.items === 'object') {
+      if (isBinaryItems(prop.items as Record<string, unknown>)) {
         files.push(name);
       }
     }
@@ -173,9 +191,8 @@ function extractMultipleFileFields(schema: Record<string, unknown> | undefined):
   const props = schema.properties as Record<string, Record<string, unknown>>;
   const multiple: string[] = [];
   for (const [name, prop] of Object.entries(props)) {
-    if (prop.type === 'array' && prop.items) {
-      const items = prop.items as Record<string, unknown>;
-      if (items.type === 'string' && (items.format === 'binary' || items.format === 'base64')) {
+    if (prop.type === 'array' && prop.items && typeof prop.items === 'object') {
+      if (isBinaryItems(prop.items as Record<string, unknown>)) {
         multiple.push(name);
       }
     }

--- a/knife4j-front/knife4j-core/src/debug/types.ts
+++ b/knife4j-front/knife4j-core/src/debug/types.ts
@@ -58,6 +58,19 @@ export interface BodyContent {
   /** multipart 场景中标记哪些字段是 file / binary */
   fileFields?: string[];
   /**
+   * `fileFields` 中允许多文件（schema `type:"array"` + `items.format:"binary"`，对应
+   * 后端 `MultipartFile[]` / `Flux<FilePart>`）的字段名子集。
+   *
+   * 之所以用旁路字段而不是把 `fileFields` 改成 `{name, multiple}[]`：`fileFields:
+   * string[]` 已被 `requestBuilder.validateRequired` 等外部调用方消费，改变形状会引入
+   * 连锁破坏。UI 层只需同时查两张表：字段在 `fileFields` 里即文件字段，在
+   * `fileFieldsMultiple` 里即允许多选；否则为单文件（`<Upload multiple={false}>`，
+   * FormData 组装时只追加一份）。
+   *
+   * 上游参考：xiaoymin/knife4j#733；本仓 issue #227、#251。
+   */
+  fileFieldsMultiple?: string[];
+  /**
    * multipart 场景中标记哪些字段的 encoding.contentType = application/json，
    * 这些字段在 UI 中以 JSON 文本框形式提交，发送时作为独立 JSON part 附加。
    */

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -267,13 +267,21 @@ function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
       // fileFieldsMultiple, or (b) it has the explicit array-of-binary/base64 shape.
       // (b) is a defence-in-depth: older documents produced before fileFieldsMultiple
       // existed still render correctly.
+      //
+      // Important: springdoc 2.x (OAS 3.1) drops `type:"string"` from items, emitting
+      // `{ items: { format: "binary", description: ... } }` for @ArraySchema(schema=
+      // @Schema(type="string", format="binary")). So the fallback must NOT require
+      // items.type === 'string'; only the format matters. Matches knife4j-core's
+      // isBinaryItems() (issue #251 live repro against knife4j-demo).
       let isMultipleFile = false;
       if (isFile) {
         if (multipleFileFields.has(name)) {
           isMultipleFile = true;
         } else if (t === 'array' && prop.items && typeof prop.items === 'object') {
           const items = prop.items as Record<string, unknown>;
-          if (items.type === 'string' && (items.format === 'binary' || items.format === 'base64')) {
+          const hasBinaryFormat = items.format === 'binary' || items.format === 'base64';
+          const typeOk = items.type === undefined || items.type === 'string';
+          if (hasBinaryFormat && typeOk) {
             isMultipleFile = true;
           }
         }

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -226,6 +226,13 @@ interface SchemaFieldRow {
   example?: unknown;
   enum?: unknown[];
   isFile: boolean;
+  /**
+   * File field backed by an array schema (`type:"array"` + `items.format:"binary"|"base64"`)
+   * — the UI renders `<Upload multiple />` and the send handler appends every file
+   * as a separate part. When `false`, the field is a single-file upload and **must**
+   * only send one part even if the user somehow staged more (issue #251).
+   */
+  isMultipleFile: boolean;
   /** encoding.contentType=application/json — render as JSON TextArea */
   isJson: boolean;
 }
@@ -240,6 +247,10 @@ function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
   const props = schema.properties as Record<string, Record<string, unknown>>;
   const requiredSet = new Set<string>(Array.isArray(schema.required) ? (schema.required as string[]) : []);
   const fileFields = new Set(bodyContent.fileFields ?? []);
+  // issue #251: multi-file field names are a subset of fileFields, derived from
+  // `type:"array"` + `items.format:"binary"|"base64"`. This set is what lets us
+  // distinguish MultipartFile / FilePart (single) from MultipartFile[] / Flux<FilePart>.
+  const multipleFileFields = new Set(bodyContent.fileFieldsMultiple ?? []);
   const jsonFields = new Set(bodyContent.jsonFields ?? []);
 
   return Object.entries(props)
@@ -252,6 +263,22 @@ function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
         (t === 'string' && prop.format === 'binary') ||
         (t === 'string' && prop.format === 'base64');
 
+      // A field is considered multi-file if either (a) knife4j-core marked it in
+      // fileFieldsMultiple, or (b) it has the explicit array-of-binary/base64 shape.
+      // (b) is a defence-in-depth: older documents produced before fileFieldsMultiple
+      // existed still render correctly.
+      let isMultipleFile = false;
+      if (isFile) {
+        if (multipleFileFields.has(name)) {
+          isMultipleFile = true;
+        } else if (t === 'array' && prop.items && typeof prop.items === 'object') {
+          const items = prop.items as Record<string, unknown>;
+          if (items.type === 'string' && (items.format === 'binary' || items.format === 'base64')) {
+            isMultipleFile = true;
+          }
+        }
+      }
+
       return {
         name,
         type: isFile ? 'file' : t,
@@ -262,6 +289,7 @@ function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
         example: prop.example,
         enum: Array.isArray(prop.enum) ? prop.enum : undefined,
         isFile,
+        isMultipleFile,
         isJson: !isFile && jsonFields.has(name),
       };
     });
@@ -890,10 +918,19 @@ function MultipartForm({ bodyContent, formFields, setFormFields, fileFieldsRef }
       key: 'value',
       render: (_value, record: SchemaFieldRow) => {
         if (record.isFile) {
+          // issue #251: only enable multi-select for schemas that are actually array
+          // of binary/base64. Otherwise the server endpoint is a single-file handler
+          // (e.g. `@RequestPart("file") MultipartFile file`) and extra parts get
+          // silently dropped, which looks like success but isn't.
+          //
+          // `maxCount={1}` on top of `multiple={false}` makes the UI replace the
+          // previously staged file on re-select instead of appending — matches user
+          // expectation for a single-file control.
           return (
             <Upload
               beforeUpload={() => false} // 阻止自动上传
-              multiple
+              multiple={record.isMultipleFile}
+              maxCount={record.isMultipleFile ? undefined : 1}
               fileList={fileListMap[record.name] ?? []}
               onChange={(info) => handleFileChange(record.name, info)}
             >
@@ -1595,10 +1632,26 @@ export default function ApiDebug() {
           }
         }
         // 添加文件字段
+        //
+        // issue #251: single-file fields must only append ONE part even if the user
+        // (or a Upload control bug) staged multiple. The server-side contract for
+        // `@RequestPart("file") MultipartFile file` binds to the first part and
+        // silently drops the rest, which is an invisible data-loss bug. We use
+        // `fileFieldsMultiple` from knife4j-core to decide, matching the UI control
+        // rendered in MultipartForm.
+        const currentBody = debugModel.bodyContents.find((b) => b.mediaType === selectedContentType);
+        const multipleFileNames = new Set(currentBody?.fileFieldsMultiple ?? []);
         const files = fileFieldsRef.current;
         for (const [name, fileList] of Object.entries(files)) {
-          for (const file of fileList) {
-            fd.append(name, file);
+          if (fileList.length === 0) continue;
+          if (multipleFileNames.has(name)) {
+            for (const file of fileList) {
+              fd.append(name, file);
+            }
+          } else {
+            // Single-file: only the first staged file is sent. Belt-and-braces alongside
+            // <Upload maxCount={1}>.
+            fd.append(name, fileList[0]);
           }
         }
         init.body = fd;


### PR DESCRIPTION
Closes #251. Surfaced by the manual browser verification step of #227.

## 实际用户症状

对着 `knife4j-demo` 的 `POST /upload/file-with-meta`（`@RequestPart("file") MultipartFile file` — **单文件**）在 React UI 调试页选 2 个文件，实际发出的请求：

```
Content-Type: multipart/form-data; boundary=...
--...
Content-Disposition: form-data; name="meta"; filename="meta.json"
Content-Type: application/json

{"description":"...","category":"avatar","isPublic":true}
--...
Content-Disposition: form-data; name="file"; filename="waiipaper.jpg"   ← 第 1 份
Content-Type: image/jpeg
...
--...
Content-Disposition: form-data; name="file"; filename="avatar.jpg"      ← 第 2 份
Content-Type: image/jpeg
...
```

服务端响应 `{"filename":"waiipaper.jpg",...}` — 只绑到第一份，第二份被 Spring servlet multipart 静默丢弃。HTTP 200，但用户的第 2 个文件根本没上传成功。

## 根因

`knife4j-core` 的 `extractFileFields()` 返回 `string[]`，把「`type:"string", format:"binary"`（单文件）」和「`type:"array", items.format:"binary"`（数组文件）」的区别抹掉了。`ApiDebug.tsx` 侧：

- `<Upload>` 硬编码 `multiple` — 所有文件字段都允许多选
- FormData 组装无脑 `fd.append(name, file)` 循环 — 选几个 append 几次

## 改动

### `knife4j-front/knife4j-core`

- `BodyContent.fileFieldsMultiple?: string[]`：`fileFields` 的子集，只含数组语义字段。用旁路字段不动既有 `fileFields: string[]` 形状，避免破坏 `requestBuilder.validateRequired` 等现存消费方。
- `extractMultipleFileFields()` 辅助函数：识别 `type:"array"` + `items.format:"binary"|"base64"`。与 PR #250 的 springdoc smoke 断言是同一 schema 形状。
- 单测扩展（`operationDebugModel.test.ts`）：
  - 单文件 multipart：`fileFieldsMultiple` 不含单 binary 字段
  - Flux<FilePart> / MultipartFile[]：`files` 在，`avatar`（单 FilePart）不在，`description` 不在
  - array-of-base64：`attachments` 也归入多文件

### `knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx`

- `SchemaFieldRow.isMultipleFile: boolean`，优先读 `fileFieldsMultiple`；回退到直接看 schema（兼容上游老文档）。
- `<Upload multiple={record.isMultipleFile} maxCount={record.isMultipleFile ? undefined : 1}>`：单文件字段的 UI 只接受 1 份，重复选择替换之前那份。
- 发送处 FormData 组装同样按 `currentBody.fileFieldsMultiple` 分流：多文件 `fileList.forEach(append)`，单文件 `fd.append(name, fileList[0])`。即使未来 `<Upload>` 控件 bug 在 ref 里塞了多份，这条路径也兜底只发一份。

## 验证

```
./scripts/test-front-core.sh
...
Test Suites: 15 passed, 15 total
Tests:       177 passed, 177 total
```

两个 workspace 的 `format:check`、`lint`、`tsc`、`vite build` 全绿。

- **未触碰 Java** — diff 只在 `knife4j-front/**` 4 个文件内，按 RUNBOOK 不需要跑 `test-java.sh`。
- **未触碰 `knife4j-vue3`** — OAS2 兼容维护 UI，遵守 `.agent/PROJECT.md` 的边界。
- **无 prettier / 格式化 drift** — `lint-staged` 在 commit 时只改到本 PR 自己新增的 4 个文件。

## 范围纪律（和 #227 的关系）

- PR #250 已 merge：springdoc 发出的 `array-of-binary` schema 契约锁在 smoke 里。
- 本 PR 闭合前端侧：UI 按 schema 区分单/多文件，并在 FormData 组装层做兜底。
- **#227 仍保持 `status:blocked`**：live WebFlux + `Flux<FilePart>` runtime 的浏览器级验证仍然是人工事项，本 PR 不覆盖。

## 手动回归建议（合入后）

1. 起 `knife4j-demo`：`cd knife4j/knife4j-demo && mvn spring-boot:run`
2. 起 React UI：`cd knife4j-front && npm ci && npm run dev -w knife4j-ui-react`
3. `POST /upload/file-with-meta` 的 `file` 字段应渲染为**单文件选择**（不能选多个）
4. `POST /upload/files-with-meta` 的 `files` 字段应仍然渲染为**多文件选择**

