### PR TITLE
feat: add knife4j-demo-openapi2 for OpenAPI 2 online demo

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -32,7 +32,7 @@ jobs:
         include:
           # OpenAPI 3 (Spring Boot 3 + springdoc + React UI) — deployed to openapi3.demo.knife4jnext.com
           - module: knife4j-demo
-            image: knife4j-demo
+            image: knife4j-demo-openapi3
             context: knife4j/knife4j-demo
           # OpenAPI 2 (Spring Boot 2 + springfox + Vue3 UI) — deployed to openapi2.demo.knife4jnext.com
           - module: knife4j-demo-openapi2

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -9,7 +9,8 @@ on:
       - 'knife4j-front/knife4j-core/**'
       - 'knife4j-front/knife4j-ui-react/**'
       - 'knife4j-front/package.json'
-      - 'knife4j-front/bun.lock'
+      - 'knife4j-front/package-lock.json'
+      - 'knife4j-vue3/**'
       - '.github/workflows/deploy-demo.yml'
     tags:
       - 'v*'
@@ -18,7 +19,6 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/knife4j-demo
 
 jobs:
   build-and-push:
@@ -26,6 +26,18 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # OpenAPI 3 (Spring Boot 3 + springdoc + React UI) — deployed to openapi3.demo.knife4jnext.com
+          - module: knife4j-demo
+            image: knife4j-demo
+            context: knife4j/knife4j-demo
+          # OpenAPI 2 (Spring Boot 2 + springfox + Vue3 UI) — deployed to openapi2.demo.knife4jnext.com
+          - module: knife4j-demo-openapi2
+            image: knife4j-demo-openapi2
+            context: knife4j/knife4j-demo-openapi2
     steps:
       - uses: actions/checkout@v4
 
@@ -39,17 +51,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-
-      - name: Set up bun
-        uses: oven-sh/setup-bun@v2
+          cache: npm
+          cache-dependency-path: knife4j-front/package-lock.json
 
       - name: Install knife4j-front workspace dependencies
-        run: bun install --frozen-lockfile
+        run: npm ci
         working-directory: knife4j-front
 
       - name: Build jar
         working-directory: knife4j
-        run: mvn -B -ntp -pl knife4j-demo -am package -DskipTests
+        run: mvn -B -ntp -pl ${{ matrix.module }} -am package -DskipTests
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -62,7 +73,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
@@ -70,7 +81,7 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: knife4j/knife4j-demo
+          context: ${{ matrix.context }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/knife4j/knife4j-demo-openapi2/Dockerfile
+++ b/knife4j/knife4j-demo-openapi2/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:8-jre-alpine
+WORKDIR /app
+COPY target/knife4j-demo-openapi2-*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "app.jar"]
+

--- a/knife4j/knife4j-demo-openapi2/pom.xml
+++ b/knife4j/knife4j-demo-openapi2/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j</artifactId>
+        <version>5.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-demo-openapi2</artifactId>
+    <name>knife4j-demo-openapi2</name>
+    <description>knife4j-next online demo application for OpenAPI 2 (Swagger 2) + Vue3 UI</description>
+
+    <properties>
+        <!-- SB2 + springfox stays on Java 8 for broadest compatibility. -->
+        <knife4j-java.version>1.8</knife4j-java.version>
+        <start-class>com.baizhukui.knife4j.demo.openapi2.DemoApplication</start-class>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipPublishing>true</skipPublishing>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${knife4j-spring-boot.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${knife4j-spring-boot.version}</version>
+                <configuration>
+                    <mainClass>${start-class}</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/DemoApplication.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/DemoApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2;
+
+import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * knife4j-next OAS2 online demo entry point.
+ *
+ * <p>Paired with {@code knife4j-demo} (OAS3 Jakarta) — this module serves the
+ * Vue3 UI webjar shipped by {@code knife4j-openapi2-ui} and is deployed to
+ * {@code openapi2.demo.knife4jnext.com}.
+ */
+@EnableKnife4j
+@SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/RootRedirectController.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/RootRedirectController.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class RootRedirectController {
+
+    @GetMapping("/")
+    public String redirectToDoc() {
+        return "redirect:/doc.html";
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/SwaggerConfig.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/SwaggerConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+/**
+ * Springfox {@link Docket} configuration for the OAS2 online demo.
+ *
+ * <p>{@code @EnableSwagger2WebMvc} is already contributed by
+ * {@code Knife4jAutoConfiguration} inside {@code knife4j-openapi2-spring-boot-starter},
+ * so we only need to declare the {@link Docket} bean here.
+ */
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public Docket defaultApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.baizhukui.knife4j.demo.openapi2"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("knife4j-next OAS2 Demo")
+                .description("knife4j-next 在线预览示例（Swagger 2 / Vue3 UI）")
+                .contact(new Contact("knife4j-next", "https://knife4jnext.com", null))
+                .version("1.0")
+                .build();
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/UploadController.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/UploadController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2;
+
+import com.baizhukui.knife4j.demo.openapi2.dto.UploadMetaDTO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Multipart file upload demo for the OAS2 / Swagger 2 line.
+ *
+ * <p>Note: Swagger 2 / springfox does not have a first-class equivalent of
+ * OAS3 {@code encoding.contentType=application/json}. This Controller still
+ * demonstrates the basic multipart form data upload pattern that knife4j
+ * Vue3 UI supports for OAS2.
+ */
+@Api(tags = "文件上传", description = "multipart 文件上传示例")
+@RestController
+@RequestMapping("/upload")
+public class UploadController {
+
+    @ApiOperation("上传单个文件 + JSON 元数据")
+    @PostMapping(value = "/file-with-meta", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, Object>> uploadFileWithMeta(
+                                                                  @RequestPart("file") MultipartFile file,
+                                                                  @RequestPart("meta") UploadMetaDTO meta) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("filename", file.getOriginalFilename());
+        result.put("size", file.getSize());
+        result.put("description", meta.getDescription());
+        result.put("category", meta.getCategory());
+        result.put("isPublic", Boolean.TRUE.equals(meta.getIsPublic()));
+        return ResponseEntity.ok(result);
+    }
+
+    @ApiOperation("批量上传文件 + JSON 元数据")
+    @PostMapping(value = "/files-with-meta", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, Object>> uploadFilesWithMeta(
+                                                                   @RequestPart("files") MultipartFile[] files,
+                                                                   @RequestPart("meta") UploadMetaDTO meta) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", files.length);
+        result.put("description", meta.getDescription());
+        result.put("category", meta.getCategory());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/UserController.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/UserController.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2;
+
+import com.baizhukui.knife4j.demo.openapi2.dto.PageQuery;
+import com.baizhukui.knife4j.demo.openapi2.dto.PageResult;
+import com.baizhukui.knife4j.demo.openapi2.dto.UserCreateRequest;
+import com.baizhukui.knife4j.demo.openapi2.dto.UserUpdateRequest;
+import com.baizhukui.knife4j.demo.openapi2.dto.UserVO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Api(tags = "用户接口", description = "用户相关示例接口")
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    @ApiOperation("获取用户列表")
+    @GetMapping("/list")
+    public List<UserVO> list() {
+        return Arrays.asList(
+                new UserVO(1L, "张三", "zhangsan@example.com"),
+                new UserVO(2L, "李四", "lisi@example.com"));
+    }
+
+    @ApiOperation("分页查询用户")
+    @GetMapping("/page")
+    public PageResult<UserVO> page(PageQuery query) {
+        List<UserVO> data = Arrays.asList(
+                new UserVO(1L, "张三", "zhangsan@example.com"),
+                new UserVO(2L, "李四", "lisi@example.com"));
+        return new PageResult<>(query.getPageNum(), query.getPageSize(), data.size(), data);
+    }
+
+    @ApiOperation("根据 ID 获取用户")
+    @ApiImplicitParam(name = "id", value = "用户 ID", paramType = "path", dataTypeClass = Long.class, required = true)
+    @GetMapping("/{id}")
+    public UserVO getById(@PathVariable Long id) {
+        return new UserVO(id, "张三", "zhangsan@example.com");
+    }
+
+    @ApiOperation("创建用户")
+    @PostMapping
+    public UserVO create(@RequestBody UserCreateRequest request) {
+        return new UserVO(3L, request.getName(), request.getEmail());
+    }
+
+    @ApiOperation("更新用户")
+    @ApiImplicitParam(name = "id", value = "用户 ID", paramType = "path", dataTypeClass = Long.class, required = true)
+    @PutMapping("/{id}")
+    public UserVO update(@PathVariable Long id, @RequestBody UserUpdateRequest request) {
+        return new UserVO(id, request.getName(), request.getEmail());
+    }
+
+    @ApiOperation("删除用户")
+    @ApiImplicitParam(name = "id", value = "用户 ID", paramType = "path", dataTypeClass = Long.class, required = true)
+    @DeleteMapping("/{id}")
+    public UserVO delete(@PathVariable Long id) {
+        return new UserVO(id, "张三", "zhangsan@example.com");
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/PageQuery.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/PageQuery.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "分页查询参数")
+public class PageQuery {
+
+    @ApiModelProperty(value = "页码（从 1 开始）", example = "1")
+    private int pageNum = 1;
+
+    @ApiModelProperty(value = "每页条数", example = "10")
+    private int pageSize = 10;
+
+    @ApiModelProperty(value = "关键词（模糊搜索用户名或邮箱）", example = "张")
+    private String keyword;
+
+    public PageQuery() {
+    }
+
+    public int getPageNum() {
+        return pageNum;
+    }
+    public void setPageNum(int pageNum) {
+        this.pageNum = pageNum;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/PageResult.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/PageResult.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.List;
+
+@ApiModel(description = "分页结果")
+public class PageResult<T> {
+
+    @ApiModelProperty(value = "当前页码", example = "1")
+    private int pageNum;
+
+    @ApiModelProperty(value = "每页条数", example = "10")
+    private int pageSize;
+
+    @ApiModelProperty(value = "总记录数", example = "100")
+    private long total;
+
+    @ApiModelProperty(value = "数据列表")
+    private List<T> list;
+
+    public PageResult() {
+    }
+
+    public PageResult(int pageNum, int pageSize, long total, List<T> list) {
+        this.pageNum = pageNum;
+        this.pageSize = pageSize;
+        this.total = total;
+        this.list = list;
+    }
+
+    public int getPageNum() {
+        return pageNum;
+    }
+    public void setPageNum(int pageNum) {
+        this.pageNum = pageNum;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+    public void setTotal(long total) {
+        this.total = total;
+    }
+
+    public List<T> getList() {
+        return list;
+    }
+    public void setList(List<T> list) {
+        this.list = list;
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UploadMetaDTO.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UploadMetaDTO.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * 文件上传附带的 JSON 元数据 DTO（用于演示 multipart 场景）。
+ */
+@ApiModel(description = "文件上传元数据")
+public class UploadMetaDTO {
+
+    @ApiModelProperty(value = "文件描述", example = "用户头像")
+    private String description;
+
+    @ApiModelProperty(value = "文件分类标签", example = "avatar")
+    private String category;
+
+    @ApiModelProperty(value = "是否公开", example = "true")
+    private Boolean isPublic;
+
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public Boolean getIsPublic() {
+        return isPublic;
+    }
+    public void setIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UserCreateRequest.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UserCreateRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "创建用户请求")
+public class UserCreateRequest {
+
+    @ApiModelProperty(value = "用户名", example = "张三", required = true)
+    private String name;
+
+    @ApiModelProperty(value = "邮箱地址", example = "zhangsan@example.com", required = true)
+    private String email;
+
+    public UserCreateRequest() {
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UserUpdateRequest.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UserUpdateRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "更新用户请求")
+public class UserUpdateRequest {
+
+    @ApiModelProperty(value = "用户名", example = "李四")
+    private String name;
+
+    @ApiModelProperty(value = "邮箱地址", example = "lisi@example.com")
+    private String email;
+
+    public UserUpdateRequest() {
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UserVO.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/dto/UserVO.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "用户视图对象")
+public class UserVO {
+
+    @ApiModelProperty(value = "用户 ID", example = "1")
+    private Long id;
+
+    @ApiModelProperty(value = "用户名", example = "张三")
+    private String name;
+
+    @ApiModelProperty(value = "邮箱地址", example = "zhangsan@example.com")
+    private String email;
+
+    public UserVO() {
+    }
+
+    public UserVO(Long id, String name, String email) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/knife4j/knife4j-demo-openapi2/src/main/resources/application.yml
+++ b/knife4j/knife4j-demo-openapi2/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+server:
+  port: 8081
+
+spring:
+  mvc:
+    # springfox 2.10.x relies on Spring's legacy AntPathMatcher; SB 2.7 default is PATH_PATTERN_PARSER.
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+knife4j:
+  enable: true
+  setting:
+    language: zh-CN
+    enable-swagger-models: true
+    enable-document-manage: true
+    swagger-model-name: 实体类列表
+

--- a/knife4j/knife4j-demo/docker-compose.yml
+++ b/knife4j/knife4j-demo/docker-compose.yml
@@ -1,7 +1,0 @@
-services:
-  knife4j-demo:
-    image: ghcr.io/songxychn/knife4j-next/knife4j-demo:latest
-    container_name: knife4j-demo
-    restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.0-SNAPSHOT</version>
     <modules>
         <module>knife4j-core</module>
         <module>knife4j-dependencies</module>
@@ -21,6 +21,7 @@
         <module>knife4j-openapi3-webflux-jakarta-spring-boot-starter</module>
         <module>knife4j-smoke-tests</module>
         <module>knife4j-demo</module>
+        <module>knife4j-demo-openapi2</module>
     </modules>
     <packaging>pom</packaging>
     <name>knife4j</name>


### PR DESCRIPTION
## Summary

Adds a standalone `knife4j-demo-openapi2` module to provide an online demo for the OpenAPI 2 / Swagger 2 + Vue3 UI product line, deployed to `openapi2.demo.knife4jnext.com`.

This gives users the ability to see both UI versions side-by-side:
- **OpenAPI 3** (React UI) → `openapi3.demo.knife4jnext.com`
- **OpenAPI 2** (Vue3 UI) → `openapi2.demo.knife4jnext.com`

## Changes

### New module: `knife4j/knife4j-demo-openapi2`
- Spring Boot 2.7.18 + springfox 2.10.5 + `knife4j-openapi2-spring-boot-starter`
- `UserController` (CRUD + pagination) with Swagger 2 annotations (`@Api`, `@ApiOperation`, `@ApiImplicitParam`)
- `UploadController` (multipart file + JSON metadata)
- DTOs: `UserVO`, `PageQuery`, `PageResult<T>`, `UserCreateRequest`, `UserUpdateRequest`, `UploadMetaDTO` (using `@ApiModel`/`@ApiModelProperty`)
- `SwaggerConfig` with `Docket` bean + `@EnableKnife4j`
- `RootRedirectController`: `/` → `/doc.html`
- `application.yml`: port 8081, `ant_path_matcher` for springfox compatibility
- `Dockerfile` based on `eclipse-temurin:8-jre-alpine`

### Modified files
- **`knife4j/pom.xml`**: register `knife4j-demo-openapi2` module
- **`.github/workflows/deploy-demo.yml`**: use matrix strategy to build and push both demo images to GHCR
  - `knife4j-demo` → `ghcr.io/songxychn/knife4j-next/knife4j-demo`
  - `knife4j-demo-openapi2` → `ghcr.io/songxychn/knife4j-next/knife4j-demo-openapi2`
- Added `knife4j-vue3/**` to workflow path triggers (OAS2 UI changes should also rebuild the OAS2 demo)

### Deleted files
- **`knife4j/knife4j-demo/docker-compose.yml`**: deployment compose is managed separately on the server

## Scope (Plan B: core subset only)

Only the core controllers are included — no issue-reproduction controllers (generic/nested/$ref, validation groups, etc.). The OAS2 line is in maintenance mode; the demo should showcase basic capabilities without implying new feature delivery.

## Verification

- ✅ `mvn -B -ntp -pl knife4j-demo-openapi2 -am package -DskipTests` — BUILD SUCCESS
- ✅ `mvn -B -ntp -pl knife4j-demo -am package -DskipTests` — BUILD SUCCESS (existing demo unaffected)

## Out of Scope

- Server-side Nginx / DNS configuration for `openapi2.demo.knife4jnext.com` and `openapi3.demo.knife4jnext.com`
- Spring Boot 3 + OpenAPI 2 (technically infeasible — springfox doesn't support jakarta)
- Spring Boot 2 + OpenAPI 3 (already covered by smoke tests; UI identical to existing OAS3 demo)

Closes #264

