### PR TITLE
[codex] Polish debug body controls and local docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,20 @@
 http://ip:port/doc.html
 ```
 
-## 本地开发
+## 本地启动
 
-### Java 主工程
+### Java Demo
 
 ```bash
 cd knife4j
-mvn -B -ntp verify
-# 或从仓库根目录运行 ./scripts/test-java.sh
+mvn -pl knife4j-demo-openapi3 -am spring-boot:run
+# 浏览器打开 http://localhost:8080/doc.html
+```
+
+```bash
+cd knife4j
+mvn -pl knife4j-demo-openapi2 -am spring-boot:run
+# 浏览器打开 http://localhost:8081/doc.html
 ```
 
 ### 文档站
@@ -112,12 +118,44 @@ bun install --frozen-lockfile
 bun run dev
 ```
 
-### React 前端实验工程
+### React 前端
 
 ```bash
 cd knife4j-front
 bun install --frozen-lockfile
 bun run --filter knife4j-ui-react dev
+```
+
+### Vue3 前端
+
+```bash
+cd knife4j-vue3
+bun install --frozen-lockfile
+bun run dev
+```
+
+## 本地测试
+
+### Java 主工程
+
+```bash
+./scripts/test-java.sh
+```
+
+该脚本会进入 `knife4j/`，执行 `spotless:check`、带测试的 Maven `verify`，并检查 smoke 测试证据。不要用单独的
+`mvn -B -ntp verify` 替代提交前验证。
+
+### 前端与文档
+
+```bash
+./scripts/test-front-core.sh
+./scripts/test-docs.sh
+```
+
+跨多个区域的改动可运行：
+
+```bash
+./scripts/test-all.sh
 ```
 
 ## 文档与链接

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -184,6 +184,7 @@ const enUS = {
 
   // ApiDebug — Body Tab
   'apiDebug.body.beautify': 'Beautify',
+  'apiDebug.body.beautifyFailed': 'Beautify failed. Check that the body is valid {{contentType}}.',
   'apiDebug.body.file': 'File',
   'apiDebug.body.selectFile': 'Select File',
   'apiDebug.body.file.placeholder': 'File path or leave empty to select file',

--- a/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
@@ -189,6 +189,7 @@ const jaJP = {
 
   // ApiDebug — Body Tab
   'apiDebug.body.beautify': '整形',
+  'apiDebug.body.beautifyFailed': '整形に失敗しました。{{contentType}} として有効な内容か確認してください。',
   'apiDebug.body.file': 'ファイル',
   'apiDebug.body.selectFile': 'ファイルを選択',
   'apiDebug.body.file.placeholder': 'ファイルパスを入力するか、空欄のままでファイル選択',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -184,6 +184,7 @@ const zhCN = {
 
   // ApiDebug — Body Tab
   'apiDebug.body.beautify': '格式化',
+  'apiDebug.body.beautifyFailed': '格式化失败，请检查内容是否为有效的 {{contentType}}。',
   'apiDebug.body.file': '文件',
   'apiDebug.body.selectFile': '选择文件',
   'apiDebug.body.file.placeholder': '文件路径或留空后选择文件',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -333,11 +333,11 @@ function initialFieldValue(field: SchemaFieldRow): string {
 // ─── Raw mode types ───────────────────────────────────
 
 const RAW_MODES = [
-  { value: 'text', label: 'Text' },
-  { value: 'json', label: 'JSON' },
-  { value: 'javascript', label: 'JavaScript' },
-  { value: 'xml', label: 'XML' },
-  { value: 'html', label: 'HTML' },
+  { value: 'text', label: 'Text(text/plain)' },
+  { value: 'json', label: 'JSON(application/json)' },
+  { value: 'javascript', label: 'JavaScript(application/javascript)' },
+  { value: 'xml', label: 'XML(application/xml)' },
+  { value: 'html', label: 'HTML(text/html)' },
 ] as const;
 
 type RawMode = (typeof RAW_MODES)[number]['value'];
@@ -350,6 +350,206 @@ const RAW_CONTENT_TYPES: Record<RawMode, string> = {
   xml: 'application/xml',
   html: 'text/html',
 };
+
+const HTML_VOID_TAGS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+function formatJsonBody(value: string): string | undefined {
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return undefined;
+  }
+}
+
+function formatTaggedBody(value: string, mode: 'xml' | 'html'): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+
+  if (mode === 'xml' && typeof DOMParser !== 'undefined') {
+    const doc = new DOMParser().parseFromString(trimmed, 'application/xml');
+    if (doc.getElementsByTagName('parsererror').length > 0) return undefined;
+  }
+
+  const tokens = trimmed
+    .replace(/>\s*</g, '><')
+    .replace(/</g, '\n<')
+    .replace(/>/g, '>\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  let indent = 0;
+  const lines: string[] = [];
+
+  for (const token of tokens) {
+    const isClosingTag = /^<\//.test(token);
+    const isDeclaration = /^<\?/.test(token) || /^<!/.test(token);
+    const tagMatch = token.match(/^<([A-Za-z][^\s/>]*)/);
+    const tagName = tagMatch?.[1].toLowerCase();
+    const isVoidTag = mode === 'html' && tagName !== undefined && HTML_VOID_TAGS.has(tagName);
+    const isSelfClosing = /\/>$/.test(token) || isVoidTag;
+    const isOpeningTag = /^<[^/!?][^>]*>$/.test(token) && !isSelfClosing;
+
+    if (isClosingTag) indent = Math.max(indent - 1, 0);
+    lines.push(`${'  '.repeat(indent)}${token}`);
+    if (isOpeningTag && !isDeclaration) indent += 1;
+  }
+
+  return lines.join('\n');
+}
+
+function formatJavaScriptBody(value: string): string | undefined {
+  const input = value.trim();
+  if (!input) return input;
+
+  let indent = 0;
+  let output = '';
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+  let invalid = false;
+
+  const appendIndent = () => {
+    output += '  '.repeat(indent);
+  };
+  const appendNewline = () => {
+    output = output.trimEnd();
+    output += '\n';
+    appendIndent();
+  };
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    const next = input[i + 1];
+
+    if (lineComment) {
+      output += char;
+      if (char === '\n') {
+        lineComment = false;
+        appendIndent();
+      }
+      continue;
+    }
+
+    if (blockComment) {
+      output += char;
+      if (char === '*' && next === '/') {
+        output += next;
+        i += 1;
+        blockComment = false;
+      }
+      continue;
+    }
+
+    if (quote) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      output = output.trimEnd();
+      output += output.endsWith('\n') ? '//' : ' //';
+      i += 1;
+      lineComment = true;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      output = output.trimEnd();
+      output += output.endsWith('\n') ? '/*' : ' /*';
+      i += 1;
+      blockComment = true;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      output += char;
+      continue;
+    }
+
+    if (char === '{') {
+      output = output.trimEnd();
+      output += ' {\n';
+      indent += 1;
+      appendIndent();
+      continue;
+    }
+
+    if (char === '}') {
+      output = output.trimEnd();
+      if (indent === 0) {
+        invalid = true;
+      } else {
+        indent -= 1;
+      }
+      output += `\n${'  '.repeat(indent)}}`;
+      if (next !== ';' && next !== ',' && next !== ')' && next !== undefined) {
+        appendNewline();
+      }
+      continue;
+    }
+
+    if (char === ';') {
+      output = output.trimEnd();
+      output += ';';
+      if (next !== undefined) appendNewline();
+      continue;
+    }
+
+    if (char === ',') {
+      output = output.trimEnd();
+      output += ', ';
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (output && !/\s$/.test(output)) output += ' ';
+      continue;
+    }
+
+    output += char;
+  }
+
+  if (invalid || quote || blockComment || indent !== 0) return undefined;
+
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line, index, lines) => line.trim() || index === lines.length - 1)
+    .join('\n')
+    .trim();
+}
+
+function formatBodyByRawMode(value: string, mode: RawMode): string | undefined {
+  if (mode === 'json') return formatJsonBody(value);
+  if (mode === 'xml' || mode === 'html') return formatTaggedBody(value, mode);
+  if (mode === 'javascript') return formatJavaScriptBody(value);
+  return undefined;
+}
 
 // ─── Custom headers section ───────────────────────────
 
@@ -721,17 +921,18 @@ function BodyTab({
       } else if (target.category === 'raw') {
         setBody(target.exampleValue ?? '');
       }
+      setRawMode(inferRawMode(target));
     }
   };
 
-  // ── JSON Beautify ──
+  // ── Body Beautify ──
   const handleBeautify = () => {
-    try {
-      const parsed = JSON.parse(body);
-      setBody(JSON.stringify(parsed, null, 2));
-    } catch {
-      // 无效 JSON，不处理
+    const formatted = formatBodyByRawMode(body, rawMode);
+    if (formatted !== undefined) {
+      setBody(formatted);
+      return;
     }
+    message.warning(t('apiDebug.body.beautifyFailed', { contentType: RAW_CONTENT_TYPES[rawMode] }));
   };
 
   return (
@@ -761,19 +962,13 @@ function BodyTab({
 
       {/* 根据分类渲染不同的表单 */}
       {category === 'json' && (
-        <div>
-          <div style={{ marginBottom: 4, textAlign: 'right' }}>
-            <Button size="small" onClick={handleBeautify}>
-              {t('apiDebug.body.beautify')}
-            </Button>
-          </div>
-          <CodeEditor
-            value={body}
-            onChange={setBody}
-            language={selectedContentType.includes('xml') ? 'xml' : 'json'}
-            placeholderText={`${currentBody.mediaType} request body`}
-          />
-        </div>
+        <RawEditor
+          body={body}
+          setBody={setBody}
+          rawMode={rawMode}
+          setRawMode={setRawMode}
+          onBeautify={handleBeautify}
+        />
       )}
 
       {category === 'urlencoded' && (
@@ -1045,6 +1240,7 @@ const RAW_MODE_LANGUAGE: Record<RawMode, CodeEditorLanguage> = {
 function RawEditor({ body, setBody, rawMode, setRawMode, onBeautify }: RawEditorProps) {
   const { t } = useTranslation();
   const useCodeEditor = rawMode === 'json' || rawMode === 'xml';
+  const canBeautify = rawMode !== 'text';
 
   return (
     <div>
@@ -1052,28 +1248,26 @@ function RawEditor({ body, setBody, rawMode, setRawMode, onBeautify }: RawEditor
         style={{
           marginBottom: 8,
           display: 'flex',
-          justifyContent: 'space-between',
           alignItems: 'center',
         }}
       >
-        <Radio.Group
-          value={rawMode}
-          onChange={(e) => setRawMode(e.target.value)}
-          size="small"
-          optionType="button"
-          buttonStyle="solid"
-        >
-          {RAW_MODES.map((m) => (
-            <Radio.Button key={m.value} value={m.value}>
-              {m.label}
-            </Radio.Button>
-          ))}
-        </Radio.Group>
-        {rawMode === 'json' && (
-          <Button size="small" onClick={onBeautify}>
-            {t('apiDebug.body.beautify')}
-          </Button>
-        )}
+        <Space size={8} wrap>
+          <Select
+            size="small"
+            value={rawMode}
+            onChange={(value) => setRawMode(value as RawMode)}
+            options={RAW_MODES.map((m) => ({
+              value: m.value,
+              label: m.label,
+            }))}
+            style={{ minWidth: 240 }}
+          />
+          {canBeautify && (
+            <Button size="small" type="primary" onClick={onBeautify}>
+              {t('apiDebug.body.beautify')}
+            </Button>
+          )}
+        </Space>
       </div>
       {useCodeEditor ? (
         <CodeEditor
@@ -1291,6 +1485,7 @@ interface InitialDebugState {
 }
 
 function inferRawMode(bodyContent: BodyContent | undefined): RawMode {
+  if (bodyContent?.category === 'json') return 'json';
   if (bodyContent?.category !== 'raw') return 'text';
   const mediaType = bodyContent.mediaType;
   if (mediaType.includes('json')) return 'json';
@@ -1655,9 +1850,17 @@ export default function ApiDebug() {
 
   /** 获取最终 effective content-type */
   const getEffectiveContentType = (): string => {
+    const category = getCurrentCategory();
+    const currentBody = debugModel.bodyContents.find((b) => b.mediaType === selectedContentType);
+    if (category === 'json') {
+      return rawMode === 'json' ? selectedContentType || RAW_CONTENT_TYPES.json : RAW_CONTENT_TYPES[rawMode];
+    }
+    if (category === 'raw') {
+      const inferredMode = inferRawMode(currentBody);
+      if (rawMode === inferredMode && selectedContentType) return selectedContentType;
+      return RAW_CONTENT_TYPES[rawMode];
+    }
     if (selectedContentType) return selectedContentType;
-    // raw mode fallback
-    if (getCurrentCategory() === 'raw') return RAW_CONTENT_TYPES[rawMode];
     return debugModel.bodyContents[0]?.mediaType ?? '';
   };
 
@@ -1956,7 +2159,7 @@ export default function ApiDebug() {
   // body tab 的标签含当前 content-type
   const bodyLabel =
     debugModel.bodyContents.length > 0
-      ? `${t('apiDebug.tab.body')} (${selectedContentType || debugModel.bodyContents[0].mediaType})`
+      ? `${t('apiDebug.tab.body')} (${getEffectiveContentType()})`
       : t('apiDebug.tab.body');
 
   const tabItems = [

--- a/knife4j-vue3/src/App.vue
+++ b/knife4j-vue3/src/App.vue
@@ -29,6 +29,14 @@ const loadingTip = computed(() => {
     '微软雅黑', Arial, sans-serif;
 }
 
+/* Ace relies on monospace metrics to keep cursor and text positions aligned. */
+.ace_editor,
+.ace_editor * {
+  font-family: Monaco, Menlo, Consolas, 'Liberation Mono', monospace !important;
+  font-variant-ligatures: none;
+  letter-spacing: 0 !important;
+}
+
 /* 滚动条优化 */
 body {
   overflow-y: scroll;

--- a/knife4j-vue3/src/style/knife4j.less
+++ b/knife4j-vue3/src/style/knife4j.less
@@ -640,37 +640,74 @@
 .knife4j-debug-request-type {
   margin-top: 0;
   display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: nowrap;
+  min-height: 35px;
 }
 
 .knife4j-debug-request-content-type {
-  width: 360px;
+  display: flex;
+  align-items: center;
+  width: auto;
   height: 35px;
-  line-height: 35px;
+  line-height: normal;
+  white-space: nowrap;
+
+  .ant-radio-wrapper {
+    display: inline-flex;
+    align-items: center;
+    height: 24px;
+    line-height: 22px;
+    white-space: nowrap;
+  }
+
+  .ant-radio {
+    display: inline-flex;
+    align-items: center;
+    top: 0;
+  }
+
+  .ant-radio + span {
+    line-height: 22px;
+  }
 }
 
 .knife4j-debug-request-content-type-float {
-  float: left;
-  width: 360px;
-}
-
-
-.knife4j-debug-request-content-type-raw {
-  //width: 360px;
-  //height: 35px;
-  //line-height: 35px;
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
 }
 
 .knife4j-debug-request-content-type-beautify {
-  //float: right;
-  margin-right: 50px;
-  flex: 1;
-  text-align: right;
-  //height: 35px;
-  //line-height: 35px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
 }
 
 .knife4j-debug-raw-span {
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: auto;
+  line-height: 22px;
+  vertical-align: baseline;
+
+  .anticon {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+  }
+}
+
+.knife4j-debug-raw-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  line-height: 22px;
+  vertical-align: baseline;
 }
 
 
@@ -697,6 +734,8 @@
 
 .knife4j-debug-status {
   margin-right: 15px;
+  padding-right: 8px;
+  box-sizing: border-box;
 
   .key {
     color: #919191;
@@ -707,6 +746,10 @@
     color: #4dc095;
     font-size: 12px;
     font-weight: bold;
+  }
+
+  .value:last-child {
+    margin-right: 8px;
   }
 }
 

--- a/knife4j-vue3/src/views/api/Debug.vue
+++ b/knife4j-vue3/src/views/api/Debug.vue
@@ -82,17 +82,15 @@
                     v-model:value="requestContentType">
                     <a-radio value="x-www-form-urlencoded">x-www-form-urlencoded</a-radio>
                     <a-radio value="form-data">form-data</a-radio>
-                    <a-radio value="raw">raw</a-radio>
-                  </a-radio-group>
-                </div>
-                <div class="knife4j-debug-request-content-type-float">
-                  <div class="knife4j-debug-request-content-type-raw">
-                    <a-dropdown v-if="rawTypeFlag">
-                      <span class="knife4j-debug-raw-span">
-                        <span>{{ rawDefaultText }}</span>
-                        <DownOutlined />
-                      </span>
-                      <template  #overlay>
+                    <a-radio value="raw">
+                      <span class="knife4j-debug-raw-inline">
+                        <span>raw</span>
+                        <a-dropdown v-if="rawTypeFlag">
+                          <span class="knife4j-debug-raw-span">
+                            <span>{{ rawDefaultText }}</span>
+                            <DownOutlined />
+                          </span>
+                          <template  #overlay>
                         <a-menu @click="rawMenuClick">
                           <a-menu-item data-mode-type="application/json" data-mode="text" key="Auto">Auto</a-menu-item>
                           <a-menu-item data-mode-type="text/plain" data-mode="text" key="Text(text/plain)">
@@ -110,11 +108,13 @@
                         </a-menu>
                       </template>
 
-                    </a-dropdown>
-                  </div>
-                </div>
-                <div v-if="formatFlag" class="knife4j-debug-request-content-type-beautify">
-                  <a @click="beautifyJson">Beautify</a>
+                        </a-dropdown>
+                        <span v-if="formatFlag" class="knife4j-debug-request-content-type-beautify" @click.stop>
+                          <a-button size="small" type="primary" @click="beautifyJson">格式化</a-button>
+                        </span>
+                      </span>
+                    </a-radio>
+                  </a-radio-group>
                 </div>
               </div>
               <a-row v-if="formFlag">

--- a/knife4j-vue3/src/views/api/EditorDebugShow.vue
+++ b/knife4j-vue3/src/views/api/EditorDebugShow.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
     <div v-if="debugResponse">
-      <editor class="knife4j-debug-ace-editor" @input="change" :options="debugOptions" v-model:value="valueText" @init="editorInit"
+      <editor class="knife4j-debug-ace-editor" :options="debugOptions" :value="valueText" @update:value="change" @init="editorInit"
         :lang="mode" theme="eclipse" width="100%" :style="{height: editorHeight + 'px'}"></editor>
     </div>
     <div v-else>
-      <editor v-model:value="valueText" @init="editorInit" @input="change" :lang="mode" theme="eclipse" width="100%"
+      <editor :value="valueText" @init="editorInit" @update:value="change" :lang="mode" theme="eclipse" width="100%"
         :style="{height: editorHeight + 'px'}"></editor>
     </div>
 
@@ -93,12 +93,15 @@ export default {
         }
         // console.log(rows_editor)
         that.editorHeight = rows_editor;
+        that.$nextTick(() => {
+          that.editor.resize();
+        });
       }, 10);
     },
-    change() {
-      // this.value = value;
+    change(value) {
+      this.valueText = value;
       // 重设高度
-      this.$emit("update:value", this.valueText);
+      this.$emit("update:value", value);
       if (!this.debugResponse) {
         this.resetEditorHeight();
       }

--- a/knife4j/README.md
+++ b/knife4j/README.md
@@ -38,19 +38,24 @@
 | `knife4j-demo-openapi3` | OpenAPI3 demo |
 | `knife4j-smoke-tests` | 兼容性 smoke 测试集合 |
 
-## 本地验证
+## 本地启动
 
-从仓库根目录运行：
+以下命令从仓库根目录运行。
 
-```bash
-./scripts/test-java.sh
-```
-
-也可以只验证 Java 主工程：
+OpenAPI3 demo：
 
 ```bash
 cd knife4j
-mvn -B -ntp verify
+mvn -pl knife4j-demo-openapi3 -am spring-boot:run
+# 浏览器打开 http://localhost:8080/doc.html
+```
+
+OpenAPI2 demo：
+
+```bash
+cd knife4j
+mvn -pl knife4j-demo-openapi2 -am spring-boot:run
+# 浏览器打开 http://localhost:8081/doc.html
 ```
 
 默认访问入口保持为：
@@ -58,5 +63,23 @@ mvn -B -ntp verify
 ```text
 http://ip:port/doc.html
 ```
+
+## 本地测试
+
+从仓库根目录运行：
+
+```bash
+./scripts/test-java.sh
+```
+
+如需手动复现脚本中的 Maven 步骤：
+
+```bash
+cd knife4j
+mvn -B -ntp spotless:check
+mvn -B -ntp -Dknife4j-skipTests=false verify
+```
+
+提交前仍以根目录 `./scripts/test-java.sh` 为准；它还会在 Maven 构建后检查 smoke 测试证据。
 
 更多接入、迁移和模块说明见仓库根目录 `README.md` 与 `docs-site/`。


### PR DESCRIPTION
## Summary

- Split local README guidance into startup vs. test flows and document the current Java/Bun commands.
- Fix Vue3 debug body editing and layout issues, including Ace cursor alignment, raw content-type placement, response status spacing, and the nearby 格式化 action.
- Update the React debug body editor so JSON/raw bodies can choose Text, JSON, JavaScript, XML, or HTML content types, format supported structured bodies, preserve body content on format failure, and show localized friendly errors.

## Why

The local development docs mixed startup and verification commands, and the Vue/React body editors exposed inconsistent raw body controls. The debug UI now keeps the formatting action next to the selected body type and lets users override the request body content type while still defaulting to the OpenAPI-declared media type.

## Validation

- `cd knife4j-vue3 && bun run build`
- `cd knife4j-front && bun run --filter knife4j-ui-react build`
- `git diff --check`

Both frontend builds pass. Existing Vite warnings remain around eval/dynamic imports/chunk size.