### PR TITLE
修复 5.0.2 Boot4 starter 发布清单

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify release module list
+        run: scripts/verify-release-modules.sh
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify release module list
+        run: scripts/verify-release-modules.sh
+        working-directory: .
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -56,10 +60,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
+          release_modules="$(sed -E 's/[[:space:]]*#.*$//' ../scripts/release-modules.txt | sed '/^[[:space:]]*$/d' | paste -sd, -)"
           mvn -B -ntp -Prelease deploy \
-            -pl knife4j-core,knife4j-dependencies,knife4j-openapi2-ui,knife4j-openapi3-ui,\
-          knife4j-openapi2-spring-boot-starter,knife4j-openapi3-spring-boot-starter,\
-          knife4j-aggregation-spring-boot-starter,knife4j-aggregation-jakarta-spring-boot-starter,\
-          knife4j-openapi3-jakarta-spring-boot-starter,knife4j-gateway-spring-boot-starter,\
-          knife4j-openapi3-webflux-spring-boot-starter,knife4j-openapi3-webflux-jakarta-spring-boot-starter \
+            -pl "$release_modules" \
             -am

--- a/scripts/release-modules.txt
+++ b/scripts/release-modules.txt
@@ -1,0 +1,13 @@
+knife4j-core
+knife4j-dependencies
+knife4j-openapi2-ui
+knife4j-openapi3-ui
+knife4j-openapi2-spring-boot-starter
+knife4j-openapi3-spring-boot-starter
+knife4j-aggregation-spring-boot-starter
+knife4j-aggregation-jakarta-spring-boot-starter
+knife4j-openapi3-jakarta-spring-boot-starter
+knife4j-openapi3-boot4-spring-boot-starter
+knife4j-gateway-spring-boot-starter
+knife4j-openapi3-webflux-spring-boot-starter
+knife4j-openapi3-webflux-jakarta-spring-boot-starter

--- a/scripts/verify-release-modules.sh
+++ b/scripts/verify-release-modules.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+modules_file="$repo_root/scripts/release-modules.txt"
+parent_pom="$repo_root/knife4j/pom.xml"
+bom_pom="$repo_root/knife4j/knife4j-dependencies/pom.xml"
+
+release_modules=()
+while IFS= read -r line; do
+  line="${line%%#*}"
+  line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  if [ -n "$line" ]; then
+    release_modules+=("$line")
+  fi
+done < "$modules_file"
+
+if [ "${#release_modules[@]}" -eq 0 ]; then
+  echo "::error::release module list is empty: $modules_file"
+  exit 1
+fi
+
+status=0
+
+duplicates="$(printf '%s\n' "${release_modules[@]}" | sort | uniq -d)"
+if [ -n "$duplicates" ]; then
+  echo "::error::duplicate release modules:"
+  printf '%s\n' "$duplicates"
+  status=1
+fi
+
+for module in "${release_modules[@]}"; do
+  if [ ! -d "$repo_root/knife4j/$module" ]; then
+    echo "::error::release module directory is missing: knife4j/$module"
+    status=1
+  fi
+  if ! grep -Fq "<module>$module</module>" "$parent_pom"; then
+    echo "::error::release module is not listed in knife4j/pom.xml: $module"
+    status=1
+  fi
+done
+
+bom_artifacts="$(
+  awk '
+    /<dependencyManagement>/ { in_dm = 1; next }
+    /<\/dependencyManagement>/ { in_dm = 0 }
+    in_dm && /<dependency>/ { in_dep = 1; group = ""; artifact = "" }
+    in_dep && /<groupId>com\.baizhukui<\/groupId>/ { group = "com.baizhukui" }
+    in_dep && /<artifactId>/ {
+      line = $0
+      sub(/.*<artifactId>/, "", line)
+      sub(/<\/artifactId>.*/, "", line)
+      artifact = line
+    }
+    in_dep && /<\/dependency>/ {
+      if (group == "com.baizhukui" && artifact ~ /^knife4j-/) print artifact
+      in_dep = 0
+    }
+  ' "$bom_pom" | sort -u
+)"
+
+for artifact in $bom_artifacts; do
+  if ! printf '%s\n' "${release_modules[@]}" | grep -Fxq "$artifact"; then
+    echo "::error::BOM artifact is missing from scripts/release-modules.txt: $artifact"
+    status=1
+  fi
+done
+
+for module in "${release_modules[@]}"; do
+  if [ "$module" = "knife4j-dependencies" ]; then
+    continue
+  fi
+  if ! printf '%s\n' "$bom_artifacts" | grep -Fxq "$module"; then
+    echo "::error::release module is missing from knife4j-dependencies dependencyManagement: $module"
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  exit "$status"
+fi
+
+echo "Release module list OK (${#release_modules[@]} modules)."


### PR DESCRIPTION
## 关联 Issue

无。维护者直接要求修复 `5.0.2` 发布缺失的 Spring Boot 4 starter 构件。

## 背景

`5.0.2` 的父 POM 和 BOM 已声明 `knife4j-openapi3-boot4-spring-boot-starter`，但 `.github/workflows/release.yml` 的 Maven `-pl` 白名单漏掉该模块，导致 Maven Central 上缺失对应 GAV。

## 变更内容

- 新增 `scripts/release-modules.txt`，集中维护 Maven Central 发布模块清单。
- 将 release workflow 改为从该清单生成 `mvn -pl` 参数，清单中包含 `knife4j-openapi3-boot4-spring-boot-starter`。
- 新增 `scripts/verify-release-modules.sh`，检查发布清单、父 POM modules、`knife4j-dependencies` 中的 `com.baizhukui` dependencyManagement 是否一致。
- 在 build workflow 中加入发布清单一致性检查，避免后续新增可发布模块时再次漏发。

## 验证

- `scripts/verify-release-modules.sh`：通过，输出 `Release module list OK (13 modules).`
- `bash -n scripts/verify-release-modules.sh`：通过。
- `mvn -B -ntp -pl knife4j-openapi3-boot4-spring-boot-starter -DskipTests validate`：通过。
- `mvn -B -ntp -pl "$release_modules" -am -DskipTests validate`：通过，reactor 包含 `knife4j-openapi3-boot4-spring-boot-starter`。

## 发布说明

本 PR 不触发发布，也不修改凭据。合并后仍需要维护者按 release 权限补发 Maven Central 上缺失的 `com.baizhukui:knife4j-openapi3-boot4-spring-boot-starter:5.0.2`。