### PR TITLE
持久化中文协作规范

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@
 - 不要让关键上下文只存在于聊天记录中，写回 issue comment 或 `.agent/`。
 - **不再修改** `.agent/TASKS.md` 和 `.agent/PROGRESS.md`。
 
+## 语言规范
+
+- 提交信息、议题标题、议题正文、议题评论、拉取请求标题、拉取请求描述和拉取请求评论统一使用中文。
+- 避免中英混杂；只有代码标识、命令、路径、分支名、label、依赖名、API 名称等必须原样表达的内容保留原文。
+- 面向维护者的工作摘要、验证说明和风险说明也使用中文。
+
 ## 默认循环
 
 1. 读取 `.agent/` 状态和 GitHub Issues（`gh issue list --label agent-task --label status:ready`）。


### PR DESCRIPTION
## 关联议题

无，按维护者要求直接持久化仓库协作规范。

## 变更内容

- 在 `AGENTS.md` 新增「语言规范」小节。
- 明确提交信息、议题标题、议题正文、议题评论、拉取请求标题、拉取请求描述和拉取请求评论统一使用中文。
- 说明代码标识、命令、路径、分支名、label、依赖名、API 名称等必须原样表达的内容保留原文。

## 验证

- 未运行构建或测试；本次仅修改仓库协作说明。
- 已核对提交内容只包含 `AGENTS.md` 的 6 行新增。

## 风险

- 无已知运行时风险。