### PR TITLE
fix(ui-react): display generic schema title with <T> notation (issue #292)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { normalizeGenericTitle } from './schemaUtils';
+
+describe('normalizeGenericTitle', () => {
+  test('converts guillemets to angle brackets', () => {
+    expect(normalizeGenericTitle('Result«UserVO»')).toBe('Result<UserVO>');
+  });
+
+  test('handles nested generics', () => {
+    expect(normalizeGenericTitle('Page«List«UserVO»»')).toBe('Page<List<UserVO>>');
+  });
+
+  test('returns unchanged string when no guillemets', () => {
+    expect(normalizeGenericTitle('UserVO')).toBe('UserVO');
+  });
+
+  test('returns undefined for undefined input', () => {
+    expect(normalizeGenericTitle(undefined)).toBeUndefined();
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.ts
@@ -6,6 +6,15 @@ export function schemaNameFromRef(ref: string | undefined): string | undefined {
   return decodeURIComponent(idx >= 0 ? ref.slice(idx + 1) : ref);
 }
 
+/**
+ * Normalize a schema title coming from springdoc/springfox.
+ * springdoc encodes generic parameters with guillemets: Result«UserVO» → Result<UserVO>
+ */
+export function normalizeGenericTitle(title: string | undefined): string | undefined {
+  if (!title) return undefined;
+  return title.replace(/«/g, '<').replace(/»/g, '>');
+}
+
 export function schemaNodeRefName(node: SchemaFieldNode): string | undefined {
   if (node.refName) return node.refName;
   if (node.type === 'array') return node.children?.[0]?.refName;

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaUtils.ts
@@ -11,7 +11,7 @@ export function schemaNameFromRef(ref: string | undefined): string | undefined {
  * springdoc encodes generic parameters with guillemets: Result«UserVO» → Result<UserVO>
  */
 export function normalizeGenericTitle(title: string | undefined): string | undefined {
-  if (!title) return undefined;
+  if (title === undefined) return undefined;
   return title.replace(/«/g, '<').replace(/»/g, '>');
 }
 

--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import SchemaFieldTable from '../components/schema/SchemaFieldTable';
+import { normalizeGenericTitle } from '../components/schema/schemaUtils';
 import { useGroup } from '../context/GroupContext';
 import type { SchemaObject, SwaggerDoc } from '../types/swagger';
 
@@ -11,6 +12,7 @@ const { Title, Text } = Typography;
 
 interface ModelDef {
   name: string;
+  title?: string;
   description?: string;
   fields: SchemaFieldNode[];
 }
@@ -29,6 +31,7 @@ function schemaToFields(schema: SchemaObject, swaggerDoc: SwaggerDoc): SchemaFie
 function schemasToModels(schemas: Record<string, SchemaObject>, swaggerDoc: SwaggerDoc): ModelDef[] {
   return Object.entries(schemas).map(([name, schema]) => ({
     name,
+    title: normalizeGenericTitle(schema.title),
     description: schema.description,
     fields: schemaToFields(schema, swaggerDoc),
   }));
@@ -50,7 +53,10 @@ export default function Schema() {
     const q = searchText.trim().toLowerCase();
     if (!q) return models;
     return models.filter(
-      (model) => model.name.toLowerCase().includes(q) || (model.description ?? '').toLowerCase().includes(q),
+      (model) =>
+        model.name.toLowerCase().includes(q) ||
+        (model.title ?? '').toLowerCase().includes(q) ||
+        (model.description ?? '').toLowerCase().includes(q),
     );
   }, [models, searchText]);
 
@@ -67,25 +73,33 @@ export default function Schema() {
     setActiveKeys(filteredModels.map((model) => model.name));
   }, [filteredModels, selectedSchemaName]);
 
-  const collapseItems = filteredModels.map((model) => ({
-    key: model.name,
-    label: (
-      <span id={modelDomId(model.name)}>
-        <Text strong style={{ fontSize: 14 }}>
-          {model.name}
-        </Text>
-        {model.description && (
-          <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
-            {model.description}
+  const collapseItems = filteredModels.map((model) => {
+    const displayTitle = model.title && model.title !== model.name ? model.title : undefined;
+    return {
+      key: model.name,
+      label: (
+        <span id={modelDomId(model.name)}>
+          <Text strong style={{ fontSize: 14 }}>
+            {displayTitle ?? model.name}
           </Text>
-        )}
-        <Tag style={{ marginLeft: 12 }} color="default">
-          {model.fields.length} {t('schema.fields')}
-        </Tag>
-      </span>
-    ),
-    children: <SchemaFieldTable fields={model.fields} />,
-  }));
+          {displayTitle && (
+            <Text type="secondary" style={{ marginLeft: 8, fontSize: 12 }}>
+              ({model.name})
+            </Text>
+          )}
+          {model.description && (
+            <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
+              {model.description}
+            </Text>
+          )}
+          <Tag style={{ marginLeft: 12 }} color="default">
+            {model.fields.length} {t('schema.fields')}
+          </Tag>
+        </span>
+      ),
+      children: <SchemaFieldTable fields={model.fields} />,
+    };
+  });
 
   return (
     <div style={{ padding: '24px', maxWidth: 1180 }}>

--- a/scripts/test-front-core.sh
+++ b/scripts/test-front-core.sh
@@ -13,5 +13,6 @@ bun run --filter knife4j-core build
 
 # --- knife4j-ui-react ---
 bun run --filter knife4j-ui-react format:check
+bun run --filter knife4j-ui-react test
 bun run --filter knife4j-ui-react build
 bun run --filter knife4j-ui-react lint


### PR DESCRIPTION
## Summary

Fixes #292 — springdoc encodes generic type parameters with guillemets (e.g. `Result«UserVO»`). This PR normalizes them to angle-bracket notation (`Result<UserVO>`) in the Schema page title.

## Changes

- `knife4j-ui-react/src/pages/Schema.tsx`: apply `normalizeGenericTitle` to schema title display
- `knife4j-ui-react/src/components/schema/schemaUtils.ts`: add `normalizeGenericTitle` utility; guard uses `=== undefined` for type-precise behavior
- `knife4j-ui-react/src/components/schema/schemaUtils.test.ts`: 4 vitest unit tests covering guillemet conversion, nested generics, passthrough, and undefined
- `scripts/test-front-core.sh`: add `bun run --filter knife4j-ui-react test` so the new tests are executed by CI

## Validation

```
bash scripts/test-front-core.sh
```

- knife4j-core: 179 tests passed
- knife4j-ui-react: 9 tests passed (including 4 new schemaUtils tests)
- format, lint, build: all green