### PR TITLE
chore(repo): remove stray root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "knife4j",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Closes #257

## 改动

删除仓库根的孤儿 `package-lock.json`。

仓库根没有 `package.json`，该 lockfile 为空壳（6 行，`lockfileVersion: 2`，`packages: {}`），所有 CI / Maven / lefthook / 脚本都只引用 `knife4j-front/package-lock.json`，根 lockfile 无人消费。

## 验证

- `grep -R "package-lock.json" .github scripts knife4j/*/pom.xml knife4j-front/lefthook.yml` 等位置：全部指向 `knife4j-front/package-lock.json`，与根 lockfile 无关。
- `.gitattributes` 中 `package-lock.json merge=ours` 是通配，继续对 `knife4j-front/package-lock.json` 生效，无需修改。
- 无构建、发布、运行时路径依赖根 lockfile。

## 风险与回滚

- 风险：极低，纯删除。
- 回滚：`git revert` 即可。

