### PR TITLE
java(BOM): add knife4j-openapi3-boot4-spring-boot-starter to dependencyManagement

### DIFF
--- a/knife4j/knife4j-dependencies/pom.xml
+++ b/knife4j/knife4j-dependencies/pom.xml
@@ -93,13 +93,18 @@
                 <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.baizhukui</groupId>
+                <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.baizhukui</groupId>
                 <artifactId>knife4j-aggregation-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.baizhukui</groupId>
                 <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>


### PR DESCRIPTION
## Summary

Follow-up to #359, addressing the [Codex/ChatGPT review comment](https://github.com/songxychn/knife4j-next/pull/359#discussion_r3220213638) (P2):

> The new `knife4j-openapi3-boot4-spring-boot-starter` module is introduced, but this commit does not add it to `knife4j-dependencies`'s `dependencyManagement` list (where all other starters are managed). Projects that import the BOM and follow the existing no-version pattern for starters will fail to resolve this new artifact unless they manually pin a version, which makes the new Boot 4 path inconsistent and harder to adopt.

This PR registers the Boot 4 starter in the BOM so downstream users importing `knife4j-dependencies` can declare the artifact without pinning a version, matching the existing pattern used for every other knife4j starter.

## Changes

- `knife4j/knife4j-dependencies/pom.xml`: add `knife4j-openapi3-boot4-spring-boot-starter` to `dependencyManagement`, placed next to `knife4j-openapi3-jakarta-spring-boot-starter` to keep the OpenAPI 3 grouping coherent.

## Validation

```
mvn -B -ntp -pl knife4j-dependencies validate
mvn -B -ntp -pl knife4j-dependencies help:effective-pom -Doutput=/tmp/bom-effective.xml
grep -A2 'knife4j-openapi3-boot4-spring-boot-starter' /tmp/bom-effective.xml
```

Effective POM confirms the new entry is resolved at `${project.version}` (5.0.1).

## Notes

- No behavior change for existing modules; pure BOM hygiene.
- Boot 4 starter `artifactId` confirmed against `knife4j/knife4j-openapi3-boot4-spring-boot-starter/pom.xml`.

Closes #361

