### PR TITLE
fix(ui-react): resolve API debug base URL from OpenAPI servers (#356)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -51,6 +51,7 @@ import { useSettings } from '../../context/SettingsContext';
 import ResponsePanel, { type DebugResponsePayload, type SseEvent } from './ResponsePanel';
 import Authorize from '../Authorize';
 import { COMMON_HEADER_NAMES } from '../../constants/httpHeaders';
+import { currentOrigin, resolveRequestBaseUrl } from './requestBaseUrl';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
@@ -71,10 +72,6 @@ type ParamValueMap = Record<string, string>;
 
 function paramKey(param: DebugParam): string {
   return `${param.in}:${param.name}`;
-}
-
-function currentOrigin(): string {
-  return typeof window === 'undefined' ? 'http://localhost:8080' : window.location.origin;
 }
 
 // ─── Response body classification ─────────────────────
@@ -1543,8 +1540,14 @@ export default function ApiDebug() {
   const { loading: docLoading, swaggerDoc, operation } = useCurrentOperation();
   const { settings } = useSettings();
   const defaultBaseUrl = useMemo(
-    () => (settings.enableHost && settings.enableHostText.trim() ? settings.enableHostText.trim() : currentOrigin()),
-    [settings.enableHost, settings.enableHostText],
+    () =>
+      resolveRequestBaseUrl({
+        swaggerDoc,
+        enableHost: settings.enableHost,
+        enableHostText: settings.enableHostText,
+        origin: currentOrigin(),
+      }),
+    [settings.enableHost, settings.enableHostText, swaggerDoc],
   );
   const [baseUrl, setBaseUrl] = useState(defaultBaseUrl);
   const [method, setMethod] = useState('GET');

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { SwaggerDoc } from '../../types/swagger';
+import { normalizeRequestBaseUrl, resolveRequestBaseUrl } from './requestBaseUrl';
+
+function docWithServers(urls: string[]): SwaggerDoc {
+  return {
+    openapi: '3.0.1',
+    info: { title: 'test', version: '1.0.0' },
+    paths: {},
+    servers: urls.map((url) => ({ url })),
+  };
+}
+
+describe('request base URL resolution', () => {
+  it('uses the first OpenAPI server URL including context path', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://127.0.0.1:18000/api']),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://127.0.0.1:18000/api');
+  });
+
+  it('resolves relative server URLs from the UI origin root', () => {
+    expect(normalizeRequestBaseUrl('/api/', 'http://127.0.0.1:18000')).toBe('http://127.0.0.1:18000/api');
+    expect(normalizeRequestBaseUrl('api', 'http://127.0.0.1:18000')).toBe('http://127.0.0.1:18000/api');
+  });
+
+  it('keeps the explicit host override ahead of OpenAPI servers', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://127.0.0.1:18000/api']),
+        enableHost: true,
+        enableHostText: 'http://gateway.example.test/root/',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://gateway.example.test/root');
+  });
+
+  it('falls back to the UI origin when no override or server is available', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers([]),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://127.0.0.1:3002');
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
@@ -1,0 +1,46 @@
+import type { SwaggerDoc } from '../../types/swagger';
+
+export interface ResolveRequestBaseUrlOptions {
+  swaggerDoc: SwaggerDoc | null;
+  enableHost: boolean;
+  enableHostText: string;
+  origin: string;
+}
+
+export function currentOrigin(): string {
+  return typeof window === 'undefined' ? 'http://localhost:8080' : window.location.origin;
+}
+
+function trimTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export function normalizeRequestBaseUrl(url: string, origin: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) return trimTrailingSlashes(origin);
+
+  try {
+    return trimTrailingSlashes(new URL(trimmed, `${origin.replace(/\/+$/, '')}/`).toString());
+  } catch {
+    return trimTrailingSlashes(trimmed);
+  }
+}
+
+export function resolveRequestBaseUrl({
+  swaggerDoc,
+  enableHost,
+  enableHostText,
+  origin,
+}: ResolveRequestBaseUrlOptions): string {
+  const hostOverride = enableHost ? enableHostText.trim() : '';
+  if (hostOverride) {
+    return normalizeRequestBaseUrl(hostOverride, origin);
+  }
+
+  const serverUrl = swaggerDoc?.servers?.find((server) => server.url.trim())?.url;
+  if (serverUrl) {
+    return normalizeRequestBaseUrl(serverUrl, origin);
+  }
+
+  return normalizeRequestBaseUrl(origin, origin);
+}


### PR DESCRIPTION
## 关联 Issue

Closes #356

## 问题描述

在 `knife4j-openapi3-jakarta-spring-boot-starter` 下，当后端配置了 `server.servlet.context-path: /api` 时，API 调试面板请求接口出现 404。

后端 `/v3/api-docs` 返回的 OpenAPI 文档中 `servers[].url` 已经正确包含了 context-path（例如 `http://127.0.0.1:18000/api`），但前端调试面板将 base URL 直接取自 `window.location.origin`，丢失了 context-path 前缀，导致请求被发送到 `http://127.0.0.1:18000/{path}` 而非 `http://127.0.0.1:18000/api/{path}`，从而 404。

## 修改内容

在 `knife4j-front/knife4j-ui-react` 中将「调试请求 base URL」的解析抽取为独立的工具函数 `resolveRequestBaseUrl`，按以下优先级解析：

1. 用户在 Settings 中显式配置的 `enableHostText`（启用 host 覆盖时）。
2. OpenAPI 文档中第一个非空的 `servers[].url`（支持相对/绝对 URL，相对 URL 会基于当前 origin 解析）。
3. 回退到 `window.location.origin`。

这样当后端通过 context-path 暴露接口时，UI 会自动跟随 OpenAPI 文档中声明的 server URL 发起请求，调试请求不再 404。

## 涉及文件

- `knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx`：使用新的 `resolveRequestBaseUrl`。
- `knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts`：新增解析逻辑。
- `knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts`：覆盖 4 个核心场景的单元测试。

## 验证方式

- 单测：`requestBaseUrl.test.ts` 覆盖
  - 使用首个 `servers[].url`（含 context-path）；
  - 相对 server URL 基于 origin 规范化；
  - 显式 host 覆盖优先于 servers；
  - 无 server 且无覆盖时回退 origin。
- 手动：在 `knife4j-openapi3-jakarta-spring-boot-starter` 下设置 `server.servlet.context-path=/api`，打开调试页面发起请求，验证请求 URL 含 `/api` 前缀且不再 404。

## 风险与回滚

- 改动仅限于 `knife4j-ui-react` 调试面板的 base URL 解析；
- 旧行为（无 servers 时使用 origin、显式覆盖优先）保持不变；
- 出问题可直接 revert 单一 commit `9da8a60`。

