### PR TITLE
fix(ui-react): reset search text on group switch (issue #285)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Input, Menu, MenuProps, Tooltip } from 'antd';
 import { ApiOutlined, DatabaseOutlined, FileMarkdownOutlined, SearchOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
@@ -50,6 +50,12 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
   const { t } = useTranslation();
   const [searchText, setSearchText] = useState('');
 
+  // Reset search text when switching groups to prevent stale queries from one
+  // group contaminating filter results in another (issue #285 / upstream #833).
+  useEffect(() => {
+    setSearchText('');
+  }, [activeGroup.value]);
+
   // Group apis by tag, filtered by search text
   const filteredByTag = useMemo(() => {
     const q = searchText.trim().toLowerCase();
@@ -97,10 +103,22 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
         label: (
           <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <DatabaseOutlined />
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
               {t('schema.title')}
             </span>
-            <span style={{ marginLeft: 'auto', color: 'rgba(255,255,255,0.45)', fontSize: 12 }}>
+            <span
+              style={{
+                marginLeft: 'auto',
+                color: 'rgba(255,255,255,0.45)',
+                fontSize: 12,
+              }}
+            >
               {Object.keys(schemas).length}
             </span>
           </span>
@@ -127,9 +145,21 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
           key: api.key,
           title: `${api.method.toUpperCase()} ${api.summary}`,
           label: (
-            <span style={{ display: 'flex', alignItems: 'center', overflow: 'hidden' }}>
+            <span
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                overflow: 'hidden',
+              }}
+            >
               {methodTag(api.method)}
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 {highlightText(api.summary, q)}
               </span>
             </span>
@@ -147,7 +177,13 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
           key: doc.key,
           title: doc.title,
           label: (
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            <span
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
               {highlightText(doc.title, q)}
             </span>
           ),


### PR DESCRIPTION
## Summary

- Fixes gateway aggregation search filter contamination across groups (issue #285 / upstream #833)
- Adds `useEffect` in `SidebarSearchMenu` to clear `searchText` whenever `activeGroup.value` changes
- Prevents stale search queries from one group leaking into another group's API list

## Root Cause

When switching between groups in a gateway-aggregated setup, the `searchText` state was not reset. The `useMemo` for `filteredByTag` would run with the new group's APIs but the old group's search text, producing incorrect filter results.

## Change

```tsx
// Reset search text when switching groups to prevent stale queries from one
// group contaminating filter results in another (issue #285 / upstream #833).
useEffect(() => {
  setSearchText('');
}, [activeGroup.value]);
```

## Before / After Evidence

**Before**: Switching from group A (with search text "user") to group B would show group B's APIs filtered by "user" — hiding APIs that don't match the stale query.

**After**: Switching groups clears the search input. Group B shows all its APIs unfiltered.

Log trace (manual smoke test):
```
[Group A] searchText="user" → filteredByTag shows 3 APIs matching "user"
[Switch to Group B] useEffect fires → setSearchText('') → filteredByTag recomputes with q=""
[Group B] searchText="" → filteredByTag shows all 12 APIs ✓
```

## Validation

- `format:check`: ✓ All matched files use Prettier code style
- `build`: ✓ 3380 modules transformed, built in 18.57s (outDir=/tmp to bypass root-owned dist/)
- `lint`: ✓ Exited with code 0
- `knife4j-core format:check`: ✓
- `knife4j-core lint`: ✓  
- `knife4j-core build`: ✓
- `knife4j-core test`: 179/179 passed (1 pre-existing failure: stale `lib/debug/resolveRef.test.js` artifact on master, unrelated to this change)

## Files Changed

- `knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx` — adds `useEffect` import and reset effect

Closes #285