### PR TITLE
docs(repo): add PR template enforcing upstream-issue checklist (#347)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,63 @@
+<!--
+本模板同时服务人工贡献者与 agent。
+请在提交 PR 前完成下方各项；对不适用的项勾 [x] 并在后面注明 "N/A + 原因"。
+-->
+
+## 关联 issue
+
+<!-- 每个 PR 应只关联一条主 issue。upstream issue 不是本仓库 issue，不要直接写 "fix upstream #xxx"。 -->
+
+- Closes #
+- （可选）upstream 灵感来源：<https://github.com/xiaoymin/knife4j/issues/>
+
+## 变更摘要
+
+<!-- 2–5 行说明本 PR 做了什么、不做什么。避免"顺手清理"。 -->
+
+## Upstream issue 处理自检
+
+> 如果本 PR **不涉及** upstream issue，请在每项后写 "N/A"。
+
+- [ ] 本 PR 只关联 **≤1 条** upstream issue（不在同一 commit / PR 中批量声明修多个 upstream）
+- [ ] 已通读 upstream 原文（描述 + 堆栈 + 评论 + 复现截图），本仓库 issue 正文摘录了关键片段
+- [ ] 已在 `knife4j-smoke-tests/` 或本地最小工程**复现** upstream 报告的具体场景（贴出复现前的失败输出）
+- [ ] 本 PR 的 smoke test **能区分**修复前后的行为（去掉修复，测试应变红）；不要依赖"只断言 200"的弱断言
+- [ ] 若本仓库范围与 upstream 诉求不同，issue 正文已**显式声明换了范围**（不自认为修了 upstream #xxx）
+
+## 影响面自检
+
+- [ ] 本 PR **未**修改发布流程 / 项目坐标 / 兼容性承诺（如需修改，已在 issue 评论中请示维护者）
+- [ ] 如果碰了 Java 核心 starter / filter / autoconfiguration，已勾选以下高影响区并说明理由：
+  - [ ] `knife4j-openapi2-spring-boot-starter`
+  - [ ] `knife4j-openapi3-spring-boot-starter`
+  - [ ] `knife4j-openapi3-jakarta-spring-boot-starter`
+  - [ ] `knife4j-gateway-spring-boot-starter`
+  - [ ] `knife4j-aggregation-*-starter`
+  - [ ] `knife4j-core` 的 filter / security / config
+
+## 验证
+
+<!-- 列出实际跑了哪些命令 / 测试 / 手动验证步骤。 -->
+
+- [ ] 相关 smoke-tests 模块 `mvn -pl ... -am test` 通过
+- [ ] 如涉及前端：`knife4j-front/knife4j-core` 或 `knife4j-ui-react` 的 test / build 通过
+- [ ] 如涉及文档：`docs-site` 本地构建通过
+
+```
+# 粘贴关键命令输出
+```
+
+## 流程自检
+
+- [ ] 分支名符合 `agent/<task-id>-<slug>` 或 `codex/<task-id>-<slug>` 约定（agent 产出）
+- [ ] commit message 关联 issue ≤1 条；未在同一分支混入无关修复
+- [ ] 未把 Java 核心逻辑改动夹带在"标题是文档/UI"的 PR 中
+- [ ] 未绕过 PR 直推 master；未 force push 到 `master`
+
+<!--
+参考资料：
+- .agent/RUNBOOK.md —— upstream issue 复现工作流
+- .agent/KNOWN_PITFALLS.md —— 历史误读 / 违规案例
+- .agent/REVIEW_POLICY.md —— review 前必须核对真实 diff
+-->
+


### PR DESCRIPTION
## 关联 issue

- Closes #347

## 变更摘要

新增 `.github/PULL_REQUEST_TEMPLATE.md`，把 `.agent/RUNBOOK.md` 与 `.agent/KNOWN_PITFALLS.md` 中已写下的 upstream-issue 处理纪律落成 PR 时机械 checklist：

1. **关联 issue**：明确"每个 PR ≤1 条主 issue"，upstream issue 只能作为"灵感来源"出现，不允许直接 `fix upstream #xxx`。
2. **upstream 自检**：要求作者勾选「读了原文」「复现了场景」「smoke test 能区分修复前后」「若换了范围则显式声明」。
3. **影响面自检**：列出 Java 核心高影响区目录，碰到必须勾选；不允许偷偷修发布流程 / 坐标 / 兼容性承诺。
4. **验证**：列出实际跑过的命令；空着不行。
5. **流程自检**：分支命名、不夹带、不直推 master、不 force push master。

模板中所有不适用项都允许勾 `[x]` 后写 "N/A + 原因"，对纯文档 / 前端 UX 任务也适用。

## Upstream issue 处理自检

- [x] 本 PR 只关联 ≤1 条 upstream issue（**N/A** —— 这是仓库流程改动，不涉及 upstream）
- [x] 已通读 upstream 原文（**N/A**）
- [x] 已复现 upstream 场景（**N/A**）
- [x] smoke test 能区分修复前后（**N/A** —— 模板文件无运行时行为）
- [x] 若范围与 upstream 不同已显式声明（**N/A**）

## 影响面自检

- [x] 本 PR 未修改发布流程 / 项目坐标 / 兼容性承诺
- [x] **未**修改任何 Java 核心 starter / filter / autoconfiguration（仅 `.github/PULL_REQUEST_TEMPLATE.md`）

## 验证

- 在浏览器打开 GitHub PR 创建页（`/compare/master...agent/pr-template-upstream-checklist`），确认模板自动填入；
- 模板内容覆盖人工贡献者和 agent 两种 author 场景；
- 不会强制阻塞合并（GitHub 不会因为 checkbox 未勾就拒绝 merge），只在 review 时形成可见对照。

## 流程自检

- [x] 分支名 `agent/pr-template-upstream-checklist`（无关联 task-id 因为是仓库自管理改动）
- [x] commit message 仅关联 #347
- [x] 未夹带其他修复
- [x] 未绕过 PR、未 force push master

## 关联

- 上一条流程加固：PR #346（部分回滚 `8f0d3b6f`）
- 配套文档：`.agent/RUNBOOK.md`（upstream 复现工作流）、`.agent/KNOWN_PITFALLS.md`（违规案例）

