### PR TITLE
fix(ui-react): render JSON field descriptions as right-aligned annotations

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
@@ -140,12 +140,15 @@ const preStyle: React.CSSProperties = {
 const jsonCodeStyle: React.CSSProperties = {
   fontFamily: "Menlo, Monaco, Consolas, 'Courier New', monospace",
   color: '#24292e',
+  flex: '1 1 auto',
+  minWidth: 0,
 };
 
 /**
- * Inline schema description comments — uses a different font (sans-serif),
- * smaller size, lighter color and italic so readers can tell at a glance
- * that it is not part of the JSON payload.
+ * Schema description annotation — floated to the right in its own column,
+ * visually separated from the JSON code. Uses a different font, smaller size,
+ * and lighter color. `userSelect: none` keeps it out of clipboard copies,
+ * matching the Vue2 `position: absolute` approach.
  */
 const jsonDescStyle: React.CSSProperties = {
   fontFamily:
@@ -154,6 +157,9 @@ const jsonDescStyle: React.CSSProperties = {
   fontStyle: 'italic',
   color: '#8c8c8c',
   userSelect: 'none',
+  flex: '0 0 auto',
+  marginLeft: 24,
+  whiteSpace: 'nowrap',
 };
 
 export default function ResponsePanel({
@@ -440,11 +446,20 @@ function ContentTab({
               </Checkbox>
             </div>
           )}
-          <pre style={preStyle}>
+          <pre style={{ ...preStyle, whiteSpace: 'pre' }}>
             {lines.map((line, i) => (
-              <span key={i}>
+              <span
+                key={i}
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  // newline is handled by the block itself; pre whitespace preserved via parent
+                }}
+              >
                 <span style={jsonCodeStyle}>{line.code}</span>
-                {line.description && <span style={jsonDescStyle}>{`  // ${line.description}`}</span>}
+                {line.description ? (
+                  <span style={jsonDescStyle}>{line.description}</span>
+                ) : null}
                 {i < lines.length - 1 ? '\n' : ''}
               </span>
             ))}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
@@ -457,9 +457,7 @@ function ContentTab({
                 }}
               >
                 <span style={jsonCodeStyle}>{line.code}</span>
-                {line.description ? (
-                  <span style={jsonDescStyle}>{line.description}</span>
-                ) : null}
+                {line.description ? <span style={jsonDescStyle}>{line.description}</span> : null}
                 {i < lines.length - 1 ? '\n' : ''}
               </span>
             ))}


### PR DESCRIPTION
## 问题

调试结果 JSON 中的字段注释（schema description）以 `// xxx` 形式内联渲染，视觉上像代码注释，且复制 JSON 时会一起被带走。

## 修复

改为 flex 布局，JSON 代码占左侧，描述文字靠右对齐，与 Vue2 版本的 `position: absolute` 效果一致：
- 描述列视觉上与 JSON 代码隔离，不再像注释
- 去掉 `// ` 前缀
- `userSelect: none` 保留，复制 JSON 时描述列不会被带走

## 变更

- `ResponsePanel.tsx`: `jsonCodeStyle` 加 `flex: 1 1 auto`，`jsonDescStyle` 加 `flex: 0 0 auto` + `marginLeft: 24`，每行容器改为 `display: flex`