### PR TITLE
fix(ui-react): Schema 守卫优先使用 route group (#366)

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -40,19 +40,28 @@ function schemasToModels(schemas: Record<string, SchemaObject>, swaggerDoc: Swag
 
 export default function Schema() {
   const { t } = useTranslation();
-  const { schemaName } = useParams<{ schemaName?: string }>();
+  const { group: routeGroup, schemaName } = useParams<{ group?: string; schemaName?: string }>();
   const { schemas, swaggerDoc, loading, activeGroup } = useGroup();
   const { settings } = useSettings();
   const navigate = useNavigate();
   const selectedSchemaName = schemaName ? decodeURIComponent(schemaName) : undefined;
   const [searchText, setSearchText] = useState('');
 
-  // Route guard: when enableSwaggerModels=false, redirect to home
+  // Route guard: when enableSwaggerModels=false, redirect away from schema page.
+  // Prefer the route's :group param (always present on /:group/schema), then fall
+  // back to a loaded activeGroup. If neither yields a non-empty group (e.g. a hard
+  // refresh while groups are still loading and activeGroup falls back to
+  // EMPTY_GROUP with value=''), navigate to '/' so the index <Home /> route can
+  // take over instead of constructing an invalid '//home' URL.
   useEffect(() => {
-    if (settings.enableSwaggerModels === false) {
-      navigate(`/${activeGroup.value}/home`, { replace: true });
+    if (settings.enableSwaggerModels !== false) return;
+    const targetGroup = routeGroup ?? (activeGroup.value || '');
+    if (targetGroup) {
+      navigate(`/${targetGroup}/home`, { replace: true });
+    } else {
+      navigate('/', { replace: true });
     }
-  }, [settings.enableSwaggerModels, activeGroup.value, navigate]);
+  }, [settings.enableSwaggerModels, routeGroup, activeGroup.value, navigate]);
 
   const models: ModelDef[] = useMemo(() => {
     if (loading || !swaggerDoc || settings.enableSwaggerModels === false) return [];


### PR DESCRIPTION
## 关联 Issue

Closes #366
关联 PR #364（chatgpt-codex-connector 的 P1 review 反馈）

## 变更内容

- `knife4j-front/knife4j-ui-react/src/pages/Schema.tsx` 中 `enableSwaggerModels=false` 的路由守卫不再依赖 `activeGroup.value`：
  - 优先使用 `useParams` 中的 `:group` 路由参数；
  - 当路由参数缺失时回退到已加载的 `activeGroup.value`；
  - 两者都为空（例如硬刷新阶段 `activeGroup` 仍是 `EMPTY_GROUP`，`value === ''`）时，跳到根路径 `/`，由 router 的 index `<Home />` 兜底，而不是构造非法的 `//home` URL。

## 验证

- `bash scripts/test-front-core.sh`：`knife4j-core` 与 `knife4j-ui-react` 的 `format:check` / `test` / `lint` / `build` 全部通过。
- 路径推断：用户访问 `/:group/schema`（含 `/:group/schema/:schemaName`）时 `useParams().group` 必为非空字符串，关闭 `enableSwaggerModels` 即跳转到 `/:group/home`，行为与原实现一致；只有在路由不带 group 的极端情况下（实际不会命中 Schema 路由，仅作防御）才会跳到 `/`。

## 风险

- 仅前端 React UI 改动；不影响 Java、Vue UI、聚合 starter。
- 不改变非 disabled 状态下的页面行为。

## 是否需要人工决策

- 否。

