### PR TITLE
fix(front-core): 处理 PR #352 的 ChatGPT review 反馈（cookie 头大小写不敏感合并）

### DIFF
--- a/knife4j-front/knife4j-core/src/__tests__/debug/requestBuilder.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/requestBuilder.test.ts
@@ -157,6 +157,20 @@ describe('authToHeaders', () => {
     expect(result.headers['Cookie']).toContain('token=xyz');
   });
 
+  test('apiKey in cookie merges into existing lowercase cookie header (case-insensitive)', () => {
+    // Simulates a caller that already injected a lowercase `cookie` key into
+    // `apiKeys`; the cookie-position scheme below should append into the same
+    // header instead of producing a duplicate `Cookie` entry.
+    const result = authToHeaders({
+      apiKeys: { cookie: 'pre=set' },
+      bySecurityKey: {
+        apiCookie: { type: 'apiKey', in: 'cookie', name: 'session', value: 'abc123' },
+      },
+    });
+    expect(result.headers['cookie']).toBe('pre=set; session=abc123');
+    expect(result.headers['Cookie']).toBeUndefined();
+  });
+
   test('http bearer via bySecurityKey', () => {
     const result = authToHeaders({
       bySecurityKey: {
@@ -492,6 +506,26 @@ describe('buildRequest', () => {
     });
 
     expect(result.headers['Cookie']).toBe('theme=dark; session=abc123; trace=req-1');
+  });
+
+  test('cookie params merge into existing lowercase cookie header (case-insensitive)', () => {
+    // 某些调用方（如全局参数或 fetch 原始 headers）会以小写 `cookie` 名义提供。
+    // appendCookieParams 应识别并合并到同一个 header，而不是另外输出大写 `Cookie`。
+    const result = buildRequest({
+      baseUrl: 'http://localhost:8080',
+      path: '/users/{id}',
+      method: 'GET',
+      debugModel,
+      formValues: {
+        pathParams: { id: '1' },
+        queryParams: {},
+        headerParams: { cookie: 'theme=dark' },
+        cookieParams: { session: 'abc123' },
+      },
+    });
+
+    expect(result.headers['cookie']).toBe('theme=dark; session=abc123');
+    expect(result.headers['Cookie']).toBeUndefined();
   });
 
   test('Content-Type header is set from selectedContentType', () => {

--- a/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
+++ b/knife4j-front/knife4j-core/src/debug/requestBuilder.ts
@@ -58,6 +58,21 @@ export function mergeHeaders(...sources: Array<Record<string, string> | undefine
   return result;
 }
 
+/**
+ * 在 headers 中查找已有的 Cookie 头（大小写不敏感）。
+ *
+ * HTTP header 名按 RFC 7230 是大小写不敏感的，调用方可能传入 `cookie` /
+ * `Cookie` / `COOKIE` 任一形式。返回命中的原 key（保持调用方的大小写），
+ * 找不到时返回 undefined。
+ */
+function findCookieHeaderKey(headers: Record<string, string>): string | undefined {
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === 'cookie') return key;
+  }
+  return undefined;
+}
+
+/** 将 cookie params 追加到 headers 的 Cookie 头，大小写不敏感地合并。 */
 function appendCookieParams(
   headers: Record<string, string>,
   cookieParams: Record<string, string>,
@@ -66,9 +81,16 @@ function appendCookieParams(
     .filter(([name, value]) => name !== '' && value !== '')
     .map(([name, value]) => `${name}=${value}`);
   if (pairs.length === 0) return headers;
+  const existingKey = findCookieHeaderKey(headers);
+  if (existingKey) {
+    return {
+      ...headers,
+      [existingKey]: `${headers[existingKey]}; ${pairs.join('; ')}`,
+    };
+  }
   return {
     ...headers,
-    Cookie: headers['Cookie'] ? `${headers['Cookie']}; ${pairs.join('; ')}` : pairs.join('; '),
+    Cookie: pairs.join('; '),
   };
 }
 
@@ -120,7 +142,12 @@ export function authToHeaders(
           queries[scheme.name] = scheme.value;
         } else if (scheme.in === 'cookie') {
           const pair = `${scheme.name}=${scheme.value}`;
-          headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${pair}` : pair;
+          const existingKey = findCookieHeaderKey(headers);
+          if (existingKey) {
+            headers[existingKey] = `${headers[existingKey]}; ${pair}`;
+          } else {
+            headers['Cookie'] = pair;
+          }
         }
       } else if (scheme.type === 'http' && scheme.scheme === 'bearer') {
         if (scheme.token) {


### PR DESCRIPTION
## 背景

PR #352（`Polish Vue and React API docs UI`）合并后，`chatgpt-codex-connector[bot]` 留下一条 P2 review 评论尚未处理：

> **Normalize existing Cookie header before appending cookie params**
>
> `appendCookieParams` only checks `headers['Cookie']`, so if a caller already supplied a lowercase `cookie` header (for example via global/custom headers), this code emits both `cookie` and `Cookie` keys instead of merging them.

按 RFC 7230，HTTP header 名是大小写不敏感的，但当前实现会在 `headers` 同时存在小写 `cookie` 与新拼接的 `Cookie` 两个 key，输出到 cURL 会得到重复 header，且经客户端归一化后 cookie 优先级与用户配置不一致。

## 改动

`knife4j-front/knife4j-core/src/debug/requestBuilder.ts`：

- 新增内部 helper `findCookieHeaderKey`，按 `key.toLowerCase() === 'cookie'` 大小写不敏感地查找已有 cookie 头。
- `appendCookieParams` 改用 helper：命中已有 key 时复用其大小写做合并；未命中时才新建大写 `Cookie` 头。
- `authToHeaders` 中 `apiKey in cookie` 分支同步切到新的合并逻辑，避免 legacy `apiKeys.cookie` 与 bySecurityKey 同时存在时产生重复 header。

测试 `knife4j-front/knife4j-core/src/__tests__/debug/requestBuilder.test.ts`：

- 新增 `apiKey in cookie merges into existing lowercase cookie header (case-insensitive)`
- 新增 `cookie params merge into existing lowercase cookie header (case-insensitive)`

## 验证

```
bash scripts/test-front-core.sh
```

- knife4j-core test：185/185 通过（含 2 条新增 case）
- knife4j-ui-react test：17/17 通过
- lint / format / build：全部通过

## 风险

仅 `knife4j-front/knife4j-core` 的 cookie 合并逻辑改动，对其他模块无影响。原大写 `Cookie` 行为保持向后兼容（无 lowercase header 时仍输出 `Cookie`）。

