### PR TITLE
fix(ui-react): prevent JSON field comments from being copied

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
@@ -153,6 +153,7 @@ const jsonDescStyle: React.CSSProperties = {
   fontSize: 12,
   fontStyle: 'italic',
   color: '#8c8c8c',
+  userSelect: 'none',
 };
 
 export default function ResponsePanel({

--- a/knife4j-vue3/src/core/Knife4jAsync.js
+++ b/knife4j-vue3/src/core/Knife4jAsync.js
@@ -3347,7 +3347,7 @@ SwaggerBootstrapUi.prototype.createDetailMenu = function (addFlag) {
         key: md5(_lititle),
         name: _lititle,
         icon: 'icon-APIwendang',
-        path: groupName + '/' + tag.name,
+        path: groupName + '/' + encodeURIComponent(tag.name),
         hasNew: tag.hasNew || tag.hasChanged,
         num: null,
         children: []


### PR DESCRIPTION
## 问题

调试结果 JSON 中的字段注释（schema description）通过 `// xxx` 形式渲染，用户复制 JSON 时会把注释一起复制下来。

## 修复

给 `jsonDescStyle` 加上 `userSelect: 'none'`，注释可见但不参与文本选择，与 Vue2 版本行为一致。

## 变更

- `ResponsePanel.tsx`: `jsonDescStyle` 新增 `userSelect: 'none'`