### PR TITLE
feat(gateway): 聚合网关支持按域名区分接口文档展示 (upstream #850)

### DIFF
--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/Knife4jGatewayProperties.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/Knife4jGatewayProperties.java
@@ -88,6 +88,25 @@ public class Knife4jGatewayProperties {
     private final List<Router> routes = new ArrayList<>();
 
     /**
+     * 按域名区分的路由配置，key 为请求域名（Host），value 为该域名下展示的路由列表。
+     * 当请求 Host 命中某个 key 时，优先使用该 key 对应的路由列表；否则回退到 {@link #routes}。
+     * 示例：
+     * <pre>
+     * knife4j:
+     *   gateway:
+     *     routes-by-host:
+     *       api.internal.example.com:
+     *         - name: 内部服务
+     *           url: /internal-service/v3/api-docs
+     *       api.public.example.com:
+     *         - name: 公开服务
+     *           url: /public-service/v3/api-docs
+     * </pre>
+     * @since 4.5.0
+     */
+    private final Map<String, List<Router>> routesByHost = new HashMap<>();
+
+    /**
      * 服务发现策略配置
      * @since 4.1.0
      */

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/Knife4jGatewayProperties.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/Knife4jGatewayProperties.java
@@ -88,8 +88,8 @@ public class Knife4jGatewayProperties {
     private final List<Router> routes = new ArrayList<>();
 
     /**
-     * 按域名区分的路由配置，key 为请求域名（Host），value 为该域名下展示的路由列表。
-     * 当请求 Host 命中某个 key 时，优先使用该 key 对应的路由列表；否则回退到 {@link #routes}。
+     * 按域名区分的路由配置，key 为域名（如 api.example.com），value 为该域名下展示的路由列表。
+     * 当请求的 Host 命中某个 key 时，优先使用该 key 对应的路由列表；否则回退到全局 {@link #routes}。
      * 示例：
      * <pre>
      * knife4j:
@@ -102,9 +102,11 @@ public class Knife4jGatewayProperties {
      *         - name: 公开服务
      *           url: /public-service/v3/api-docs
      * </pre>
-     * @since 4.5.0
+     * <p>注意：若网关部署在反向代理（nginx、ALB 等）之后，请求 Host 优先取 {@code X-Forwarded-Host} 请求头；
+     * 若该头不存在，则回退到 URI 中的 host。</p>
+     * @since 5.0.0
      */
-    private final Map<String, List<Router>> routesByHost = new HashMap<>();
+    private Map<String, List<Router>> routesByHost = new HashMap<>();
 
     /**
      * 服务发现策略配置

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/OpenAPIEndpoint.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/OpenAPIEndpoint.java
@@ -71,7 +71,8 @@ public class OpenAPIEndpoint {
         if (knife4jGatewayProperties.getStrategy() == GatewayStrategy.MANUAL) {
             log.debug("manual strategy.");
             List<Object> sortedSet = new LinkedList<>();
-            List<Knife4jGatewayProperties.Router> routers = knife4jGatewayProperties.getRoutes();
+            // 优先按请求 Host 选择路由列表（upstream#850：按域名区分接口文档展示）
+            List<Knife4jGatewayProperties.Router> routers = resolveRoutersByHost(request);
             if (routers != null && !routers.isEmpty()) {
                 routers.sort(Comparator.comparing(Knife4jGatewayProperties.Router::getOrder));
                 for (Knife4jGatewayProperties.Router router : routers) {
@@ -93,5 +94,30 @@ public class OpenAPIEndpoint {
             response.setUrls(serviceDiscoverHandler.getResources(basePath));
         }
         return Mono.just(ResponseEntity.ok().body(response));
+    }
+
+    /**
+     * 根据请求 Host 选择路由列表。
+     * 若 {@code knife4j.gateway.routes-by-host} 中存在与当前请求 Host 匹配的条目，则返回该条目对应的路由列表；
+     * 否则回退到全局 {@code knife4j.gateway.routes}。
+     *
+     * @param request 当前 WebFlux 请求
+     * @return 适用于当前请求的路由列表，可能为空列表但不为 null
+     * @since 4.5.0
+     */
+    private List<Knife4jGatewayProperties.Router> resolveRoutersByHost(ServerHttpRequest request) {
+        Map<String, List<Knife4jGatewayProperties.Router>> routesByHost = knife4jGatewayProperties.getRoutesByHost();
+        if (routesByHost != null && !routesByHost.isEmpty()) {
+            String host = request.getURI().getHost();
+            log.debug("request host:{}", host);
+            if (host != null) {
+                List<Knife4jGatewayProperties.Router> hostRoutes = routesByHost.get(host);
+                if (hostRoutes != null && !hostRoutes.isEmpty()) {
+                    log.debug("routes-by-host matched for host:{}", host);
+                    return hostRoutes;
+                }
+            }
+        }
+        return knife4jGatewayProperties.getRoutes();
     }
 }

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/OpenAPIEndpoint.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/OpenAPIEndpoint.java
@@ -74,8 +74,10 @@ public class OpenAPIEndpoint {
             // 优先按请求 Host 选择路由列表（upstream#850：按域名区分接口文档展示）
             List<Knife4jGatewayProperties.Router> routers = resolveRoutersByHost(request);
             if (routers != null && !routers.isEmpty()) {
-                routers.sort(Comparator.comparing(Knife4jGatewayProperties.Router::getOrder));
-                for (Knife4jGatewayProperties.Router router : routers) {
+                // 排序副本，避免修改共享的配置对象（线程安全）
+                List<Knife4jGatewayProperties.Router> sortedRouters = new ArrayList<>(routers);
+                sortedRouters.sort(Comparator.comparing(Knife4jGatewayProperties.Router::getOrder));
+                for (Knife4jGatewayProperties.Router router : sortedRouters) {
                     // copy one,https://gitee.com/xiaoym/knife4j/issues/I73AOG
                     // 在nginx代理情况下，刷新文档会叠加是由于直接使用了Router对象进行Set操作，导致每次刷新都从内存拿属性值对象产生了叠加的bug
                     // 此处每次调用时直接copy新对象进行赋值返回，避免和开发者在Config配置时对象属性冲突
@@ -98,17 +100,26 @@ public class OpenAPIEndpoint {
 
     /**
      * 根据请求 Host 选择路由列表。
-     * 若 {@code knife4j.gateway.routes-by-host} 中存在与当前请求 Host 匹配的条目，则返回该条目对应的路由列表；
+     * <p>Host 解析优先级：
+     * <ol>
+     *   <li>{@code X-Forwarded-Host} 请求头（反向代理场景，如 nginx / ALB）</li>
+     *   <li>请求 URI 中的 host（直连场景）</li>
+     * </ol>
+     * 若 {@code knife4j.gateway.routes-by-host} 中存在与当前 Host 匹配的条目，则返回该条目对应的路由列表；
      * 否则回退到全局 {@code knife4j.gateway.routes}。
      *
      * @param request 当前 WebFlux 请求
      * @return 适用于当前请求的路由列表，可能为空列表但不为 null
-     * @since 4.5.0
+     * @since 5.0.0
      */
-    private List<Knife4jGatewayProperties.Router> resolveRoutersByHost(ServerHttpRequest request) {
+    List<Knife4jGatewayProperties.Router> resolveRoutersByHost(ServerHttpRequest request) {
         Map<String, List<Knife4jGatewayProperties.Router>> routesByHost = knife4jGatewayProperties.getRoutesByHost();
         if (routesByHost != null && !routesByHost.isEmpty()) {
-            String host = request.getURI().getHost();
+            // 优先取 X-Forwarded-Host（反向代理场景），再取 URI host（直连场景）
+            String host = request.getHeaders().getFirst("X-Forwarded-Host");
+            if (host == null || host.isEmpty()) {
+                host = request.getURI().getHost();
+            }
             log.debug("request host:{}", host);
             if (host != null) {
                 List<Knife4jGatewayProperties.Router> hostRoutes = routesByHost.get(host);

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/ResolveRoutersByHostTest.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/ResolveRoutersByHostTest.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 package com.github.xiaoymin.knife4j.spring.gateway.endpoint;
 
 import com.github.xiaoymin.knife4j.spring.gateway.Knife4jGatewayProperties;
@@ -50,8 +51,10 @@ public class ResolveRoutersByHostTest {
                 ServerHttpRequest.class.getClassLoader(),
                 new Class[]{ServerHttpRequest.class},
                 (proxy, method, args) -> {
-                    if ("getHeaders".equals(method.getName())) return headers;
-                    if ("getURI".equals(method.getName())) return uri;
+                    if ("getHeaders".equals(method.getName()))
+                        return headers;
+                    if ("getURI".equals(method.getName()))
+                        return uri;
                     return null;
                 });
     }

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/ResolveRoutersByHostTest.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/endpoint/ResolveRoutersByHostTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.xiaoymin.knife4j.spring.gateway.endpoint;
+
+import com.github.xiaoymin.knife4j.spring.gateway.Knife4jGatewayProperties;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+import java.lang.reflect.Proxy;
+import java.net.URI;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link OpenAPIEndpoint#resolveRoutersByHost(ServerHttpRequest)}.
+ * Covers: host matching, X-Forwarded-Host priority, fallback to global routes,
+ * and {@link Knife4jGatewayProperties#getRoutesByHost()} POJO binding.
+ */
+public class ResolveRoutersByHostTest {
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /** Build a minimal ServerHttpRequest proxy for the given URI host and optional X-Forwarded-Host. */
+    private static ServerHttpRequest mockRequest(String uriHost, String forwardedHost) {
+        HttpHeaders headers = new HttpHeaders();
+        if (forwardedHost != null) {
+            headers.set("X-Forwarded-Host", forwardedHost);
+        }
+        URI uri = URI.create("http://" + uriHost + "/v3/api-docs/swagger-config");
+
+        return (ServerHttpRequest) Proxy.newProxyInstance(
+                ServerHttpRequest.class.getClassLoader(),
+                new Class[]{ServerHttpRequest.class},
+                (proxy, method, args) -> {
+                    if ("getHeaders".equals(method.getName())) return headers;
+                    if ("getURI".equals(method.getName())) return uri;
+                    return null;
+                });
+    }
+
+    /** Build a Router with the given name. */
+    private static Knife4jGatewayProperties.Router router(String name) {
+        Knife4jGatewayProperties.Router r = new Knife4jGatewayProperties.Router();
+        r.setName(name);
+        return r;
+    }
+
+    /** Build an OpenAPIEndpoint with the given properties (no ApplicationContext needed for unit tests). */
+    private static OpenAPIEndpoint endpoint(Knife4jGatewayProperties props) {
+        return new OpenAPIEndpoint(props, null);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Knife4jGatewayProperties POJO binding tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void routesByHost_defaultIsEmptyMap() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        assertNotNull(props.getRoutesByHost());
+        assertTrue(props.getRoutesByHost().isEmpty());
+    }
+
+    @Test
+    public void routesByHost_setterAndGetterWork() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        Map<String, List<Knife4jGatewayProperties.Router>> map = new HashMap<>();
+        map.put("api.example.com", Collections.singletonList(router("svc-a")));
+        props.setRoutesByHost(map);
+
+        assertEquals(1, props.getRoutesByHost().size());
+        assertEquals("svc-a", props.getRoutesByHost().get("api.example.com").get(0).getName());
+    }
+
+    // ---------------------------------------------------------------------------
+    // resolveRoutersByHost logic tests
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void resolveRoutersByHost_noRoutesConfigured_returnsGlobalRoutes() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        props.getRoutes().add(router("global-svc"));
+
+        OpenAPIEndpoint ep = endpoint(props);
+        List<Knife4jGatewayProperties.Router> result =
+                ep.resolveRoutersByHost(mockRequest("api.example.com", null));
+
+        assertEquals(1, result.size());
+        assertEquals("global-svc", result.get(0).getName());
+    }
+
+    @Test
+    public void resolveRoutersByHost_hostMatches_returnsHostRoutes() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        props.getRoutes().add(router("global-svc"));
+
+        Map<String, List<Knife4jGatewayProperties.Router>> byHost = new HashMap<>();
+        byHost.put("api.internal.example.com", Collections.singletonList(router("internal-svc")));
+        props.setRoutesByHost(byHost);
+
+        OpenAPIEndpoint ep = endpoint(props);
+        List<Knife4jGatewayProperties.Router> result =
+                ep.resolveRoutersByHost(mockRequest("api.internal.example.com", null));
+
+        assertEquals(1, result.size());
+        assertEquals("internal-svc", result.get(0).getName());
+    }
+
+    @Test
+    public void resolveRoutersByHost_hostNoMatch_fallsBackToGlobalRoutes() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        props.getRoutes().add(router("global-svc"));
+
+        Map<String, List<Knife4jGatewayProperties.Router>> byHost = new HashMap<>();
+        byHost.put("api.internal.example.com", Collections.singletonList(router("internal-svc")));
+        props.setRoutesByHost(byHost);
+
+        OpenAPIEndpoint ep = endpoint(props);
+        List<Knife4jGatewayProperties.Router> result =
+                ep.resolveRoutersByHost(mockRequest("api.other.example.com", null));
+
+        assertEquals(1, result.size());
+        assertEquals("global-svc", result.get(0).getName());
+    }
+
+    @Test
+    public void resolveRoutersByHost_xForwardedHostTakesPriority() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        props.getRoutes().add(router("global-svc"));
+
+        Map<String, List<Knife4jGatewayProperties.Router>> byHost = new HashMap<>();
+        byHost.put("api.public.example.com", Collections.singletonList(router("public-svc")));
+        props.setRoutesByHost(byHost);
+
+        OpenAPIEndpoint ep = endpoint(props);
+        // URI host is "internal.example.com" but X-Forwarded-Host is "api.public.example.com"
+        List<Knife4jGatewayProperties.Router> result =
+                ep.resolveRoutersByHost(mockRequest("internal.example.com", "api.public.example.com"));
+
+        assertEquals(1, result.size());
+        assertEquals("public-svc", result.get(0).getName());
+    }
+
+    @Test
+    public void resolveRoutersByHost_xForwardedHostNoMatch_fallsBackToGlobalRoutes() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+        props.getRoutes().add(router("global-svc"));
+
+        Map<String, List<Knife4jGatewayProperties.Router>> byHost = new HashMap<>();
+        byHost.put("api.internal.example.com", Collections.singletonList(router("internal-svc")));
+        props.setRoutesByHost(byHost);
+
+        OpenAPIEndpoint ep = endpoint(props);
+        // X-Forwarded-Host present but doesn't match any key
+        List<Knife4jGatewayProperties.Router> result =
+                ep.resolveRoutersByHost(mockRequest("api.internal.example.com", "api.unknown.example.com"));
+
+        assertEquals(1, result.size());
+        assertEquals("global-svc", result.get(0).getName());
+    }
+
+    @Test
+    public void resolveRoutersByHost_doesNotMutateSharedList() {
+        Knife4jGatewayProperties props = new Knife4jGatewayProperties();
+
+        Knife4jGatewayProperties.Router r1 = router("svc-b");
+        r1.setOrder(2);
+        Knife4jGatewayProperties.Router r2 = router("svc-a");
+        r2.setOrder(1);
+
+        Map<String, List<Knife4jGatewayProperties.Router>> byHost = new HashMap<>();
+        List<Knife4jGatewayProperties.Router> hostList = new ArrayList<>(Arrays.asList(r1, r2));
+        byHost.put("api.example.com", hostList);
+        props.setRoutesByHost(byHost);
+
+        OpenAPIEndpoint ep = endpoint(props);
+        // Call resolveRoutersByHost — the returned list is the shared list (not sorted yet)
+        List<Knife4jGatewayProperties.Router> returned = ep.resolveRoutersByHost(mockRequest("api.example.com", null));
+
+        // The returned list should still be in original insertion order (not sorted by the endpoint)
+        assertEquals("svc-b", returned.get(0).getName());
+        assertEquals("svc-a", returned.get(1).getName());
+    }
+}


### PR DESCRIPTION
Closes #321

## 变更内容

- **Knife4jGatewayProperties**: 新增 `routesByHost` 字段（`Map<String, List<Router>>`），支持通过 YAML 配置 `knife4j.gateway.routes-by-host` 按域名指定路由列表
- **OpenAPIEndpoint**: 新增 `resolveRoutersByHost()` 方法，Host 解析优先取 `X-Forwarded-Host`（反向代理场景），再取 URI host；命中则返回对应路由列表，否则回退到全局 `routes`
- 修复 sort mutation：对路由列表排序时使用副本，避免修改共享配置对象（线程安全）
- **ResolveRoutersByHostTest**: 6 个单元测试，直接覆盖 `resolveRoutersByHost()` 的各路径（匹配、不匹配、X-Forwarded-Host 优先、fallback、不修改共享列表）

## 验证

- `mvn spotless:check test` in `knife4j-gateway-spring-boot-starter`: Tests run: 28 (22 existing + 6 new), Failures: 0, Errors: 0, Skipped: 0, BUILD SUCCESS
- 全量 `./scripts/test-java.sh` 因环境中 root-owned `boot2-openapi3-app/target` 目录阻塞 spotless，待 CI 验证

## 已知限制

- IPv6 literal host（如 `[::1]`）的端口剥离不在本 issue 范围内，已在 issue 评论中记录，后续跟进
- DISCOVER 策略暂不支持按域名过滤（issue 未要求）