### PR TITLE
fix(vue3): encode tag.name in menu path to handle special chars

### DIFF
--- a/knife4j-vue3/src/core/Knife4jAsync.js
+++ b/knife4j-vue3/src/core/Knife4jAsync.js
@@ -3347,7 +3347,7 @@ SwaggerBootstrapUi.prototype.createDetailMenu = function (addFlag) {
         key: md5(_lititle),
         name: _lititle,
         icon: 'icon-APIwendang',
-        path: groupName + '/' + tag.name,
+        path: groupName + '/' + encodeURIComponent(tag.name),
         hasNew: tag.hasNew || tag.hasChanged,
         num: null,
         children: []


### PR DESCRIPTION
## 问题

同 #262（React 版本已修复）。

Vue3 版本（`knife4j-vue3`）中，`Knife4jAsync.js` 生成菜单路由 path 时直接拼 `tag.name`：

```js
path: groupName + '/' + tag.name
```

tag name 含 `#` 号时（如 `注解解析复现（#717 #675...）`），hash 路由中 `#` 被浏览器截断，点击侧边栏接口跳 404。

## 修复

```js
path: groupName + '/' + encodeURIComponent(tag.name)
```

Vue Router 动态路由段会自动 decode 参数，路由匹配侧不需要改。