### PR TITLE
docs: 收口 5.0.2 发布后文档

### DIFF
--- a/docs-site/guide/faq.md
+++ b/docs-site/guide/faq.md
@@ -29,7 +29,7 @@ title: 常见问题
 
 | 版本 | 修复/新增内容 | 对应 upstream issue |
 | --- | --- | --- |
-| `5.0.2` | 补丁修复：BOM 补登 Boot4 starter、Schema 路由守卫与 React 设置默认对齐（含读取后端 `enableHost` 等注入项）、调试器 raw body 多格式 Beautify（JSON/XML/HTML/JS）、调试器 baseUrl 智能解析（servers[0] 优先于 origin）、Cookie header 大小写合并 | — |
+| `5.0.2` | 补丁修复：Boot4 starter 构件补发与 release 发布清单校验、BOM 补登 Boot4 starter、Schema 路由守卫与 React 设置默认对齐（含读取后端 `enableHost` 等注入项）、调试器 raw body 多格式 Beautify（JSON/XML/HTML/JS）、调试器 baseUrl 智能解析（servers[0] 优先于 origin）、Cookie header 大小写合并 | — |
 | `5.0.1` | 补丁修复：反向代理 prefix / swagger-config 发现、OAS2 webjar 构建产物、特殊字符路由、分组搜索状态、schema 显示细节 | — |
 | `5.0.0` | Bug 修复 & 功能增强：petstore 闪烁、OAuth2 四种 flow 基础鉴权、离线文档 Markdown/OpenAPI JSON、tags-sorter | — |
 | `1.0.0` | 正式版：全部 fork 安全修复 + Boot 3.4/3.5 兼容 + React UI 完整集成 | — |

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -74,7 +74,7 @@ knife4j:
 
 ## 5.0.2 版本亮点 <Badge type="tip" text="最新" />
 
-- 📦 `knife4j-dependencies` BOM 补登 `knife4j-openapi3-boot4-spring-boot-starter`，下游通过 BOM 引入 Boot4 starter 不再需要显式版本
+- 📦 `knife4j-openapi3-boot4-spring-boot-starter:5.0.2` 已补发至 Maven Central，并通过发布清单校验避免后续模块漏发
 - 🧭 修复 `enableSwaggerModels=false` 时直接刷新 `/:group/schema` 会跳到非法 `//home` 的路由守卫问题
 - 🛡️ Schema 页在被禁用时显示 403 提示，并防止通过 URL 参数注入被禁用的标签
 - 📝 HTML body 美化改用正则切分 + DOMParser 校验，避免文本中的 `<` / `>` 被误判为标签起止

--- a/docs-site/reference/version-ref.md
+++ b/docs-site/reference/version-ref.md
@@ -13,6 +13,7 @@ title: 版本对照
 | `5.0.0` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ❌ | 首个正式稳定版本 |
 
 > knife4j-next 从 `5.0.0` 起采用独立 [SemVer](https://semver.org/lang/zh-CN/) 版本号，与上游 knife4j 版本号无关。
+> `5.0.2` 的 Boot4 专用 starter 构件已补发到 Maven Central，可直接使用 `com.baizhukui:knife4j-openapi3-boot4-spring-boot-starter:5.0.2`。
 
 ## 核心依赖版本
 

--- a/docs-site/release-notes/index.md
+++ b/docs-site/release-notes/index.md
@@ -14,11 +14,12 @@ title: 发布说明
 
 ### 5.0.2 <Badge type="tip" text="最新" />
 
-`5.0.2` 是基于 `5.0.1` 的补丁版本，集中修复 BOM 缺漏、React UI 路由守卫与配置默认值的对齐、调试器细节，以及前端解析层的 cookie 大小写合并。
+`5.0.2` 是基于 `5.0.1` 的补丁版本，集中修复 Boot4 starter 发布清单、BOM 缺漏、React UI 路由守卫与配置默认值的对齐、调试器细节，以及前端解析层的 cookie 大小写合并。
 
 **后端 & 打包**
 
 - `knife4j-dependencies` BOM 补登 `knife4j-openapi3-boot4-spring-boot-starter`（PR #362），下游通过 BOM 引入 Boot4 starter 时不再需要显式声明版本。
+- 修复 release workflow 的 Maven Central 发布模块清单，避免新增可发布模块时漏发；`knife4j-openapi3-boot4-spring-boot-starter:5.0.2` 已补发完成，可从 [Maven Central](https://repo1.maven.org/maven2/com/baizhukui/knife4j-openapi3-boot4-spring-boot-starter/5.0.2/) 直接拉取（PR #370）。
 
 **前端（React UI）**
 


### PR DESCRIPTION
Closes #371

## 关联 Issue

#371

## 变更内容

- 在发布说明中补齐 PR #370 的 release 发布清单校验，以及 Boot4 starter 5.0.2 构件已补发到 Maven Central 的说明。
- 更新文档站首页 5.0.2 亮点，避免只写 BOM 补登而漏掉实际构件补发。
- 更新 FAQ 版本修复表，补充 Boot4 starter 构件补发与 release 发布清单校验。
- 在版本对照页补充 `com.baizhukui:knife4j-openapi3-boot4-spring-boot-starter:5.0.2` 可直接使用。

## 验证

- `./scripts/test-docs.sh`：通过。
- `git diff --check`：通过。

## 风险

仅文档改动，未修改 Java/前端源码，未触发发布流程。Boot4 支持边界保持为 Spring Boot 4 / Spring Framework 7 的 WebMVC + OpenAPI3 starter。