### PR TITLE
docs: 反向代理 prefix 场景文档（nginx 斜杠说明 + SB2/SB3 差异）

### DIFF
--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -319,6 +319,9 @@ server:
 **nginx 侧**：
 
 ```nginx
+# 注意：location 末尾的斜杠与 proxy_pass 末尾的斜杠配合，
+# 让 nginx 在转发时自动剥离 /prod-api/dispatch 前缀。
+# X-Forwarded-Prefix 不带末尾斜杠，与 Spring 的 ForwardedHeaderFilter 期望一致。
 location /prod-api/dispatch/ {
     proxy_pass http://backend:8080/;
     proxy_set_header X-Forwarded-Prefix /prod-api/dispatch;
@@ -346,7 +349,7 @@ curl -s http://localhost:8080/v3/api-docs/swagger-config | jq '.urls'
 - `server.forward-headers-strategy=framework` 会注册 Spring 的 `ForwardedHeaderFilter`，它在 Servlet 层面重写 `HttpServletRequest` 的 scheme/host/contextPath，对所有 springdoc 端点透明生效，**无需修改 knife4j 配置**。
 - 若使用 `server.forward-headers-strategy=native`，则由容器（Tomcat/Jetty）处理 `X-Forwarded-Proto/Host/Port`，但**不支持 `X-Forwarded-Prefix`**（Tomcat 原生不识别该 header），因此 `native` 模式**无法**完成 prefix 重写，不适用于本场景；请使用 `framework`。
 - 若同时启用了 `knife4j.basic.enable=true`，需确认 nginx 传递的路径与 `knife4j.basic.include` 规则匹配，否则带前缀的 api-docs 请求会被 Basic Auth filter 拦截返回 401。
-- Spring Boot 3.x（Jakarta）与 Spring Boot 2.7.x（javax）均支持上述配置，行为一致。
+- Spring Boot 3.x（Jakarta / Spring Framework 6.x）与 Spring Boot 2.7.x（javax / Spring Framework 5.3）均支持上述配置。注意：`ForwardedHeaderFilter` 在 Spring Framework 6.x 中若重复注册会抛出异常（`IllegalStateException`），请勿在 `WebMvcConfigurer` 中手动再注册一次；Spring Framework 5.3 对重复注册的处理较宽松，但同样建议避免。
 
 ---
 

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -344,7 +344,7 @@ curl -s http://localhost:8080/v3/api-docs/swagger-config | jq '.urls'
 ### 注意事项
 
 - `server.forward-headers-strategy=framework` 会注册 Spring 的 `ForwardedHeaderFilter`，它在 Servlet 层面重写 `HttpServletRequest` 的 scheme/host/contextPath，对所有 springdoc 端点透明生效，**无需修改 knife4j 配置**。
-- 若使用 `server.forward-headers-strategy=native`，则由容器（Tomcat/Jetty）处理，效果相同但不支持 `X-Forwarded-Prefix`（Tomcat 原生不识别该 header）；推荐使用 `framework`。
+- 若使用 `server.forward-headers-strategy=native`，则由容器（Tomcat/Jetty）处理 `X-Forwarded-Proto/Host/Port`，但**不支持 `X-Forwarded-Prefix`**（Tomcat 原生不识别该 header），因此 `native` 模式**无法**完成 prefix 重写，不适用于本场景；请使用 `framework`。
 - 若同时启用了 `knife4j.basic.enable=true`，需确认 nginx 传递的路径与 `knife4j.basic.include` 规则匹配，否则带前缀的 api-docs 请求会被 Basic Auth filter 拦截返回 401。
 - Spring Boot 3.x（Jakarta）与 Spring Boot 2.7.x（javax）均支持上述配置，行为一致。
 

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -303,6 +303,53 @@ knife4j:
 
 ---
 
+## 反向代理场景（nginx prefix / X-Forwarded-Prefix）
+
+当应用部署在 nginx 等反向代理后面，外网访问路径带有前缀（如 `/prod-api/dispatch`），而 knife4j 前端拼出的 `api-docs` URL 没有该前缀时，会出现 404。这是 upstream [#849](https://github.com/xiaoymin/knife4j/issues/849) 描述的典型场景。
+
+### 推荐方案：标准 Forwarded Header 透传
+
+**Spring Boot 侧**（`application.yml`）：
+
+```yaml
+server:
+  forward-headers-strategy: framework
+```
+
+**nginx 侧**：
+
+```nginx
+location /prod-api/dispatch/ {
+    proxy_pass http://backend:8080/;
+    proxy_set_header X-Forwarded-Prefix /prod-api/dispatch;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header X-Forwarded-Port  $server_port;
+}
+```
+
+配置生效后，springdoc 会通过标准 `ForwardedHeaderFilter` 自动派生 base URL，`/v3/api-docs/swagger-config` 返回的 `urls[].url` 将携带 `/prod-api/dispatch` 前缀，knife4j 前端可正常加载文档。
+
+### 验证方式
+
+```bash
+# 带前缀 header 请求，urls[].url 应包含 /prod-api/dispatch
+curl -s -H "X-Forwarded-Prefix: /prod-api/dispatch" \
+     http://localhost:8080/v3/api-docs/swagger-config | jq '.urls'
+
+# 不带 header 请求，作为对照（url 不含前缀）
+curl -s http://localhost:8080/v3/api-docs/swagger-config | jq '.urls'
+```
+
+### 注意事项
+
+- `server.forward-headers-strategy=framework` 会注册 Spring 的 `ForwardedHeaderFilter`，它在 Servlet 层面重写 `HttpServletRequest` 的 scheme/host/contextPath，对所有 springdoc 端点透明生效，**无需修改 knife4j 配置**。
+- 若使用 `server.forward-headers-strategy=native`，则由容器（Tomcat/Jetty）处理，效果相同但不支持 `X-Forwarded-Prefix`（Tomcat 原生不识别该 header）；推荐使用 `framework`。
+- 若同时启用了 `knife4j.basic.enable=true`，需确认 nginx 传递的路径与 `knife4j.basic.include` 规则匹配，否则带前缀的 api-docs 请求会被 Basic Auth filter 拦截返回 401。
+- Spring Boot 3.x（Jakarta）与 Spring Boot 2.7.x（javax）均支持上述配置，行为一致。
+
+---
+
 ## 配置示例
 
 ### 最小配置（WebMvc + OpenAPI3）


### PR DESCRIPTION
## 关联

Refs #345

## 变更内容

在 `docs-site/reference/configuration.md` 新增「反向代理场景（nginx prefix / X-Forwarded-Prefix）」章节，说明：

1. **nginx location 末尾斜杠**：新增内联注释，解释 `location /prod-api/dispatch/`（带斜杠）与 `X-Forwarded-Prefix /prod-api/dispatch`（不带斜杠）的不对称是有意为之：nginx 的路径剥离依赖 location 末尾斜杠，而 Spring `ForwardedHeaderFilter` 期望 prefix 不带末尾斜杠。
2. **SB2/SB3 行为差异**：将不准确的「行为一致」替换为准确描述：Spring Framework 6.x（SB 3.x）中 `ForwardedHeaderFilter` 重复注册会抛 `IllegalStateException`，5.3（SB 2.7）处理较宽松，但同样建议避免。

## Scope note

This PR documents the recommended reverse-proxy configuration path for #345. It does not add the Java smoke test or starter-side fallback for `X-Forwarded-Prefix`, so #345 should stay open until we verify whether standard forwarded headers fully cover the reported scenario.

## 验证

- `./scripts/test-docs.sh` 从 repo 根目录运行，exit 0，VitePress build 完成（8.45s）
- 两个 LOW reviewer findings 均已修复