### PR TITLE
fix(demo-openapi2): pin slf4j-api to 1.7.36 to restore startup logs (#334)

### DIFF
--- a/knife4j/knife4j-demo-openapi2/pom.xml
+++ b/knife4j/knife4j-demo-openapi2/pom.xml
@@ -34,6 +34,19 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${knife4j-spring-boot.version}</version>
         </dependency>
+        <!--
+          覆盖 root pom 的 slf4j-api 2.0.16（provided），回到与 Spring Boot 2.7.18
+          自带的 logback-classic 1.2.12 兼容的 1.7.x。SLF4J 2.x 走 ServiceLoader
+          查找 SLF4JServiceProvider，logback 1.2.x 只提供 1.x 的 StaticLoggerBinder
+          SPI，会让 LoggerFactory fallback 到 NOPLoggerFactory，Spring Boot banner、
+          Tomcat 启动日志和 Springfox 扫描日志会被全部静默丢弃。
+        -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## 背景

直接启动 `knife4j-demo-openapi2`（Spring Boot 2.7.18 + Springfox 2.10.5）时控制台**完全没有日志输出**——没有 Spring Boot banner、没有 Tomcat 启动消息、没有 Springfox mapping 日志。进程本身其实是正常运行的（端口正常监听，`/v2/api-docs`、`/swagger-resources` 都返回 200），只是所有 SLF4J 调用都被静默吞掉了。

## 根因

仓库根 `knife4j/pom.xml` 把 `slf4j-api` 统一托管到 `2.0.16`（`<knife4j-slf4j.version>`，`provided` scope），所有子模块继承。但 Spring Boot 2.7.18 自带 `logback-classic 1.2.12`，只提供 SLF4J 1.x 的 `StaticLoggerBinder` SPI；SLF4J 2.x 改为通过 `ServiceLoader` 查找 `SLF4JServiceProvider`，找不到 provider → `LoggerFactory` fallback 到 `NOPLoggerFactory` → 整进程所有日志被丢弃。

OAS3 demo 不受影响，因为 Spring Boot 3.4.x 自带的 logback 1.5.x 天然兼容 SLF4J 2.x。

## 方案

仅在 `knife4j-demo-openapi2/pom.xml` 本地覆盖 `slf4j-api` 回到 `1.7.36`（`compile` scope）。不动根 pom、不动上层 starter，避免影响下游用户的 logging 选型。

## 验证

修改后：

```
$ mvn dependency:tree | grep -E 'slf4j-api|logback-classic'
[INFO] |  |  |  +- ch.qos.logback:logback-classic:jar:1.2.12:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.36:compile
```

```
$ mvn spring-boot:run
 .   ____          _            __ _ _
 ...
 :: Spring Boot ::               (v2.7.18)

INFO ... o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 9099 (http)
INFO ... pertySourcedRequestMappingHandlerMapping : Mapped URL path [/v2/api-docs] onto method [...Swagger2ControllerWebMvc#getDocumentation...]
INFO ... c.b.k.demo.openapi2.DemoApplication      : Started DemoApplication in 0.698 seconds
```

接口：

```
GET /v2/api-docs      -> 200 (10358 bytes)
GET /swagger-resources -> 200
```

## 范围与风险

- 只改 `knife4j/knife4j-demo-openapi2/pom.xml` 一个文件，新增 13 行（8 行依赖 + 5 行注释）
- 不影响 starter、aggregation、gateway、smoke-tests 等任何生产路径
- 下游用户的依赖解析不会改变（demo 模块 `maven.deploy.skip=true` / `skipPublishing=true`）

## 后续

`doc.html` 页面空白是另一个独立 bug：`knife4j-openapi2-ui` webjar 产物用的是 `VITE_RELEASE_APP_TYPE=SpringDocOpenApi`（knife4j-vue3 的 `.env.production` 默认值），导致前端请求 `/v3/api-docs/swagger-config` 而 OAS2 后端必然 404。已单开 issue 跟踪，不在本 PR 范围内。

Closes #334

