### PR TITLE
[codex] Sync docs with current implementation

### DIFF
--- a/.agent/KNOWN_PITFALLS.md
+++ b/.agent/KNOWN_PITFALLS.md
@@ -21,7 +21,7 @@
 ## 文档
 
 - `README.md` 可能有意引用 upstream 作为历史或临时参考。目标是去除混淆，不是抹掉来源。
-- 文档构建依赖 `npm ci`，因此环境和 lockfile 一致性很重要。
+- 文档构建依赖 `bun install --frozen-lockfile`，因此环境和 lockfile 一致性很重要。
 
 ## Agent 工作流
 

--- a/.agent/RUNBOOK.md
+++ b/.agent/RUNBOOK.md
@@ -35,7 +35,7 @@
 > - 本地 `./scripts/test-java.sh` 尾部的 `==> Smoke-tests evidence OK (N modules)` 行；或
 > - CI 上 `java-build-test` job 内 `Smoke-tests evidence summary` step 的绿色链接。
 >
-> `scripts/test-java.sh` 结尾包含一个哨兵，若任一 smoke 模块（`boot2-app`、`boot3-app`、`boot3-jakarta-app`、`boot35-jakarta-app`）缺少 surefire 报告、报告为空、或存在 failures/errors，脚本会非零退出。CI 同时会把 smoke 结果写进 job summary，失败时上传 surefire 报告 artifact 便于定位。
+> `scripts/test-java.sh` 结尾包含一个哨兵，若任一 smoke 模块（`boot2-app`、`boot2-openapi3-app`、`boot3-app`、`boot3-jakarta-app`、`boot35-jakarta-app`）缺少 surefire 报告、报告为空、或存在 failures/errors，脚本会非零退出。CI 同时会把 smoke 结果写进 job summary，失败时上传 surefire 报告 artifact 便于定位。
 >
 > 如果未来有模块被有意下线，须同步更新 `scripts/test-java.sh` 中的 `SMOKE_MODULES` 列表和 `.github/workflows/build.yml` 里 `Smoke-tests evidence summary` 的循环列表，并在 PR 描述里说明原因。
 
@@ -50,7 +50,7 @@
 它会：
 
 - 进入 `knife4j-front/`（workspace 根）
-- 运行 `npm ci`（统一安装所有 workspace 依赖）
+- 运行 `bun install --frozen-lockfile`（统一安装所有 workspace 依赖）
 - 对 `knife4j-core` workspace 运行 test、lint 和 build
 - 对 `knife4j-ui-react` workspace 运行 `format:check`、`tsc` 和 `vite build`（与 CI 等价）
 
@@ -64,7 +64,7 @@
 > **强制**：修改 `knife4j-front/**` 下任何源码时，必须跑 `./scripts/test-front-core.sh`。
 > 不得用单步 `tsc --noEmit` / `vite build` 替代，因为 CI 还会跑 `prettier --check` 与 `eslint`，这两项本地单跑极易漏。
 
-> **注意**：`knife4j-front/` 使用 npm workspaces。`knife4j-core` 和 `knife4j-ui-react` 共享根 `node_modules`，通过 symlink 联动。子项目不再有独立的 `package-lock.json`。
+> **注意**：`knife4j-front/` 使用 Bun workspace。`knife4j-core` 和 `knife4j-ui-react` 共享根 `node_modules`，通过 symlink 联动。子项目不再有独立的 `package-lock.json`。
 
 ### 文档站
 
@@ -76,8 +76,8 @@
 
 它会：
 
-- 进入 `knife4j-doc`
-- 运行 `npm ci`
+- 进入 `docs-site`
+- 运行 `bun install --frozen-lockfile`
 - 运行文档构建
 
 适用于：

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - 仓库来源：fork 自 `xiaoymin/knife4j`
 - 当前定位：社区维护分支，不是 upstream 官方仓库
 - Java 主坐标：`com.baizhukui`
-- 当前版本：`5.0.0-SNAPSHOT`
+- 当前稳定版本：`5.0.0`
 - 对外访问入口：`http://ip:port/doc.html`
 
 > `doc.html` 仍然是默认访问入口，这一点保持与原项目兼容。
@@ -26,15 +26,15 @@
 |-------------------|---------------------------------------------------------------------------|
 | `knife4j`         | Java 主工程，包含 starter、UI webjar、聚合组件、Gateway starter、WebFlux starter 与依赖管理 |
 | `docs-site`           | 当前文档站（VitePress）——项目对外文档的主入口                          |
-| `knife4j-front`       | React 前端工作区（npm workspaces），活跃子模块为 `knife4j-core`（TypeScript 解析库）和 `knife4j-ui-react`（OAS3 主线 UI，打包进 `knife4j-openapi3-ui` webjar） |
-| `knife4j-smoke-tests` | smoke 测试，覆盖 Boot 2.x / Boot 3.x / Boot 3.x Jakarta / Boot 3.5 Jakarta 等组合 |
+| `knife4j-front`       | React 前端工作区（Bun workspace），活跃子模块为 `knife4j-core`（TypeScript 解析库）和 `knife4j-ui-react`（OAS3 主线 UI，打包进 `knife4j-openapi3-ui` webjar） |
+| `knife4j-smoke-tests` | smoke 测试，覆盖 Boot 2.x OAS2/OAS3、Boot 3.x Jakarta、Boot 3.5 Jakarta 等组合 |
 | `knife4j-vue`         | upstream 旧版的历史 Vue 2 前端实现，仅作为行为参考留存，不再预期改动                   |
 | `knife4j-vue3`    | OAS2 兼容维护 UI（Vue 3 + Vite），打包进 `knife4j-openapi2-ui` webjar，只接收回归修复与显示层 bug |
 | `knife4j-insight` | 独立渲染/聚合方向的扩展方案                                                            |
 
 ## 当前维护策略
 
-- Java 后端（`knife4j/`）：优先做兼容性修复、回归修复和发布维护，当前版本线 `5.0.0-SNAPSHOT`
+- Java 后端（`knife4j/`）：优先做兼容性修复、回归修复和发布维护，当前稳定版本线 `5.0.0`
 - **前端分工**（详见 `.agent/PROJECT.md`）：
   - **OAS3 主线**：`knife4j-front/knife4j-ui-react`（React + Vite）→ `knife4j-openapi3-ui` webjar → `knife4j-openapi3-*-spring-boot-starter` 系列、`knife4j-gateway-spring-boot-starter`、`knife4j-aggregation-jakarta-spring-boot-starter`。所有新功能、UX 改进在这里落地。
   - **OAS2 兼容维护**：`knife4j-vue3`（Vue 3 + Vite）→ `knife4j-openapi2-ui` webjar → `knife4j-openapi2-spring-boot-starter`、`knife4j-aggregation-spring-boot-starter`。只接收回归修复与显示层 bug，不做功能扩张。
@@ -51,7 +51,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -62,7 +62,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -73,7 +73,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -84,7 +84,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-spring-boot-starter</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0</version>
 </dependency>
 ```
 
@@ -101,22 +101,23 @@ http://ip:port/doc.html
 ```bash
 cd knife4j
 mvn -B -ntp verify
+# 或从仓库根目录运行 ./scripts/test-java.sh
 ```
 
 ### 文档站
 
 ```bash
 cd docs-site
-npm install
-npm run dev
+bun install --frozen-lockfile
+bun run dev
 ```
 
 ### React 前端实验工程
 
 ```bash
 cd knife4j-front
-npm ci
-npm run dev -w knife4j-ui-react
+bun install --frozen-lockfile
+bun run --filter knife4j-ui-react dev
 ```
 
 ## 文档与链接

--- a/docs-site/guide/faq.md
+++ b/docs-site/guide/faq.md
@@ -22,14 +22,14 @@ title: 常见问题
 
 **大多数情况仍然有效**。upstream 文档 <https://doc.xiaominfo.com/> 上关于 `@ApiOperationSupport`、`knife4j.*` 配置、UI 行为的内容本 fork 完全兼容。两个例外：
 
-1. 版本发布节奏：upstream 最新是 `4.6.0`，fork 是 `5.0.0`（采用独立 SemVer 版本号）；fork 包含全部兼容/安全修复和 React 新前端。
-2. 新 React 前端覆盖范围：upstream Vue2 前端上有的 UI 功能（Postman 导出、afterScript、自定义 Footer、版本小蓝点等）在本 fork 的新 React 前端中尚未全部覆盖；这些功能在本仓库 `knife4j-vue3`（`knife4j-openapi2-ui` 打包产物）中继续保留。详见下文 [React 配置不生效](#react-setting-not-effective)。
+1. 版本发布节奏：upstream 最新是 `4.6.0`，fork 是 `5.0.0`（采用独立 SemVer 版本号）；fork 包含已确认并合入的兼容/安全修复和 React 新前端。
+2. 新 React 前端覆盖范围：upstream Vue2 前端上有的 UI 功能（Postman 导出、afterScript、自定义 Footer、版本小蓝点等）在本 fork 的新 React 前端中尚未全部覆盖；OAuth2、离线导出、自定义 Markdown 文档等能力则已在 React UI 中补齐或重做。这些历史功能在本仓库 `knife4j-vue3`（`knife4j-openapi2-ui` 打包产物）中继续保留。详见下文 [React 配置不生效](#react-setting-not-effective)。
 
 ### 本 fork 相比 upstream 多了哪些修复
 
 | 版本 | 修复/新增内容 | 对应 upstream issue |
 | --- | --- | --- |
-| `5.0.0` | Bug 修复 & 功能增强：petstore 闪烁、OAuth2 授权码、离线文档 Markdown/OpenAPI JSON、tags-sorter | — |
+| `5.0.0` | Bug 修复 & 功能增强：petstore 闪烁、OAuth2 四种 flow 基础鉴权、离线文档 Markdown/OpenAPI JSON、tags-sorter | — |
 | `1.0.0` | 正式版：全部 fork 安全修复 + Boot 3.4/3.5 兼容 + React UI 完整集成 | — |
 | `4.6.0.3` (Preview) | `/v2/api-docs;xxx` 分号绕过 Basic 认证漏洞 | [#886](https://github.com/xiaoymin/knife4j/issues/886) |
 | `4.6.0.3` (Preview) | Gateway context-path 导致 host 缺少斜杠 | [#954](https://github.com/xiaoymin/knife4j/issues/954) |
@@ -561,4 +561,3 @@ upstream `doc.xiaominfo.com` 仍在提供完整的历史 FAQ，如 Springfox 2.9
 
 - 查 [GitHub Issues](https://github.com/songxychn/knife4j-next/issues)
 - 提 issue 时请带上：knife4j 版本、Spring Boot 版本、是否用 jakarta、关键配置片段、最小复现。
-

--- a/docs-site/guide/features.md
+++ b/docs-site/guide/features.md
@@ -48,7 +48,7 @@ Knife4j Next 围绕"文档更清晰、调试更顺手、聚合更简单、交付
 
 ## 功能详解
 
-> 以下功能按**前端 UI 可用性**标注状态。✅ = React + Vue3 均可用；⚠️ = 仅 Vue3 可用（React 暂不支持）；❌ = 均暂不可用。
+> 以下功能按**前端 UI 可用性**标注状态。✅ = React + Vue3 均可用；🔲 = 部分实现；⬜ = 未实现；❌ = 均暂不可用。
 >
 > 这里的 Vue3 指本仓库 `knife4j-vue3`，打包进 `knife4j-openapi2-ui` webjar，面向 OAS2 starter；React 指 `knife4j-front/knife4j-ui-react`，打包进 `knife4j-openapi3-ui` webjar，面向 OAS3 starter。Vue3 处于兼容维护状态，React 为主线。
 
@@ -76,11 +76,11 @@ Knife4j UI 内置 OAuth2 授权调试面板（**Authorize**），支持四种模
 | --- | --- | --- | --- |
 | 授权码（authorization_code） | ✅ | ✅ | 最安全的模式，推荐 |
 | 隐式（implicit） | ✅ | ✅ | 不推荐（OAuth2.1 已移除） |
-| 密码（password） | ✅ | ⬜ | React 暂未实现，需要 username / password / clientId / clientSecret |
-| 客户端凭证（client_credentials） | ✅ | ⬜ | React 暂未实现，需要 clientId / clientSecret |
+| 密码（password） | ✅ | ✅ | React 支持按 `tokenUrl` 直接换取 token |
+| 客户端凭证（client_credentials） | ✅ | ✅ | React 支持按 `tokenUrl` 直接换取 token |
 
 ::: warning OAuth2 回调地址
-隐式模式和授权码模式需要配置回调地址。Knife4j 提供的回调页面位于 `webjars/oauth/oauth2.html`，因此服务端需将重定向 URI 配为 `http://<host>:<port>/webjars/oauth/oauth2.html`。
+隐式模式和授权码模式需要配置回调地址。React UI 的默认回调页为 `http://<host>:<port>/oauth2-redirect.html`；OAS2 Vue3 UI 继续使用 `http://<host>:<port>/webjars/oauth/oauth2.html`。
 :::
 
 #### OpenAPI3 配置示例（springdoc）
@@ -239,8 +239,8 @@ Host 地址支持以下格式：
 - `knife4j.example.com`（域名）
 - `http://192.168.0.111:8080/v1`（带 basePath）
 
-::: warning ⚠️ React UI 暂不支持
-自定义 Host 仅在 Vue3 UI（OAS2 starter）中可用。React 新前端暂不支持。
+::: warning React UI
+React 新前端可以在右上角设置面板手动开启 Host 覆盖，但目前仍未自动读取服务端注入的 `knife4j.setting.enable-host` / `enable-host-text` 默认值。
 :::
 
 ::: tip 前置条件：跨域

--- a/docs-site/guide/introduction.md
+++ b/docs-site/guide/introduction.md
@@ -24,7 +24,7 @@ title: 产品介绍
 
 ## 这份 fork 想解决什么
 
-1. **兼容性修复**。upstream 对 Spring Boot 3.4 / 3.5 的适配步伐变慢，fork 已经升级 `springdoc-openapi-jakarta` 到 `2.8.9`，把 3.4.0 / 3.5.0 两个版本纳入 smoke-tests 模块定期回归。
+1. **兼容性修复**。upstream 对 Spring Boot 3.4 / 3.5 的适配步伐变慢，fork 已经升级 `springdoc-openapi-jakarta` 到 `2.8.9`，并通过 smoke-tests 覆盖 Boot 2.7.18 的 OAS2/OAS3、Boot 3.4.x Jakarta 与 Boot 3.5.0 Jakarta 组合。
 2. **安全修复**。修复了 `/v2/api-docs;xxx` 分号绕过 Basic 认证的漏洞（[#886](https://github.com/xiaoymin/knife4j/issues/886)），以及 gateway `context-path` 下聚合 host 少斜杠的问题（[#954](https://github.com/xiaoymin/knife4j/issues/954)）。
 3. **可重复发布流程**。`.github/workflows/release.yml` 通过 Central Publishing Plugin 直接推送 Maven Central，不依赖人工临场操作。
 4. **可试用的 Demo**。`knife4j-demo-openapi3`（Spring Boot 3.4 + OpenAPI 3 + React UI）和 `knife4j-demo-openapi2`（Spring Boot 2.7 + OpenAPI 2 + Vue 3 UI）两个示例工程都附带 Dockerfile，可分别本地运行或在线预览。
@@ -46,14 +46,15 @@ title: 产品介绍
 
 ## 哪些是 **没有** 做或 **部分实现**，需要你知道
 
-upstream 文档里列出的 29 个增强特性在本 fork 的实际实现状态，前端和后端存在差异：
+upstream 文档里列出的增强特性在本 fork 的实际实现状态，前端和后端存在差异：
 
-| 情况 | 数量 | 示例 | 建议 |
-| --- | --- | --- | --- |
-| 全部模块已实现 | 4 项 | `knife4j.enable`、`knife4j.production`、`knife4j.basic`、JSR303 透传 | 安心使用 |
-| openapi2-starter 完整，openapi3 系列**部分丢弃** | 6 项 | `@DynamicParameters`、`@DynamicResponseParameters`、`@ApiOperationSupport(ignoreParameters/includeParameters)` 等 Springfox 专属能力 | 迁到 openapi3 时改用实体类替代 |
-| 后端实现，新 React 前端未读取 | 13 项 | `knife4j.setting.enable-debug=false`、`enable-search`、`enable-open-api`、`enable-version`、`enable-footer-custom`、`home-custom-path`、`swagger-model-name`、`enable-after-script` 等 | 依赖这些 UI 开关的用户暂时使用 openapi2 starter + 本仓库 Vue 3 UI |
-| 全模块未实现 | 2 项 | 导出 Postman、Markdown 离线导出（新前端仅 HTML/Word） | 等待后续迭代 |
+| 情况 | 示例 | 建议 |
+| --- | --- | --- |
+| 服务端能力已覆盖 | `knife4j.enable`、`knife4j.production`、`knife4j.basic`、JSR303 透传 | 安心使用 |
+| Springfox 专属增强在 OAS3 中不处理 | `@DynamicParameters`、`@DynamicResponseParameters`、`@ApiOperationSupport(ignoreParameters/includeParameters)` 等 | 迁到 OpenAPI3 时改用实体类或标准 OpenAPI 注解替代 |
+| 后端实现，新 React 前端尚未自动读取 | `knife4j.setting.enable-debug=false`、`enable-search`、`enable-open-api`、`enable-version`、`enable-footer-custom`、`home-custom-path`、`swagger-model-name`、`enable-after-script` 等 | 依赖这些 UI 开关的用户暂时使用 openapi2 starter + 本仓库 Vue 3 UI |
+| React UI 已补齐或重做 | OAuth2 四种 flow 基础鉴权、HTML/Word/Markdown/OpenAPI JSON 离线导出、`tags-sorter` / `operations-sorter`、`x-markdownFiles` 自定义文档 | 优先以本仓库文档和实际 demo 为准 |
+| 仍未覆盖 | Postman 导出、afterScript 等 | 等待后续迭代 |
 
 完整对应关系见 [路线图 / 新前端覆盖范围](../roadmap/#react-ui-coverage)。
 

--- a/docs-site/guide/oas2-issue-triage.md
+++ b/docs-site/guide/oas2-issue-triage.md
@@ -1,12 +1,16 @@
 ---
-title: OAS2 UI Issue 盘点（knife4j-vue3）
+title: OAS2 UI Issue 初筛（knife4j-vue3）
 ---
 
-# OAS2 UI Issue 盘点（knife4j-vue3）
+# OAS2 UI Issue 初筛（knife4j-vue3）
 
 本文汇总 upstream `xiaoymin/knife4j` 中属于 **OAS2 / Swagger 2 场景**的 UI issue，并按 knife4j-next 的[前端分工策略](/guide/migration#spring-boot-2-x-springfox-openapi2)给出处置结论。
 
 > **前端分工策略摘要**：`knife4j-vue3` 只做回归修复、安全补丁、显示层 bug 修复，不做功能扩张。OAS2 场景的新功能请求一律按 `wontfix: scope-policy` 关闭，引导用户迁移到 OAS3 starter。
+
+::: warning 这不是当前任务队列
+这页是 upstream issue 的历史初筛记录，不代表 issue 已在本仓库复现、修复或承诺排期。真正开工前必须重新阅读 upstream 原文、在当前仓库复现，并在本仓库 issue / PR 中写清楚实际范围；不要只凭 upstream 标题或截图认定修复方向。
+:::
 
 ---
 
@@ -16,13 +20,13 @@ title: OAS2 UI Issue 盘点（knife4j-vue3）
 
 | upstream issue | 摘要 | 处置状态 |
 |---|---|---|
-| [#523](https://github.com/xiaoymin/knife4j/issues/523) | 设置全局安全验证后调试请求不生效（v4.0.0） | 待独立 PR |
-| [#608](https://github.com/xiaoymin/knife4j/issues/608) | 3.0.3 版本多文件上传不显示上传按钮（springfox 3.0.x） | 待独立 PR |
-| [#638](https://github.com/xiaoymin/knife4j/issues/638) | 4.3.0 版本文件上传不显示上传选择文本域 | 待独立 PR |
-| [#758](https://github.com/xiaoymin/knife4j/issues/758) | yml 不支持 `showTagStatus` 但前端有此参数 | 待独立 PR（或补文档） |
-| [#565](https://github.com/xiaoymin/knife4j/issues/565) | `application/json` 内写 schema 无法显示（OAS2 写法） | 待独立 PR |
+| [#523](https://github.com/xiaoymin/knife4j/issues/523) | 设置全局安全验证后调试请求不生效（v4.0.0） | 待当前仓库复现后决定 |
+| [#608](https://github.com/xiaoymin/knife4j/issues/608) | 3.0.3 版本多文件上传不显示上传按钮（springfox 3.0.x） | 待当前仓库复现后决定 |
+| [#638](https://github.com/xiaoymin/knife4j/issues/638) | 4.3.0 版本文件上传不显示上传选择文本域 | 待当前仓库复现后决定 |
+| [#758](https://github.com/xiaoymin/knife4j/issues/758) | yml 不支持 `showTagStatus` 但前端有此参数 | 待当前仓库复现后决定 |
+| [#565](https://github.com/xiaoymin/knife4j/issues/565) | `application/json` 内写 schema 无法显示（OAS2 写法） | 待当前仓库复现后决定 |
 
-**修复原则**：每个 issue 独立 PR，修复范围限于 `knife4j-vue3/src/` 显示层，不引入新功能，不改动 `knife4j-core`（TypeScript）。
+**修复原则**：每个 issue 独立 PR；如果确认为 OAS2 UI 显示层问题，修复范围限于 `knife4j-vue3/src/`，不引入新功能，不改动 `knife4j-core`（TypeScript）。如果复现结果指向 Java / 静态资源 / 聚合路径，应重新归到对应后端任务。
 
 ---
 
@@ -39,7 +43,7 @@ title: OAS2 UI Issue 盘点（knife4j-vue3）
 | [#788](https://github.com/xiaoymin/knife4j/issues/788) | 导出 Word 格式错乱 | 导出体验改进，已在 `knife4j-ui-react` 重做；OAS2 保留现状 |
 | [#550](https://github.com/xiaoymin/knife4j/issues/550) | 语言切换回调（i18n 扩展） | 功能扩张，`knife4j-ui-react` 主线考虑 |
 
-**处置方式**：在 upstream 对应 issue 回帖，说明 knife4j-next 的分工策略，并附 OAS3 迁移指南链接（见下方[回帖模板](#回帖模板)）。
+**处置方式**：在本仓库 issue / PR 中说明分工策略，并附 OAS3 迁移指南链接。是否回帖 upstream 由维护者按场景决定，不把回帖当作完成条件。
 
 ---
 
@@ -49,15 +53,15 @@ title: OAS2 UI Issue 盘点（knife4j-vue3）
 
 | upstream issue | 摘要 | 处置方向 |
 |---|---|---|
-| [#503](https://github.com/xiaoymin/knife4j/issues/503) | Tomcat `Http11Nio2Protocol` 时文档页面不显示 | 纳入 [#198](https://github.com/songxychn/knife4j-next/issues/198) 启动期 bug 子分组，Java 侧修复 |
-| [#687](https://github.com/xiaoymin/knife4j/issues/687) | 测试环境访问 `doc.html` 返回 500 | 同上（[#198](https://github.com/songxychn/knife4j-next/issues/198)） |
-| [#666](https://github.com/xiaoymin/knife4j/issues/666) | 静态资源 `Content-type` 响应不对 | 同上（[#198](https://github.com/songxychn/knife4j-next/issues/198)） |
+| [#503](https://github.com/xiaoymin/knife4j/issues/503) | Tomcat `Http11Nio2Protocol` 时文档页面不显示 | 待当前仓库复现后判定是否为 Java 启动 / 静态资源问题 |
+| [#687](https://github.com/xiaoymin/knife4j/issues/687) | 测试环境访问 `doc.html` 返回 500 | 待当前仓库复现后判定是否为 Java 启动 / 静态资源问题 |
+| [#666](https://github.com/xiaoymin/knife4j/issues/666) | 静态资源 `Content-type` 响应不对 | 不再直接归入 #198；需按静态资源 MIME / MessageConverter 顺序方向独立复现与跟踪 |
 
 ---
 
 ## 回帖模板
 
-对 wontfix 类 issue，在 upstream 回帖时使用以下模板（中文）：
+对 wontfix 类 issue，如果维护者决定回帖 upstream，可使用以下模板（中文）：
 
 ```
 感谢反馈！

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -25,11 +25,11 @@ features:
     link: /guide/migration
     linkText: 迁移指引
   - title: Spring Boot 2.7、3.4、3.5 都跑过
-    details: 4 个 smoke 模块（Boot 2.7.18、Boot 3.4.0、Boot 3.5.0）随每次构建回归，springdoc-openapi-jakarta 已对齐 2.8.9。
+    details: 5 个 smoke 模块覆盖 Boot 2.7.18 的 OAS2/OAS3、Boot 3.4.x Jakarta 与 Boot 3.5.0 Jakarta 组合，springdoc-openapi-jakarta 已对齐 2.8.9。
     link: /reference/compatibility
     linkText: 兼容矩阵
   - title: React + Vite 新前端
-    details: knife4j-openapi3-ui webjar 已集成 React 前端，支持国际化、类型感知参数输入、OAuth2 授权码流程、响应复制/下载等。
+    details: knife4j-openapi3-ui webjar 已集成 React 前端，支持国际化、类型感知参数输入、OAuth2 四种 flow 的基础鉴权调试、响应复制/下载等。
     link: /release-notes/
     linkText: 发布说明
   - title: Gateway 与多服务聚合
@@ -79,7 +79,7 @@ springdoc:
 ## 5.0.0 版本亮点 <Badge type="tip" text="最新" />
 
 - 🐛 修复页面加载时 Petstore 示例数据一闪而过
-- 🔐 OAuth2 授权码 / 隐式模式弹窗流程
+- 🔐 OAuth2 四种 flow 的基础鉴权调试
 - 📄 离线文档导出新增 Markdown 与 OpenAPI JSON
 - 🏷️ 尊重后端 `tags-sorter` / `operations-sorter` 配置
 - 🔧 GlobalParam 布局修复 + ApiDoc 工具栏优化
@@ -87,7 +87,7 @@ springdoc:
 完整更新列表见 [发布说明](/release-notes/)。
 
 ::: warning 关于新前端覆盖范围
-新 React 前端当前**仅覆盖部分** upstream 增强特性。如果你依赖的是 `knife4j.setting.enable-debug=false`、`enable-footer-custom`、`home-custom-path`、`swagger-model-name`、`enable-after-script`、`enable-version`、Postman 导出，请在切换到新前端前先查阅 [新前端覆盖范围](/roadmap/#react-ui-coverage)。`knife4j-openapi2-ui` 由本仓库 `knife4j-vue3` 构建，处于兼容维护状态，upstream 已有特性继续可用。
+新 React 前端当前**仅覆盖部分** upstream 增强特性。如果你依赖的是 `knife4j.setting.enable-debug=false`、`enable-footer-custom`、`home-custom-path`、`swagger-model-name`、`enable-after-script`、`enable-version`、Postman 导出，或依赖服务端 `knife4j.setting.*` 自动驱动前端开关，请在切换到新前端前先查阅 [新前端覆盖范围](/roadmap/#react-ui-coverage)。`knife4j-openapi2-ui` 由本仓库 `knife4j-vue3` 构建，处于兼容维护状态，upstream 已有特性继续可用。
 :::
 
 ## 文档导航
@@ -110,7 +110,7 @@ springdoc:
 
 - [兼容矩阵](/reference/compatibility)：Java、Spring、Boot、springdoc 基线
 - [版本参考表](/reference/version-ref)：Boot 版本如何选 knife4j 版本
-- [模块说明](/reference/modules)：14 个 Maven 模块的职责与选择决策
+- [模块说明](/reference/modules)：15 个 Maven 模块的职责与选择决策
 - [配置参考](/reference/configuration)：全部 `knife4j.*` YAML 选项
 - [注解速查](/reference/annotations)：Springfox 专有 vs 通用注解
 

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -380,7 +380,7 @@ knife4j:
     password: ${DOC_PASSWORD}
 ```
 
-> **生产环境响应格式（#859）**：`production=true` 时，被屏蔽的请求返回 `application/json` 格式的错误响应（`{"code":403,"message":"..."}`），而非 HTML 错误页面，避免前端 `JSON.parse` 时抛出 `Unexpected token '<', "<!DOCTYPE "...` 异常。
+> **生产环境响应格式**：`production=true` 时，被屏蔽的请求返回 `application/json` 格式的错误响应（`{"code":403,"message":"..."}`），而非 HTML 错误页面，避免前端 `JSON.parse` 时抛出 `Unexpected token '<', "<!DOCTYPE "...` 异常。
 
 ### Gateway 聚合配置（DISCOVER 模式）
 
@@ -413,4 +413,3 @@ knife4j:
         serviceName: user-service
         groupName: DEFAULT_GROUP
         namespaceId: public
-

--- a/docs-site/reference/modules.md
+++ b/docs-site/reference/modules.md
@@ -9,11 +9,10 @@ title: 模块说明
 | 目录 | 说明 |
 | --- | --- |
 | `knife4j/` | Java 主工程——用户实际引入的 starter 和 webjar 都在这里构建 |
-| `knife4j-front/` | 下一代前端工作区（React UI + parser-core） |
+| `knife4j-front/` | 下一代前端工作区（React UI + `knife4j-core`） |
 | `knife4j-vue/` | 历史 Vue2 前端实现（upstream 旧版），仅作为"现有行为参考"留存，不再预期改动 |
 | `knife4j-vue3/` | OAS2 兼容维护 UI，打包进 `knife4j-openapi2-ui` webjar，只接收回归修复与显示层 bug |
 | `knife4j-insight/` | 独立渲染 / 聚合方向的扩展能力 |
-| `knife4j-doc/` | 历史 Docusaurus 文档站（已废弃，内容迁移到 `docs-site/`） |
 | `docs-site/` | 当前 VitePress 文档站 |
 
 ## Java 模块（`knife4j/` 下）
@@ -61,7 +60,7 @@ title: 模块说明
 | --- | --- |
 | `knife4j-demo-openapi3` | OpenAPI 3 在线演示应用（Boot 3.4.5 + Jakarta starter + React UI，部署到 `openapi3.demo.knife4jnext.com`） |
 | `knife4j-demo-openapi2` | OpenAPI 2 在线演示应用（Boot 2.7.18 + springfox 2.10.5 + Vue 3 UI，部署到 `openapi2.demo.knife4jnext.com`） |
-| `knife4j-smoke-tests` | 自动化冒烟测试（4 个子模块覆盖 Boot 2.x / 3.x / 3.5.x） |
+| `knife4j-smoke-tests` | 自动化冒烟测试（5 个子模块覆盖 Boot 2.x OAS2/OAS3、Boot 3.4.x Jakarta 与 Boot 3.5.x Jakarta） |
 
 ## 选型决策树
 
@@ -97,7 +96,7 @@ title: 模块说明
 | 模块 | 说明 |
 | --- | --- |
 | `knife4j-ui-react` | React 新前端，已集成进 `knife4j-openapi3-ui` webjar |
-| `parser-core` | 前端 OpenAPI 解析核心库 |
+| `knife4j-core` | 前端 OpenAPI 解析核心库 |
 
 ## 注意事项
 

--- a/docs-site/release-notes/index.md
+++ b/docs-site/release-notes/index.md
@@ -23,7 +23,7 @@ knife4j-next 首个正式稳定版本。整合了 Preview 阶段（4.6.0.3）和
 - ApiDebug：多 content-type 请求体（JSON / form-data / x-www-form-urlencoded）
 - ApiDebug：发送前 cURL 预览、响应体复制 / 下载 / 大小显示
 - ApiDebug：认证 & 全局参数合并注入（来源标签 interface / global / auth）
-- Authorize：按 securitySchemes 动态渲染，支持 OAuth2 授权码 / 隐式模式弹窗流程（`oauth2-redirect.html` 回跳）
+- Authorize：按 securitySchemes 动态渲染，支持 OAuth2 四种 flow 的基础 token 获取 / 注入（授权码和隐式模式通过 `oauth2-redirect.html` 回跳）
 - 侧边栏：接口搜索高亮 + HTTP Method 过滤 + 尊重后端 `tags-sorter` / `operations-sorter` 配置
 - Tab 标签页：右键菜单（关闭当前 / 关闭其他 / 关闭全部）+ 刷新后状态持久化
 - Home 页：OpenAPI 概览（接口统计、分组信息、扩展属性）

--- a/docs-site/roadmap/index.md
+++ b/docs-site/roadmap/index.md
@@ -25,7 +25,7 @@ title: 路线图
 | React 前端 | ApiDoc 接口文档展示（参数表格 + 响应结构 + 复制操作） | ✅ |
 | React 前端 | ApiDebug 接口调试（类型感知参数输入 + requestBody 多 content-type + cURL 预览 + 响应复制/下载） | ✅ |
 | React 前端 | SwaggerModels 数据模型展示 | ✅ |
-| React 前端 | Authorize 鉴权配置（securitySchemes 动态渲染 + OAuth2 授权码流程） | ✅ |
+| React 前端 | Authorize 鉴权配置（securitySchemes 动态渲染 + OAuth2 四种 flow 基础 token 获取/注入） | ✅ |
 | React 前端 | GlobalParam 全局参数 | ✅ |
 | React 前端 | Home 首页统计概览（重设计） | ✅ |
 | React 前端 | 离线文档导出（HTML / Word） | ✅ |
@@ -36,12 +36,12 @@ title: 路线图
 | React 前端 | Tab 右键菜单 + 刷新后状态持久化 | ✅ |
 | React 前端 | 侧边栏接口搜索高亮 + Method 过滤条 | ✅ |
 | React 前端 | Markdown 渲染（API/tag/info description） | ✅ |
-| React 前端 | OAuth2 授权码 / 隐式模式弹窗流程 | ✅ |
+| React 前端 | OAuth2 四种 flow 的基础鉴权调试 | ✅ |
 | React 前端 | 离线文档导出（HTML / Word / Markdown / OpenAPI JSON） | ✅ |
 | React 前端 | 尊重后端 tags-sorter / operations-sorter 配置 | ✅ |
 | knife4j-core | debug 解析层抽取（resolveRef / OperationDebugModel / requestBuilder） | ✅ |
 | knife4j-core | buildSchemaExample & buildSchemaFieldTree | ✅ |
-| 基础设施 | npm workspaces 统一 knife4j-front 包管理 | ✅ |
+| 基础设施 | Bun workspace 统一 knife4j-front 包管理 | ✅ |
 | 基础设施 | Node.js 22 LTS + Prettier + Spotless 格式化规范 | ✅ |
 
 ---
@@ -61,7 +61,7 @@ title: 路线图
 | 数据模型展示 | ✅ | ✅ | — |
 | 分组切换 | ✅ | ✅ | — |
 | 接口搜索 | ✅ | ✅ | — |
-| Authorize 鉴权 | ✅ | 🔲 | React 支持 securitySchemes 动态渲染 + OAuth2 授权码/隐式流程，缺少 password/client_credentials |
+| Authorize 鉴权 | ✅ | ✅ | React 支持 securitySchemes 动态渲染 + OAuth2 四种 flow 基础 token 获取/注入 |
 | 全局参数 | ✅ | ✅ | — |
 | 离线文档导出 | ✅ | 🔲 | React 支持 HTML/Word/Markdown/OpenAPI JSON，缺少 Word 模板自定义 |
 | 首页统计 | ✅ | ✅ | — |
@@ -71,7 +71,7 @@ title: 路线图
 | 功能 | Vue3 | React | 缺口说明 |
 | --- | --- | --- | --- |
 | multipart/form-data 文件上传 | ✅ | 🔲 | 基础表单可用，完整文件上传待优化 |
-| OAuth2 password/client_credentials | ✅ | ⬜ | — |
+| OAuth2 password/client_credentials | ✅ | ✅ | 基础 `tokenUrl` 换取 token 已实现 |
 | afterScript（请求后脚本） | ✅ | ⬜ | — |
 
 ### 增强功能
@@ -82,7 +82,7 @@ title: 路线图
 | `@ApiSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
 | `@ApiOperationSupport.order` 操作排序 | ✅ | ⬜ | 后端已生效，UI 不排序 |
 | `@ApiOperationSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
-| 自定义 Markdown 文档 | ✅ | ⬜ | 依赖 UI 设置面板读取 setting |
+| 自定义 Markdown 文档 | ✅ | ✅ | React 读取 `x-markdownFiles` 并在侧边栏渲染 |
 | 全局搜索（跨分组） | ✅ | 🔲 | React 仅搜索当前分组 |
 | TypeScript 代码生成 | ✅ | ⬜ | — |
 | Postman 导出 | ✅ | ⬜ | — |
@@ -122,8 +122,8 @@ title: 路线图
 ## 下一步
 
 1. **补齐 `knife4j.setting.*` UI 开关联动**：React 前端读取后端注入的 x-knife4j setting
-2. **补齐 OAuth2 password / client_credentials** 调试流程
-3. **补齐 Postman 导出**
-4. **`@ApiSupport.order` / `@ApiOperationSupport.order` 排序**
+2. **补齐 Postman 导出**
+3. **`@ApiSupport.order` / `@ApiOperationSupport.order` 排序**
+4. **补齐 multipart/form-data 文件上传细节**
 
 如果你想参与某个任务的实现，欢迎提 Issue 或 PR。详见 [GitHub 仓库](https://github.com/songxychn/knife4j-next)。

--- a/knife4j-front/README.md
+++ b/knife4j-front/README.md
@@ -1,54 +1,43 @@
 # knife4j-front
 
-这是前端项目
+这是 `knife4j-next` 的前端工作区，当前使用 Bun workspace 管理活跃包。
 
-- knife4j-core: 基于TypeScript编写基础核心解析包，包括对Swagger2、OpenAPI3、AsyncApi等规范的解析，并暴露解析后的数据结构，供上层应用使用
-- knife4j-cli: Node生态下的cli工具，基于TypeScript编写
-- knife4j-extension: 基于TypeScript编写的浏览器插件的基础包
-- knife4j-extension-chrome:Chrome浏览器扩展程序
-- knife4j-extension-firefox:firefox浏览器扩展程序
-- knife4j-extension-edge:edge浏览器扩展程序
-- knife4j-ui-react:基于React+Vite+Antd编写的前端Ui层呈现（OpenAPI 3 主线）
+## 活跃模块
 
-# 架构设计
+| 模块 | 说明 |
+| --- | --- |
+| `knife4j-core` | 基于 TypeScript 的 OpenAPI / Swagger 解析核心库，为上层 UI 提供统一数据结构 |
+| `knife4j-ui-react` | React + Vite + Ant Design 前端 UI，面向 OpenAPI 3.x，并打包进 `knife4j-openapi3-ui` webjar |
+
+`knife4j-cli`、`knife4j-extension` 和浏览器扩展目录目前属于历史规划或占位内容，尚未纳入 Bun workspace。
+
+## 架构设计
 
 ![](../static/knife4j-front-architecture.png)
 
-
-# 模块说明
-
 ## knife4j-core
 
-前端核心模块，也是所有上层应用的基础库，基于TypeScript编写，主要作用：
+前端核心模块，也是上层应用的基础库，主要负责：
 
-一、解析适配
-
-- 提供对当前流行的规范解析，例如：OpenAPI3、AsyncApi3、Swagger2等
-- 提供对当前流行的工具格式解析，例如：Postman、curl
-- 提供对Knife4j框架本身的扩展支持
-
-
-二、统一数据结构
-
-解析相应的规范、工具后，提供统一的数据结构规范，供上层应用使用
-
-
-## knife4j-cli
-
-基于Node环境下开箱即用的cli工具集合，所有可实现的IDEA都可以在该集合中进行体现，例如：
-
-- 将OpenAPI结构的文件转换成一份美观的Markdown文档
-- 本地快速开启服务端口，预览当前OpenAPI结构的文档
-- more...
-
-
-## knife4j-extension
-
-该模块是各个浏览器插件的底层基础库，依赖knife4j-core模块提供的功能，主要是为上层浏览器扩展程序插件提供基础的支撑。
-
-目前主要考虑的三个主流浏览器插件实现：chrome、firefox、edge
-
+- 解析 OpenAPI 3、Swagger 2、AsyncAPI 等规范
+- 解析 Postman、curl 等工具格式
+- 提供统一数据结构，供 UI 和后续工具使用
+- 为 Knife4j 自身扩展能力提供前端解析支撑
 
 ## knife4j-ui-react
 
-基于 React + Vite + Antd 编写的前端 UI 呈现，面向 OpenAPI 3.x，作为下一代 `doc.html` 主线，提供文档预览、接口调试等核心功能。
+OpenAPI 3.x 主线 UI，提供文档预览、接口调试、鉴权配置、数据模型、离线导出等核心功能。
+
+## 本地命令
+
+```bash
+bun install --frozen-lockfile
+bun run --filter knife4j-core test
+bun run --filter knife4j-ui-react dev
+```
+
+完整前端验证请从仓库根目录运行：
+
+```bash
+./scripts/test-front-core.sh
+```

--- a/knife4j-front/knife4j-ui-react/README.md
+++ b/knife4j-front/knife4j-ui-react/README.md
@@ -1,27 +1,29 @@
-# React + TypeScript + Vite
+# knife4j-ui-react
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+`knife4j-ui-react` 是 `knife4j-next` 的 OpenAPI 3.x 主线前端，使用 React + Vite + Ant Design 构建，并打包进 `knife4j-openapi3-ui` webjar，最终通过 `doc.html` 暴露给 OpenAPI3 starter。
 
-Currently, two official plugins are available:
+它不是通用 Vite 模板，也不是 OAS2 兼容 UI。OAS2 兼容维护线在 `knife4j-vue3`。
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## 本地开发
 
-## Expanding the ESLint configuration
+从 `knife4j-front/` workspace 根目录运行：
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-   parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
-    tsconfigRootDir: __dirname,
-   },
+```bash
+bun install --frozen-lockfile
+bun run --filter knife4j-ui-react dev
 ```
 
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+## 验证命令
+
+```bash
+bun run --filter knife4j-ui-react format:check
+bun run --filter knife4j-ui-react test
+bun run --filter knife4j-ui-react build
+bun run --filter knife4j-ui-react lint
+```
+
+涉及 `knife4j-front/**` 的改动，优先从仓库根目录运行统一脚本：
+
+```bash
+./scripts/test-front-core.sh
+```

--- a/knife4j/README.md
+++ b/knife4j/README.md
@@ -1,80 +1,62 @@
-# knife4j项目说明
+# knife4j Java 主工程
 
-knife4j的前身是`swagger-bootstrap-ui`，为了契合微服务的架构发展,由于原来`swagger-bootstrap-ui`采用的是后端Java代码+前端Ui混合打包的方式,在微服务架构下显的很臃肿,因此项目正式更名为`knife4j`
+本目录是 `knife4j-next` 的 Java 多模块主工程，负责构建用户实际引入的 starter、UI webjar、聚合组件和依赖管理。
 
-更名后主要专注的方面
+`knife4j-next` 是 `xiaoymin/knife4j` 的社区维护 fork。当前发布坐标使用 `com.baizhukui`，Java 包名仍保留 `com.github.xiaoymin.knife4j.*`，以维持既有用户代码兼容。
 
-- 前后端Java代码以及前端Ui模块进行分离,在微服务架构下使用更加灵活
-- 提供专注于Swagger的增强解决方案,不同于只是改善增强前端Ui部分
+## 当前坐标
 
-目前`knife4j`的项目结构：
-
-| 模块名称                                                 | 说明                                                                                                |
-|------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| knife4j-aggregation-spring-boot-starter              | 基于 Servlet 体系下的聚合中间件                                                                              |
-| knife4j-core                                         | 核心类,包含一些工具包、增强注解等                                                                                 |
-| knife4j-dependencies                                 | Knife4j 提供的 dependencies 工程，引入该工程后，knife4j\springfox\swagger\springdoc-openapi 等版本号不用在独自声明        |
-| knife4j-openapi2-ui                                  | 增强 UI 文档,该包是一个 webjar,只包含前端代码，支持 OpenAPI2                                                         |
-| knife4j-openapi3-ui                                  | 增强 UI 文档,该包是一个 webjar,只包含前端代码，支持 OpenAPI3                                                         |
-| knife4j-gateway-spring-boot-starter                  | 基于Spring Cloud Gateway网关的项目可以引用该组件实现简单的文档聚合,参考[文档](knife4j-gateway-spring-boot-starter)           |
-| knife4j-openapi2-spring-boot-starter                 | 基于 OpenAPI2 规范，在 Spring Boot < 3.0.0-M1 的单体架构下可以直接引用此 starter,该模块包含了 Ui 部分，底层依赖 springfox-swagger 2.10.5 项目 |
-| knife4j-openapi3-spring-boot-starter                 | 基于 OpenAPI3 规范，在 Spring Boot < 3.0.0-M1 的单体架构下可以直接引用此 starter,该模块包含了 Ui 部分，底层基于 springdoc-openapi 项目 |
-| knife4j-openapi3-jakarta-spring-boot-starter         | 基于 OpenAPI3 规范，在 Spring Boot >= 3.0.0-M1 的单体架构下可以直接引用此 starter,该模块包含了 Ui 部分，底层基于 springdoc-openapi 项目 |
-| knife4j-openapi3-webflux-spring-boot-starter         | 基于 OpenAPI3 规范，在 Spring Boot <  3.0.0-M1 的单体架构下可以直接引用此 starter,该模块包含了 Ui 部分，底层基于 springdoc-openapi 项目 |
-| knife4j-openapi3-webflux-jakarta-spring-boot-starter | 基于 OpenAPI3 规范，在 Spring Boot >=  3.0.0-M1 的单体架构下可以直接引用此 starter,该模块包含了 Ui 部分，底层基于 springdoc-openapi 项目 |
-
-## 业务场景
-
-### 不使用增强功能,纯粹换一个swagger的前端皮肤
-
-不使用增强功能,纯粹换一个swagger的前端皮肤，这种情况是最简单的,你项目结构下无需变更
-
-可以直接引用swagger-bootstrap-ui的最后一个版本1.9.6或者使用knife4j-spring-ui
-
-老版本引用
+已发布稳定版本：
 
 ```xml
 <dependency>
-    <groupId>com.github.xiaoymin</groupId>
-    <artifactId>swagger-bootstrap-ui</artifactId>
-    <version>1.9.6</version>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>5.0.0</version>
 </dependency>
 ```
 
-新版本引用
+源码分支中的根 POM 可能进入下一轮 `SNAPSHOT` 开发状态；对外接入示例以已发布版本为准。
 
-```xml
-<dependency>
-    <groupId>com.github.xiaoymin</groupId>
-    <artifactId>knife4j-openapi2-ui</artifactId>
-    <version>${lastVersion}</version>
-</dependency>
+## 模块概览
+
+| 模块 | 说明 |
+| --- | --- |
+| `knife4j-core` | 核心增强逻辑、配置解析、vendor extension 与 OpenAPI 自定义器 |
+| `knife4j-dependencies` | BOM / dependencyManagement |
+| `knife4j-openapi2-ui` | OpenAPI2 / Springfox UI webjar，打包 `knife4j-vue3` 构建产物 |
+| `knife4j-openapi3-ui` | OpenAPI3 UI webjar，打包 `knife4j-front/knife4j-ui-react` 构建产物 |
+| `knife4j-openapi2-spring-boot-starter` | Spring Boot 2.x + Springfox / Swagger2 |
+| `knife4j-openapi3-spring-boot-starter` | Spring Boot 2.x + springdoc-openapi 1.x / OpenAPI3 |
+| `knife4j-openapi3-jakarta-spring-boot-starter` | Spring Boot 3.x + springdoc-openapi 2.x / OpenAPI3 |
+| `knife4j-openapi3-webflux-spring-boot-starter` | Spring Boot 2.x WebFlux 依赖编排 |
+| `knife4j-openapi3-webflux-jakarta-spring-boot-starter` | Spring Boot 3.x WebFlux 依赖编排 |
+| `knife4j-gateway-spring-boot-starter` | Spring Cloud Gateway 聚合 |
+| `knife4j-aggregation-spring-boot-starter` | Spring Boot 2.x 独立聚合 |
+| `knife4j-aggregation-jakarta-spring-boot-starter` | Spring Boot 3.x 独立聚合 |
+| `knife4j-demo-openapi2` | OpenAPI2 demo |
+| `knife4j-demo-openapi3` | OpenAPI3 demo |
+| `knife4j-smoke-tests` | 兼容性 smoke 测试集合 |
+
+## 本地验证
+
+从仓库根目录运行：
+
+```bash
+./scripts/test-java.sh
 ```
 
-### Spring Boot项目单体架构使用增强功能
+也可以只验证 Java 主工程：
 
-在Spring Boot单体架构下,knife4j提供了starter供开发者快速使用
-
-```xml
-<dependency>
-    <groupId>com.github.xiaoymin</groupId>
-    <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>${knife4j.version}</version>
-</dependency>
+```bash
+cd knife4j
+mvn -B -ntp verify
 ```
 
-该包会引用所有的knife4j提供的资源，包括前端Ui的jar包
- 
-## 另外说明
+默认访问入口保持为：
 
-不管是knife4j还是swagger-bootstrap-ui
+```text
+http://ip:port/doc.html
+```
 
-对外提供的地址依然是doc.html
-
-访问：http://ip:port/doc.html
-
-即可查看文档
-
-**这是永远不会改变的**
-
-在线Demo示例：[https://doc.xiaominfo.com/demo/doc.html](https://doc.xiaominfo.com/demo/doc.html)
+更多接入、迁移和模块说明见仓库根目录 `README.md` 与 `docs-site/`。


### PR DESCRIPTION
## Summary

- Sync the root README and docs-site with the current stable `5.0.0` artifact version and Bun-based local workflow.
- Update docs-site feature, roadmap, module, and release-note wording to match the current React UI and smoke-test coverage.
- Replace stale module READMEs and internal runbook notes that still described upstream, Vite template, npm, parser-core, or the old smoke module count.
- Clarify upstream issue triage wording so historical issue lists are not presented as already-reproduced tasks or completed fixes.

## Why

The public docs and README had drifted from the repository state: examples still referenced `5.0.0-SNAPSHOT`, several local commands still used npm, smoke coverage was described as 4 modules instead of 5, and React UI capability tables still marked already-implemented OAuth2 and custom Markdown behavior as missing.

Some upstream issue references had also become too definitive. The OAS2 issue triage page now states that entries are historical triage notes and must be revalidated in the current repository before implementation. It also avoids mis-routing static-resource/MIME issues to an unrelated historical task.

## Validation

- `./scripts/test-docs.sh`
- `git diff --check`
- Residual stale-wording scan for old npm/SNAPSHOT/parser-core/smoke/module-count phrases
- Residual scan for stale upstream-triage phrases such as `待独立 PR`, `纳入 #198`, `生产环境响应格式（#859）`, and outdated React OAuth2 wording