### PR TITLE
docs(agent): enforce upstream-issue reproduction-first policy (#340)

### DIFF
--- a/.agent/KNOWN_PITFALLS.md
+++ b/.agent/KNOWN_PITFALLS.md
@@ -29,3 +29,20 @@
 - 不要把“修一个点”静默扩大成“顺手清理相关区域”。
 - 不确定时，把不确定性写下来，并停在安全检查点。
 - **Reviewer 声称某改动 "revert 了 X" / "删除了 Y" 时，coordinator 必须在接受结论前用 `git show <commit> -- <file>` 核对真实 diff**。历史案例：#198 三次 reviewer `block` 指控 commit `8f0d3b6f` 把 `ProductionSecurityFilter` revert 回 `sendError`、默认值 `knife4j.basic.enable` 翻转、删除 `addCustomApiDocsPathRule`，经人工复核**全部与 master 实际代码相反**；推测 reviewer 对照了 worker 未提交的 stash 或错误 base。不先核对 diff 就按 reviewer 描述动代码，会把正确修复改回 bug。
+- **上游 issue（`upstream #xxx`）必须先在当前仓库复现，再决定是否需要修复**。本仓库是 `knife4j` 的 fork，upstream 报告的 bug 可能在以下情况下**已经不再存在**：
+  - 当前已升级到修复版本的依赖（如 springdoc、Spring Boot）；
+  - 当前 fork 已经在历史提交里修过同一问题；
+  - upstream 触发条件依赖特定旧版本 + 特定配置组合，当前默认配置已规避。
+  动手前必须做的最小复现工作流：
+  1. 在 `knife4j-smoke-tests/` 下挑或新建一个尽量贴合 upstream 复现条件的最小工程（pin Spring Boot / springdoc / 触发用 controller）；
+  2. 在**未应用任何修复**的 master 状态下跑该工程，确认 bug 真的会出现（异常堆栈、错误响应、错误日志等），把证据贴进 issue；
+  3. 如果**复现不到**：在 issue 里写明已尝试的复现条件并 close 或转 `status:blocked` 等待上游补充信息，**不要凭想象写 try-catch / null guard 类"防御性"代码**，那只是制造噪音和静默吞错；
+  4. 如果**能复现**，再开始设计修复方案，并保留该 smoke 工程作为修复后回归测试的载体。
+  反面案例：#303（upstream #961）经过 2 轮 worker+reviewer 循环都被 block，根因就是没有先复现，worker 直接在 `Knife4jJakartaOperationCustomizer.customize()` 外层包了 `try-catch(NullPointerException)`。更糟的是，回去核对 upstream 原文堆栈才发现实际异常是 `java.lang.StackOverflowError`，堆栈顶是 springdoc 的 `MethodParameterPojoExtractor` / `ReturnTypeParser` 递归；该 NPE/SOE 实际抛在 springdoc 内部、调用 `customize()` 之前，这层 try-catch 在 JVM 调用栈上根本拦不到；同时 smoke test 只断言 `/v3/api-docs` 返回 200，去掉 try-catch 也会过，是典型的 false positive。
+- **不要凭 upstream 标题 / 单张截图臆测本仓库任务范围**。triage upstream issue 时必须读完 upstream 正文 + 堆栈 + 评论，再确认本仓库 code path 是否命中；可以"以 upstream 为灵感定义本仓库的增强"，但必须在本仓库 issue 正文里**显式声明已经换了范围**，不要让 PR 看起来像"修了 upstream"但实际修了别的东西。
+  历史误读案例（2026-05 audit 发现）：
+  - **#303 (upstream #961)**：upstream 正文第一行异常实际是 `java.lang.StackOverflowError`，堆栈顶是 springdoc `MethodParameterPojoExtractor` / `ReturnTypeParser` 递归；但 issue 标题被 worker 读成 `NullPointerException`（"null" 字样误导），连续 2 轮方向错误。正确修复路径是升级 springdoc 版本，已拆到 #335 跟踪。
+  - **#285 / PR #331 (upstream #833)**：upstream 原文只说"右上角搜索结果出现重复的三个"+ 一张截图；本仓库 issue #285 把它引申成"group 间搜索串扰"，PR #331 实现 `setSearchText('')` on group switch。这可能**部分缓解**现象，但 upstream 反映的更可能是网关聚合把同一 endpoint 注册多次，**与 searchText 状态无关**。PR merge 了，但 upstream 真正的 bug 由 #338 独立跟踪。以后类似情况，issue 正文应写"**不自认为修了 upstream #xxx**，而是修了衍生场景"。
+  - **#226 / PR #237 (upstream #917)**：upstream 是 `gateway-spring-boot-starter` 配 basic auth 后 `/doc.html` 返回 500 的**后端** bug；本仓库 #226 正文显式转译为"ui-react 在 401 响应时自动弹认证框"的 UX 任务。PR 实现了一个真实 ui-react bug（401 check 错位）。这是**合理的范围转译**，因为 issue 正文已清楚声明"是 UX 缺口，与 upstream 行为不一致"——可作正面示范。
+  - **#239 / commit `982959a8` (upstream #666 #859)**：upstream #666 / #859 是**webjars 静态资源 MIME / MessageConverter 顺序** bug；commit message 却声称在修 `ProductionSecurityFilter`。`ProductionSecurityFilter` 只在 `knife4j.production=true` 时生效，和 webjars 静态资源完全无关；`sendError(403)` 本身是一个合理的小重构（让 servlet 容器决定 Content-Type），但**它没修 upstream #666 / #859 所描述的问题**。upstream 本体已由 #339 独立跟踪。
+- **"先 deref 再 null check"类的 `@Bean` 方法 null-guard 通常是假 bug**。`@Bean` 方法的参数是 Spring 从容器注入的 bean，Spring **不会注入 null**（找不到就抛 `NoSuchBeanDefinitionException`，不会静默注入 null）。所以 `@Bean` 方法里 `if (injectedBean == null)` 分支永远是死代码，"修它"并不解决任何实际问题，只是代码美化。不要把这类重构包装成 bug fix；需要的话可以写 `fix:`，但 commit message 要说明"纯重构，运行时行为不变"。历史案例：PR #246（#239）。

--- a/.agent/RUNBOOK.md
+++ b/.agent/RUNBOOK.md
@@ -98,6 +98,20 @@
 - 改动横跨多个区域
 - 准备的 PR 同时触碰 Java 和前端/文档
 
+## 上游 issue 复现前置流程（强制）
+
+凡 issue 正文含 `Upstream: https://github.com/xiaoymin/knife4j/issues/<N>` 或标题带 `(upstream #<N>)` 的任务，动手写修复代码之前必须完成以下步骤：
+
+1. **阅读 upstream issue**：拉下完整错误堆栈、触发代码、依赖版本组合。如 upstream 没贴堆栈，不要臆造修复方向，先在 issue 评论里列出需要的上游信息并转 `status:blocked`。
+2. **挑选或新建最小复现工程**：优先复用 `knife4j-smoke-tests/` 下已有模块（`boot2-app`、`boot3-app`、`boot3-jakarta-app`、`boot35-jakarta-app`）。如必须新建，`pom.xml` 里**显式 pin**触发问题的 Spring Boot / springdoc 版本（不要只依赖 starter 的传递解析），并在 `knife4j-smoke-tests/pom.xml`、`scripts/test-java.sh` 的 `SMOKE_MODULES`、`.github/workflows/build.yml` 的 smoke loop 三处同步登记。
+3. **在 master（未打任何修复）上先跑一次复现**：记录精确异常、错误响应或错误日志，把证据贴到 issue 评论。
+4. **根据复现结果分流**：
+   - **已无法复现**：在 issue 写明已尝试的触发条件（SB 版本、springdoc 版本、controller 签名等），保留 smoke 工程作为回归防护，然后：
+     - 若已在本仓库 fix 历史中修过，把对应 commit 链接贴出来 → `gh issue close <N> --comment "cannot reproduce; fixed in <sha>"`。
+     - 若只是上游触发条件不明 → 加 `status:blocked` 等上游补信息。
+   - **能复现**：保留该 smoke 工程，在其中加入断言复现条件的测试（例如断言特定 WARN 日志、断言特定 JSON 字段），再进入修复阶段。修复后同一测试应从失败转为通过，这才是有效的回归证据。
+5. **禁止在未复现的前提下写"防御性"代码**（盲目加 `try-catch`、`if (x != null)` guard 等）。这种改动无法被 smoke 证伪，等同于噪音；#303 已有血泪案例，详见 `KNOWN_PITFALLS.md`。
+
 ## 选择验证的规则
 
 - 纯文档改动通常不需要 Java 或前端验证，除非触碰生成物或已知会影响构建的代码示例。


### PR DESCRIPTION
## Summary

把 2026-05-07 blocked issue audit 中总结出来的经验固化进 `.agent/` 长期文档，防止后续 worker / coordinator 重复犯错。

Closes #340

## 背景

对 12 个 `status:blocked` 的 issue 做 audit（详见 #271 umbrella、#303、#275、#285、#239 的结论），发现重复出现的结构性问题：

- 多个 worker 在**未先复现 upstream bug** 的情况下直接写"防御性"代码（try-catch、null guard），实际没拦住上游问题；
- 多个 issue / PR 把 upstream 标题 / 截图**臆测**成本仓库的任务范围（commit message 声称修 upstream #xxx，实际改动与 upstream 描述无关）；
- `@Bean` 方法里 `injectedBean == null` 分支被当成"可达的 null-guard"来修，但 Spring 不会为 `@Bean` 参数注入 null，这类分支永远是死代码。

## 改动

### `.agent/KNOWN_PITFALLS.md`

Agent 工作流节新增 3 条硬规则：

1. **上游 issue 必须先复现再修复**：4 步最小复现工作流，明令禁止未复现就写防御性 `try-catch` / null guard。反面案例：#303 (upstream #961)。
2. **不要凭 upstream 标题 / 截图臆测任务范围**：要求 triage 必须读完 upstream 正文 + 堆栈 + 评论。附 4 个历史案例（1 正 3 负）：
   - 正例：#226 / PR #237（upstream #917）——显式声明"以 upstream 为灵感定义本仓库增强"；
   - 负例：#303、#285 / PR #331、#239 / commit `982959a8` —— 修了不同的 bug 却用了 upstream 编号。
3. **`@Bean` 方法里 `injectedBean == null` 分支是死代码**：不要包装成 `fix:`。历史案例：PR #246。

### `.agent/RUNBOOK.md`

「选择验证的规则」前新增一节「上游 issue 复现前置流程（强制）」，5 步操作指引：

1. 读 upstream 完整正文 + 堆栈 + 评论；缺信息直接 `status:blocked`；
2. 挑或新建最小复现工程，三处同步登记（`knife4j-smoke-tests/pom.xml`、`scripts/test-java.sh` 的 `SMOKE_MODULES`、`.github/workflows/build.yml` 的 smoke loop）；
3. master 上先跑复现，把证据贴回 issue；
4. 复现不到 → 记录尝试条件并 close / 等上游补信息；复现到 → 保留 smoke 工程作回归载体；
5. 禁止未复现就写"防御性"代码。

## 范围

- 纯 `.agent/` 文档改动
- 无运行时行为变化
- 不触碰 Java / TS / CI 代码

## 验证

按 `.agent/RUNBOOK.md` 「纯文档改动通常不需要 Java 或前端验证」条款：无需运行 `./scripts/test-*.sh`。

CI 的 markdown lint（如有）会自行校验。

## 风险

- 文档级改动，零运行时风险。
- 唯一的可变性是：后续 worker / coordinator 是否真的遵守新规则。已经把本次 audit 的负例直接点名写入文档作为"不要这样做"的反面示范，可直接作为 review checklist 的一部分。

## 关联

- 审查伞：#271
- 代表性负面案例：#303、#275、#285、#239 / commit `982959a8`、PR #246
- 衍生 tracking issue：#335、#338、#339

