### PR TITLE
fix(ui): encode tag/operationId in route key (#717)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -143,7 +143,7 @@ export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): M
           tagMap.set(tag, { tag, operations: [] });
         }
         const menuOp: MenuOperation = {
-          key: `${tag}/${op.operationId ?? path}`,
+          key: `${encodeURIComponent(tag)}/${encodeURIComponent(op.operationId ?? path)}`,
           path,
           method,
           summary: op.summary ?? path,

--- a/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
@@ -24,7 +24,7 @@ export function useCurrentOperation(): CurrentOperation {
     const menuTag = menuTags.find((item) => item.tag === routeTag);
     return menuTag?.operations.find((item) => {
       const fallbackId = item.operationId ?? item.path;
-      return fallbackId === routeOperationId || item.key === `${routeTag}/${routeOperationId}`;
+      return fallbackId === routeOperationId || item.key === `${encodeURIComponent(routeTag)}/${encodeURIComponent(routeOperationId)}`;
     });
   }, [menuTags, operaterId, tag]);
 

--- a/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/useCurrentOperation.tsx
@@ -24,7 +24,10 @@ export function useCurrentOperation(): CurrentOperation {
     const menuTag = menuTags.find((item) => item.tag === routeTag);
     return menuTag?.operations.find((item) => {
       const fallbackId = item.operationId ?? item.path;
-      return fallbackId === routeOperationId || item.key === `${encodeURIComponent(routeTag)}/${encodeURIComponent(routeOperationId)}`;
+      return (
+        fallbackId === routeOperationId ||
+        item.key === `${encodeURIComponent(routeTag)}/${encodeURIComponent(routeOperationId)}`
+      );
     });
   }, [menuTags, operaterId, tag]);
 


### PR DESCRIPTION
## 问题

tag name 含 `#` 号（如 `注解解析复现（#717 #675 #745 #743 #767）`）时，直接拼进路由路径，浏览器把 `#` 当 fragment 截断，导致点击侧边栏接口跳 404。

## 修复

`knife4jClient.ts`：key 生成时对 tag 和 operationId 分别做 `encodeURIComponent`。

`useCurrentOperation.tsx`：key 比对时同步改为 encoded 形式。

路由解析侧（`useParams` + `decodeURIComponent`）已有 decode，不需要改。

## 影响范围

任何 tag name 含 `#`、`?`、`&`、空格等特殊字符的接口，均受此修复保护。