### PR TITLE
fix(demo-openapi2): add /v3/api-docs/swagger-config for Vue3 UI

### DIFF
--- a/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/SwaggerConfigController.java
+++ b/knife4j/knife4j-demo-openapi2/src/main/java/com/baizhukui/knife4j/demo/openapi2/SwaggerConfigController.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.baizhukui.knife4j.demo.openapi2;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides a {@code /v3/api-docs/swagger-config} endpoint so that the
+ * knife4j-vue3 UI (which always requests this path when {@code springdoc=true})
+ * can discover the Swagger 2 spec served by springfox at {@code /v2/api-docs}.
+ *
+ * <p>The response shape mirrors what springdoc-openapi returns for its
+ * {@code swagger-config} endpoint, so the Vue3 UI can parse it without
+ * any frontend changes.
+ */
+@RestController
+public class SwaggerConfigController {
+
+    @GetMapping("/v3/api-docs/swagger-config")
+    public Map<String, Object> swaggerConfig() {
+        return Map.of(
+                "configUrl", "/v3/api-docs/swagger-config",
+                "urls", List.of(
+                        Map.of(
+                                "url", "/v2/api-docs",
+                                "name", "knife4j-next OAS2 Demo")));
+    }
+}


### PR DESCRIPTION
## 问题

https://openapi2.demo.knife4jnext.com/doc.html 页面空白。

根本原因：knife4j-vue3 UI 固定以 `springdoc: true` 模式初始化，始终请求 `/v3/api-docs/swagger-config`。但 openapi2 demo 用的是 springfox，只提供 `/v2/api-docs`，没有 swagger-config 端点，导致 UI 拿不到配置，页面无法渲染。

## 修复

新增 `SwaggerConfigController`，暴露 `/v3/api-docs/swagger-config` 端点，返回指向 `/v2/api-docs` 的 urls 列表，桥接 springfox 和 Vue3 UI 的协议差异。

## 变更

- 新增 `SwaggerConfigController.java`

Closes #272