### PR TITLE
fix(openapi3): discover custom api-docs swagger config

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchSwaggerUiConfig, parseGroupsFromConfig } from './knife4jClient';
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe('knife4jClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('discovers custom springdoc swagger-config through the Knife4j fallback endpoint', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, false))
+      .mockResolvedValueOnce(jsonResponse({ swaggerConfigUrl: 'api/openapi/swagger-config' }))
+      .mockResolvedValueOnce(jsonResponse({ url: '/api/openapi', tagsSorter: 'alpha' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchSwaggerUiConfig()).resolves.toEqual({ url: '/api/openapi', tagsSorter: 'alpha' });
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'v3/api-docs/swagger-config');
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'knife4j/swagger-config');
+    expect(fetchMock).toHaveBeenNthCalledWith(3, 'api/openapi/swagger-config');
+  });
+
+  it('uses the single springdoc url when swagger-config has no urls array', () => {
+    expect(parseGroupsFromConfig({ url: '/api/openapi' })).toEqual([{ name: 'default', url: '/api/openapi' }]);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -28,8 +28,27 @@ export type OperationsSorter = 'alpha' | 'method' | 'preserve';
  * 返回 `null` 表示端点不存在或返回异常（例如 springfox 场景）。
  */
 export async function fetchSwaggerUiConfig(): Promise<SwaggerUiConfig | null> {
+  const defaultConfig = await fetchSwaggerUiConfigFrom('v3/api-docs/swagger-config');
+  if (defaultConfig) {
+    return defaultConfig;
+  }
+
   try {
-    const res = await fetch('v3/api-docs/swagger-config');
+    const res = await fetch('knife4j/swagger-config');
+    if (!res.ok) return null;
+    const discovery = (await res.json()) as SwaggerUiConfig;
+    if (typeof discovery.swaggerConfigUrl !== 'string' || discovery.swaggerConfigUrl.length === 0) {
+      return null;
+    }
+    return fetchSwaggerUiConfigFrom(discovery.swaggerConfigUrl);
+  } catch (_) {
+    return null;
+  }
+}
+
+async function fetchSwaggerUiConfigFrom(url: string): Promise<SwaggerUiConfig | null> {
+  try {
+    const res = await fetch(url);
     if (!res.ok) return null;
     return (await res.json()) as SwaggerUiConfig;
   } catch (_) {
@@ -40,11 +59,15 @@ export async function fetchSwaggerUiConfig(): Promise<SwaggerUiConfig | null> {
 /**
  * 从已获取的 SwaggerUiConfig 解析 group 列表。
  * - 有 `urls` → 多文档场景
+ * - 有 `url` → 单文档场景
  * - 否则 → 单文档，固定使用 `v3/api-docs`
  */
 export function parseGroupsFromConfig(config: SwaggerUiConfig): SwaggerGroup[] {
-  if (config.urls && Array.isArray(config.urls)) {
+  if (config.urls && Array.isArray(config.urls) && config.urls.length > 0) {
     return config.urls.map((u) => ({ name: u.name, url: u.url }));
+  }
+  if (typeof config.url === 'string' && config.url.length > 0) {
+    return [{ name: 'default', url: config.url }];
   }
   return [{ name: 'default', url: 'v3/api-docs' }];
 }

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -19,8 +19,12 @@ export interface SwaggerGroup {
  *   `operationsSorter` 还可取 `'method'` 按 HTTP method 排序；其他值一律保持原序。
  */
 export interface SwaggerUiConfig {
+  /** 单文档 api-docs 地址（springdoc 单文档场景） */
+  url?: string;
   /** 分组列表（springdoc 多文档场景） */
   urls?: Array<{ name: string; url: string }>;
+  /** Knife4j 固定 discovery 端点返回的实际 swagger-config 地址 */
+  swaggerConfigUrl?: string;
   /** tag 排序策略（例如 'alpha'） */
   tagsSorter?: string;
   /** operation 排序策略（例如 'alpha' / 'method'） */

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/conf/GlobalConstants.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/core/conf/GlobalConstants.java
@@ -91,6 +91,11 @@ public class GlobalConstants {
     public static final String EXTENSION_OPEN_MARKDOWN_NAME = "x-markdownFiles";
 
     /**
+     * Stable Knife4j discovery key for the actual springdoc swagger-config URL.
+     */
+    public static final String EXTENSION_SWAGGER_CONFIG_URL = "swaggerConfigUrl";
+
+    /**
      * 响应HTTP状态码
      */
     public static final Integer BASIC_SECURITY_RESPONSE_CODE = 401;

--- a/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/extend/filter/BasicFilter.java
+++ b/knife4j/knife4j-core/src/main/java/com/github/xiaoymin/knife4j/extend/filter/BasicFilter.java
@@ -49,6 +49,7 @@ public class BasicFilter {
         // https://gitee.com/xiaoym/knife4j/issues/I6H8BE
         urlFilters.add(Pattern.compile(".*?/swagger-ui.*", Pattern.CASE_INSENSITIVE));
         urlFilters.add(Pattern.compile(".*?/v3/api-docs.*", Pattern.CASE_INSENSITIVE));
+        urlFilters.add(Pattern.compile(".*?/knife4j/swagger-config.*", Pattern.CASE_INSENSITIVE));
     }
 
     /**

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -36,9 +36,14 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+
+import java.util.Collections;
+import java.util.Map;
 
 /***
  * Knife4j 基础自动配置类
@@ -66,6 +71,49 @@ public class Knife4jAutoConfiguration {
     public Knife4jOpenApiCustomizer knife4jOpenApiCustomizer(SpringDocConfigProperties docProperties) {
         log.debug("Register Knife4jOpenApiCustomizer");
         return new Knife4jOpenApiCustomizer(this.properties, docProperties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Knife4jSwaggerConfigController.class)
+    public Knife4jSwaggerConfigController knife4jSwaggerConfigController(SpringDocConfigProperties docProperties) {
+        return new Knife4jSwaggerConfigController(docProperties);
+    }
+
+    @RestController
+    public static class Knife4jSwaggerConfigController {
+
+        private static final String DEFAULT_API_DOCS_PATH = "v3/api-docs";
+
+        private final SpringDocConfigProperties docProperties;
+
+        public Knife4jSwaggerConfigController(SpringDocConfigProperties docProperties) {
+            this.docProperties = docProperties;
+        }
+
+        @GetMapping("/knife4j/swagger-config")
+        public Map<String, String> swaggerConfig() {
+            return Collections.singletonMap(
+                    GlobalConstants.EXTENSION_SWAGGER_CONFIG_URL,
+                    resolveApiDocsPath() + "/swagger-config");
+        }
+
+        private String resolveApiDocsPath() {
+            if (docProperties == null || docProperties.getApiDocs() == null) {
+                return DEFAULT_API_DOCS_PATH;
+            }
+            String path = docProperties.getApiDocs().getPath();
+            if (path == null || path.trim().isEmpty()) {
+                return DEFAULT_API_DOCS_PATH;
+            }
+            String normalized = path.trim();
+            while (normalized.startsWith("/")) {
+                normalized = normalized.substring(1);
+            }
+            while (normalized.endsWith("/")) {
+                normalized = normalized.substring(0, normalized.length() - 1);
+            }
+            return normalized.isEmpty() ? DEFAULT_API_DOCS_PATH : normalized;
+        }
     }
 
     @Bean

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -36,11 +36,15 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 import javax.servlet.DispatcherType;
+import java.util.Collections;
+import java.util.Map;
 
 /***
  * Knife4j 基础自动配置类
@@ -69,6 +73,49 @@ public class Knife4jAutoConfiguration {
                                                              SpringDocConfigProperties docProperties) {
         logger.debug("Register Knife4jOpenApiCustomizer");
         return new Knife4jOpenApiCustomizer(knife4jProperties, docProperties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Knife4jSwaggerConfigController.class)
+    public Knife4jSwaggerConfigController knife4jSwaggerConfigController(SpringDocConfigProperties docProperties) {
+        return new Knife4jSwaggerConfigController(docProperties);
+    }
+
+    @RestController
+    public static class Knife4jSwaggerConfigController {
+
+        private static final String DEFAULT_API_DOCS_PATH = "v3/api-docs";
+
+        private final SpringDocConfigProperties docProperties;
+
+        public Knife4jSwaggerConfigController(SpringDocConfigProperties docProperties) {
+            this.docProperties = docProperties;
+        }
+
+        @GetMapping("/knife4j/swagger-config")
+        public Map<String, String> swaggerConfig() {
+            return Collections.singletonMap(
+                    GlobalConstants.EXTENSION_SWAGGER_CONFIG_URL,
+                    resolveApiDocsPath() + "/swagger-config");
+        }
+
+        private String resolveApiDocsPath() {
+            if (docProperties == null || docProperties.getApiDocs() == null) {
+                return DEFAULT_API_DOCS_PATH;
+            }
+            String path = docProperties.getApiDocs().getPath();
+            if (path == null || path.trim().isEmpty()) {
+                return DEFAULT_API_DOCS_PATH;
+            }
+            String normalized = path.trim();
+            while (normalized.startsWith("/")) {
+                normalized = normalized.substring(1);
+            }
+            while (normalized.endsWith("/")) {
+                normalized = normalized.substring(0, normalized.length() - 1);
+            }
+            return normalized.isEmpty() ? DEFAULT_API_DOCS_PATH : normalized;
+        }
     }
 
     @Bean

--- a/knife4j/knife4j-smoke-tests/boot2-openapi3-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2openapi3/Boot2OpenApi3DocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot2-openapi3-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2openapi3/Boot2OpenApi3DocHttpSmokeTest.java
@@ -101,6 +101,12 @@ public class Boot2OpenApi3DocHttpSmokeTest {
         Assert.assertTrue("Response should be JSON when production=true (#666, #859)",
                 apiDocs.body.contains("\"code\"") || apiDocs.body.contains("\"message\""));
 
+        HttpResponse knife4jConfig = get(port, "/knife4j/swagger-config");
+        Assert.assertFalse("Knife4j swagger-config should not return HTML when production=true",
+                knife4jConfig.body.contains("<!DOCTYPE"));
+        Assert.assertTrue("Knife4j swagger-config should be blocked when production=true",
+                knife4jConfig.body.contains("\"code\"") || knife4jConfig.body.contains("\"message\""));
+
         // doc.html should also be blocked
         HttpResponse docHtml = get(port, "/doc.html");
         Assert.assertFalse("doc.html should not return HTML content when production=true",
@@ -127,6 +133,23 @@ public class Boot2OpenApi3DocHttpSmokeTest {
         Assert.assertEquals(200, apiDocs.statusCode);
         Assert.assertTrue("Custom api-docs path should return OpenAPI JSON (#573, #849)",
                 apiDocs.body.contains("\"openapi\""));
+
+        HttpResponse defaultConfig = get(port, "/v3/api-docs/swagger-config");
+        Assert.assertEquals("Default swagger-config should not exist when api-docs path is customized (#344)",
+                404, defaultConfig.statusCode);
+
+        HttpResponse knife4jConfig = get(port, "/knife4j/swagger-config");
+        Assert.assertEquals(200, knife4jConfig.statusCode);
+        Assert.assertTrue("Knife4j discovery endpoint should expose the custom swagger-config URL (#344):\n"
+                + knife4jConfig.body,
+                knife4jConfig.body.contains("\"swaggerConfigUrl\"")
+                        && knife4jConfig.body.contains("api/openapi/swagger-config"));
+
+        HttpResponse customConfig = get(port, "/api/openapi/swagger-config");
+        Assert.assertEquals(200, customConfig.statusCode);
+        Assert.assertTrue("Custom swagger-config should point the UI at the custom api-docs path (#344):\n"
+                + customConfig.body,
+                customConfig.body.contains("/api/openapi"));
     }
 
     private HttpResponse get(int port, String path) throws IOException {

--- a/knife4j/knife4j-smoke-tests/boot3-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3JakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot3-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3JakartaDocHttpSmokeTest.java
@@ -94,6 +94,12 @@ public class Boot3JakartaDocHttpSmokeTest {
         Assert.assertTrue("Response should be JSON when production=true (#666, #859)",
                 apiDocs.body.contains("\"code\"") || apiDocs.body.contains("\"message\""));
 
+        HttpResponse knife4jConfig = get(port, "/knife4j/swagger-config");
+        Assert.assertFalse("Knife4j swagger-config should not return HTML when production=true",
+                knife4jConfig.body.contains("<!DOCTYPE"));
+        Assert.assertTrue("Knife4j swagger-config should be blocked when production=true",
+                knife4jConfig.body.contains("\"code\"") || knife4jConfig.body.contains("\"message\""));
+
         // doc.html should also be blocked
         HttpResponse docHtml = get(port, "/doc.html");
         Assert.assertFalse("doc.html should not return HTML content when production=true",
@@ -216,6 +222,23 @@ public class Boot3JakartaDocHttpSmokeTest {
         Assert.assertEquals(200, apiDocs.statusCode);
         Assert.assertTrue("Custom api-docs path should return OpenAPI JSON (#573, #849)",
                 apiDocs.body.contains("\"openapi\""));
+
+        HttpResponse defaultConfig = get(port, "/v3/api-docs/swagger-config");
+        Assert.assertEquals("Default swagger-config should not exist when api-docs path is customized (#344)",
+                404, defaultConfig.statusCode);
+
+        HttpResponse knife4jConfig = get(port, "/knife4j/swagger-config");
+        Assert.assertEquals(200, knife4jConfig.statusCode);
+        Assert.assertTrue("Knife4j discovery endpoint should expose the custom swagger-config URL (#344):\n"
+                + knife4jConfig.body,
+                knife4jConfig.body.contains("\"swaggerConfigUrl\"")
+                        && knife4jConfig.body.contains("api/openapi/swagger-config"));
+
+        HttpResponse customConfig = get(port, "/api/openapi/swagger-config");
+        Assert.assertEquals(200, customConfig.statusCode);
+        Assert.assertTrue("Custom swagger-config should point the UI at the custom api-docs path (#344):\n"
+                + customConfig.body,
+                customConfig.body.contains("/api/openapi"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a stable `/knife4j/swagger-config` discovery endpoint for both OpenAPI3 starters
- let the React UI fall back to that endpoint when the default `v3/api-docs/swagger-config` is absent
- parse springdoc single-document `url` values so custom `springdoc.api-docs.path` loads the real api-docs URL
- protect `/knife4j/swagger-config` with the existing Basic/production filter patterns
- extend Boot2 and Boot3 smoke tests for custom api-docs path and production blocking

## Validation
- `git diff --check`
- Boot3 targeted smoke passed: `Boot3JakartaDocHttpSmokeTest#shouldServeCustomApiDocsPath+shouldBlockApiDocsWhenProductionTrue` — Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
- Boot2 OpenAPI3 targeted smoke passed: `Boot2OpenApi3DocHttpSmokeTest#shouldServeCustomApiDocsPath+shouldBlockApiDocsWhenProductionTrue` — Tests run: 2, Failures: 0, Errors: 0, Skipped: 0

Local front validation note: this worktree had no `knife4j-front/node_modules`; `bun install --frozen-lockfile` and `bun install --frozen-lockfile --offline` both stalled during dependency resolution. The PR includes a focused `knife4jClient` Vitest test, and the GitHub `front-core-test` job should be treated as the authoritative front validation.

Closes #344