### PR TITLE
fix(ui-react): display generic schema title with <T> notation (issue #292)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
@@ -6,7 +6,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useGroup } from '../../context/GroupContext';
 import type { SchemaObject, SwaggerDoc } from '../../types/swagger';
-import { schemaNodeRefName, schemaNodeTypeLabel } from './schemaUtils';
+import { normalizeGenericTitle, schemaNodeRefName, schemaNodeTypeLabel } from './schemaUtils';
 
 const { Text } = Typography;
 
@@ -69,6 +69,16 @@ export function SchemaTypeLink({ node }: SchemaTypeLinkProps) {
     );
   }
 
+  // Use the schema's title (normalized from guillemets) as the display label when available
+  const normalizedTitle = normalizeGenericTitle(schema.title);
+  const displayLabel =
+    normalizedTitle && normalizedTitle !== refName
+      ? node.type === 'array'
+        ? `${normalizedTitle}[]`
+        : normalizedTitle
+      : label;
+  const popoverTitle = normalizedTitle && normalizedTitle !== refName ? normalizedTitle : refName;
+
   const previewFields = modelPreviewFields(schema, swaggerDoc);
   const content = (
     <div style={{ maxWidth: 420 }}>
@@ -106,10 +116,10 @@ export function SchemaTypeLink({ node }: SchemaTypeLinkProps) {
 
   return (
     <ConstraintTooltip node={node}>
-      <Popover title={refName} content={content} placement="right" overlayStyle={{ maxWidth: 460 }}>
+      <Popover title={popoverTitle} content={content} placement="right" overlayStyle={{ maxWidth: 460 }}>
         <RouterLink to={target}>
           <Tag color={color} style={{ cursor: 'pointer' }}>
-            {label}
+            {displayLabel}
           </Tag>
         </RouterLink>
       </Popover>

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { normalizeGenericTitle } from './schemaUtils';
+
+describe('normalizeGenericTitle', () => {
+  test('converts guillemets to angle brackets', () => {
+    expect(normalizeGenericTitle('Result«UserVO»')).toBe('Result<UserVO>');
+  });
+
+  test('handles nested generics', () => {
+    expect(normalizeGenericTitle('Page«List«UserVO»»')).toBe('Page<List<UserVO>>');
+  });
+
+  test('returns unchanged string when no guillemets', () => {
+    expect(normalizeGenericTitle('UserVO')).toBe('UserVO');
+  });
+
+  test('returns undefined for undefined input', () => {
+    expect(normalizeGenericTitle(undefined)).toBeUndefined();
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.ts
@@ -6,6 +6,15 @@ export function schemaNameFromRef(ref: string | undefined): string | undefined {
   return decodeURIComponent(idx >= 0 ? ref.slice(idx + 1) : ref);
 }
 
+/**
+ * Normalize a schema title coming from springdoc/springfox.
+ * springdoc encodes generic parameters with guillemets: Result«UserVO» → Result<UserVO>
+ */
+export function normalizeGenericTitle(title: string | undefined): string | undefined {
+  if (!title) return undefined;
+  return title.replace(/«/g, '<').replace(/»/g, '>');
+}
+
 export function schemaNodeRefName(node: SchemaFieldNode): string | undefined {
   if (node.refName) return node.refName;
   if (node.type === 'array') return node.children?.[0]?.refName;

--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import SchemaFieldTable from '../components/schema/SchemaFieldTable';
+import { normalizeGenericTitle } from '../components/schema/schemaUtils';
 import { useGroup } from '../context/GroupContext';
 import type { SchemaObject, SwaggerDoc } from '../types/swagger';
 
@@ -11,6 +12,7 @@ const { Title, Text } = Typography;
 
 interface ModelDef {
   name: string;
+  title?: string;
   description?: string;
   fields: SchemaFieldNode[];
 }
@@ -29,6 +31,7 @@ function schemaToFields(schema: SchemaObject, swaggerDoc: SwaggerDoc): SchemaFie
 function schemasToModels(schemas: Record<string, SchemaObject>, swaggerDoc: SwaggerDoc): ModelDef[] {
   return Object.entries(schemas).map(([name, schema]) => ({
     name,
+    title: normalizeGenericTitle(schema.title),
     description: schema.description,
     fields: schemaToFields(schema, swaggerDoc),
   }));
@@ -50,7 +53,10 @@ export default function Schema() {
     const q = searchText.trim().toLowerCase();
     if (!q) return models;
     return models.filter(
-      (model) => model.name.toLowerCase().includes(q) || (model.description ?? '').toLowerCase().includes(q),
+      (model) =>
+        model.name.toLowerCase().includes(q) ||
+        (model.title ?? '').toLowerCase().includes(q) ||
+        (model.description ?? '').toLowerCase().includes(q),
     );
   }, [models, searchText]);
 
@@ -67,25 +73,34 @@ export default function Schema() {
     setActiveKeys(filteredModels.map((model) => model.name));
   }, [filteredModels, selectedSchemaName]);
 
-  const collapseItems = filteredModels.map((model) => ({
-    key: model.name,
-    label: (
-      <span id={modelDomId(model.name)}>
-        <Text strong style={{ fontSize: 14 }}>
-          {model.name}
-        </Text>
-        {model.description && (
-          <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
-            {model.description}
+  const collapseItems = filteredModels.map((model) => {
+    const displayName = model.title && model.title !== model.name ? model.title : model.name;
+    const showKey = model.title && model.title !== model.name;
+    return {
+      key: model.name,
+      label: (
+        <span id={modelDomId(model.name)}>
+          <Text strong style={{ fontSize: 14 }}>
+            {displayName}
           </Text>
-        )}
-        <Tag style={{ marginLeft: 12 }} color="default">
-          {model.fields.length} {t('schema.fields')}
-        </Tag>
-      </span>
-    ),
-    children: <SchemaFieldTable fields={model.fields} />,
-  }));
+          {showKey && (
+            <Text type="secondary" style={{ marginLeft: 8, fontSize: 12 }}>
+              ({model.name})
+            </Text>
+          )}
+          {model.description && (
+            <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
+              {model.description}
+            </Text>
+          )}
+          <Tag style={{ marginLeft: 12 }} color="default">
+            {model.fields.length} {t('schema.fields')}
+          </Tag>
+        </span>
+      ),
+      children: <SchemaFieldTable fields={model.fields} />,
+    };
+  });
 
   return (
     <div style={{ padding: '24px', maxWidth: 1180 }}>


### PR DESCRIPTION
## Summary

- Add `normalizeGenericTitle()` to `schemaUtils.ts`: converts springdoc guillemet encoding (`Result«UserVO»`) to angle-bracket notation (`Result<UserVO>`)
- `Schema.tsx`: show normalized title as primary label in the schema list; fall back to key name when no title; include title in search filtering
- `SchemaFieldTable.tsx`: use normalized title in type tag and popover title for `$ref` fields pointing to generic schemas
- Add vitest unit tests for `normalizeGenericTitle` (4 cases: guillemets, nested generics, no guillemets, undefined)

## Test plan

- [ ] Run `vitest run src/components/schema/schemaUtils.test.ts` — 4 tests pass
- [ ] Open a springdoc API with generic response types (e.g. `Result<UserVO>`) — schema list shows `Result<UserVO>` instead of `ResultUserVO`
- [ ] Type `Result<UserVO>` in the schema search box — matches correctly
- [ ] Click a field whose type is a generic ref — type tag shows `Result<UserVO>` and popover title shows `Result<UserVO>`

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)