### PR TITLE
ci(deploy-demo): switch from npm to bun for frontend deps

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -9,7 +9,7 @@ on:
       - 'knife4j-front/knife4j-core/**'
       - 'knife4j-front/knife4j-ui-react/**'
       - 'knife4j-front/package.json'
-      - 'knife4j-front/package-lock.json'
+      - 'knife4j-front/bun.lock'
       - 'knife4j-vue3/**'
       - '.github/workflows/deploy-demo.yml'
     tags:
@@ -51,12 +51,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: knife4j-front/package-lock.json
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install knife4j-front workspace dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
         working-directory: knife4j-front
+
+      - name: Install knife4j-vue3 dependencies
+        run: bun install --frozen-lockfile
+        working-directory: knife4j-vue3
 
       - name: Build jar
         working-directory: knife4j
@@ -85,5 +90,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-


### PR DESCRIPTION
## 背景

Closes #269

PR #267 合并后，deploy-demo workflow 失败（[run #25445869199](https://github.com/songxychn/knife4j-next/actions/runs/25445869199)）。

错误：`Some specified paths were not resolved, unable to cache dependencies.`

根因：workflow 配置了 `cache: npm` + `cache-dependency-path: knife4j-front/package-lock.json`，但项目用的是 bun（`bun.lock`），根本没有 `package-lock.json`。后续 `npm ci` 也无 lockfile 可用。

## 改动

| 变更 | 说明 |
|------|------|
| 移除 `setup-node` 的 `cache: npm` / `cache-dependency-path` | `package-lock.json` 不存在 |
| 新增 `oven-sh/setup-bun@v2` | 与 `build.yml` / `release.yml` 对齐 |
| `npm ci` → `bun install --frozen-lockfile`（`knife4j-front`） | 正确的包管理器 |
| 新增 `bun install --frozen-lockfile`（`knife4j-vue3`） | `knife4j-openapi2-ui` 的 maven 构建依赖 `knife4j-vue3` 前端产物 |
| paths 过滤 `package-lock.json` → `bun.lock` | 监听正确的 lockfile |

## 验证

- 本地两个 demo 模块 `mvn package -DskipTests` 成功
- 最终验收以合并后 master 上的 deploy-demo run 成功为准

