### PR TITLE
fix: 支持调试器接口级 servers

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -1583,11 +1583,12 @@ export default function ApiDebug() {
     () =>
       resolveRequestBaseUrl({
         swaggerDoc,
+        operation,
         enableHost: settings.enableHost,
         enableHostText: settings.enableHostText,
         origin: currentOrigin(),
       }),
-    [settings.enableHost, settings.enableHostText, swaggerDoc],
+    [operation, settings.enableHost, settings.enableHostText, swaggerDoc],
   );
   const [baseUrl, setBaseUrl] = useState(defaultBaseUrl);
   const [method, setMethod] = useState('GET');

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { SwaggerDoc } from '../../types/swagger';
+import type { MenuOperation, SwaggerDoc } from '../../types/swagger';
 import { normalizeRequestBaseUrl, resolveRequestBaseUrl } from './requestBaseUrl';
 
 function docWithServers(urls: string[]): SwaggerDoc {
@@ -8,6 +8,42 @@ function docWithServers(urls: string[]): SwaggerDoc {
     info: { title: 'test', version: '1.0.0' },
     paths: {},
     servers: urls.map((url) => ({ url })),
+  };
+}
+
+function docWithServerLevels({
+  root = [],
+  path = [],
+  operation = [],
+}: {
+  root?: string[];
+  path?: string[];
+  operation?: string[];
+}): SwaggerDoc {
+  return {
+    openapi: '3.0.1',
+    info: { title: 'test', version: '1.0.0' },
+    paths: {
+      '/pets': {
+        servers: path.map((url) => ({ url })),
+        get: {
+          summary: 'List pets',
+          responses: {},
+          servers: operation.map((url) => ({ url })),
+        },
+      },
+    },
+    servers: root.map((url) => ({ url })),
+  };
+}
+
+function petOperation(doc: SwaggerDoc): MenuOperation {
+  return {
+    key: 'Pets/listPets',
+    path: '/pets',
+    method: 'get',
+    summary: 'List pets',
+    operation: doc.paths['/pets'].get!,
   };
 }
 
@@ -29,14 +65,73 @@ describe('request base URL resolution', () => {
   });
 
   it('keeps the explicit host override ahead of OpenAPI servers', () => {
+    const swaggerDoc = docWithServerLevels({
+      root: ['http://root.example.test/api'],
+      path: ['http://path.example.test/api'],
+      operation: ['http://operation.example.test/api'],
+    });
+
     expect(
       resolveRequestBaseUrl({
-        swaggerDoc: docWithServers(['http://127.0.0.1:18000/api']),
+        swaggerDoc,
+        operation: petOperation(swaggerDoc),
         enableHost: true,
         enableHostText: 'http://gateway.example.test/root/',
         origin: 'http://127.0.0.1:3002',
       }),
     ).toBe('http://gateway.example.test/root');
+  });
+
+  it('prefers operation-level servers ahead of path and root servers', () => {
+    const swaggerDoc = docWithServerLevels({
+      root: ['http://root.example.test/api'],
+      path: ['http://path.example.test/api'],
+      operation: ['http://operation.example.test/api'],
+    });
+
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc,
+        operation: petOperation(swaggerDoc),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://operation.example.test/api');
+  });
+
+  it('uses path-level servers when the operation has no usable server', () => {
+    const swaggerDoc = docWithServerLevels({
+      root: ['http://root.example.test/api'],
+      path: ['http://path.example.test/api'],
+      operation: [''],
+    });
+
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc,
+        operation: petOperation(swaggerDoc),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://path.example.test/api');
+  });
+
+  it('falls back to root servers when operation and path servers are unavailable', () => {
+    const swaggerDoc = docWithServerLevels({
+      root: ['http://root.example.test/api'],
+    });
+
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc,
+        operation: petOperation(swaggerDoc),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://root.example.test/api');
   });
 
   it('falls back to the UI origin when no override or server is available', () => {

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
@@ -1,7 +1,8 @@
-import type { SwaggerDoc } from '../../types/swagger';
+import type { MenuOperation, SwaggerDoc, SwaggerServer } from '../../types/swagger';
 
 export interface ResolveRequestBaseUrlOptions {
   swaggerDoc: SwaggerDoc | null;
+  operation?: MenuOperation | null;
   enableHost: boolean;
   enableHostText: string;
   origin: string;
@@ -26,8 +27,13 @@ export function normalizeRequestBaseUrl(url: string, origin: string): string {
   }
 }
 
+function firstServerUrl(servers: SwaggerServer[] | undefined): string | undefined {
+  return servers?.find((server) => server.url.trim())?.url;
+}
+
 export function resolveRequestBaseUrl({
   swaggerDoc,
+  operation,
   enableHost,
   enableHostText,
   origin,
@@ -37,7 +43,11 @@ export function resolveRequestBaseUrl({
     return normalizeRequestBaseUrl(hostOverride, origin);
   }
 
-  const serverUrl = swaggerDoc?.servers?.find((server) => server.url.trim())?.url;
+  const pathItem = operation ? swaggerDoc?.paths[operation.path] : undefined;
+  const serverUrl =
+    firstServerUrl(operation?.operation.servers) ??
+    firstServerUrl(pathItem?.servers) ??
+    firstServerUrl(swaggerDoc?.servers);
   if (serverUrl) {
     return normalizeRequestBaseUrl(serverUrl, origin);
   }

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -150,9 +150,13 @@ export interface OperationObject {
   deprecated?: boolean;
   /** operation 级别的 security 声明，每项是 `{ [schemeName]: string[] } */
   security?: Record<string, string[]>[];
+  /** OAS3 operation 级 servers */
+  servers?: SwaggerServer[];
 }
 
 export interface PathItemObject {
+  /** OAS3 path item 级 servers */
+  servers?: SwaggerServer[];
   get?: OperationObject;
   post?: OperationObject;
   put?: OperationObject;


### PR DESCRIPTION
## 关联 Issue
- Closes #372

## 变更内容
- 调试器 baseUrl 解析传入当前 operation，上游地址优先级调整为 host override > operation servers > path item servers > 文档根级 servers > UI origin。
- 为 OAS3 operation/path item 级 `servers` 补齐 ui-react 类型定义。
- 扩展 `requestBaseUrl` 单元测试，覆盖 operation/path/root servers 优先级和 host override 最高优先级。

## 验证
- `./scripts/test-front-core.sh`

## 风险
- 改动限定在 `knife4j-ui-react` 的 OAS3 调试器 baseUrl 解析，不触碰 Vue3/OAS2 产物。