### PR TITLE
修复调试地址 HTTPS 同域降级问题

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -2361,21 +2361,27 @@ export default function ApiDebug() {
           </Title>
         </Space>
 
-        <Space.Compact style={{ width: '100%', marginBottom: 16 }}>
+        <Space.Compact style={{ width: '100%', marginBottom: 16, display: 'flex' }}>
           <Select
             value={method}
             onChange={setMethod}
-            style={{ width: 110 }}
+            style={{ width: 110, flex: '0 0 110px' }}
             options={['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].map((item) => ({
               value: item,
               label: item,
             }))}
           />
-          <Input value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} style={{ width: 240 }} />
+          <Input
+            value={baseUrl}
+            title={baseUrl}
+            onChange={(event) => setBaseUrl(event.target.value)}
+            style={{ flex: '0 1 420px', minWidth: 320 }}
+          />
           <Input
             value={displayPath}
+            title={displayPath}
             onChange={(event) => handlePathInputChange(event.target.value)}
-            style={{ flex: 1 }}
+            style={{ flex: '1 1 220px', minWidth: 0 }}
           />
           <Button type="primary" icon={<SendOutlined />} onClick={handleSend} loading={loading}>
             {t('apiDebug.send')}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
@@ -59,6 +59,28 @@ describe('request base URL resolution', () => {
     ).toBe('http://127.0.0.1:18000/api');
   });
 
+  it('upgrades same-host OpenAPI server URLs when the UI is served over HTTPS', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://api.example.test/api/']),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'https://api.example.test',
+      }),
+    ).toBe('https://api.example.test/api');
+  });
+
+  it('keeps cross-host OpenAPI server URLs on their declared protocol', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://api.example.test/api']),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'https://docs.example.test',
+      }),
+    ).toBe('http://api.example.test/api');
+  });
+
   it('resolves relative server URLs from the UI origin root', () => {
     expect(normalizeRequestBaseUrl('/api/', 'http://127.0.0.1:18000')).toBe('http://127.0.0.1:18000/api');
     expect(normalizeRequestBaseUrl('api', 'http://127.0.0.1:18000')).toBe('http://127.0.0.1:18000/api');
@@ -80,6 +102,17 @@ describe('request base URL resolution', () => {
         origin: 'http://127.0.0.1:3002',
       }),
     ).toBe('http://gateway.example.test/root');
+  });
+
+  it('keeps the explicit host override protocol unchanged', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['https://api.example.test/api']),
+        enableHost: true,
+        enableHostText: 'http://api.example.test/custom/',
+        origin: 'https://api.example.test',
+      }),
+    ).toBe('http://api.example.test/custom');
   });
 
   it('prefers operation-level servers ahead of path and root servers', () => {

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
@@ -8,6 +8,10 @@ export interface ResolveRequestBaseUrlOptions {
   origin: string;
 }
 
+interface NormalizeRequestBaseUrlOptions {
+  upgradeSameHostHttpToHttps?: boolean;
+}
+
 export function currentOrigin(): string {
   return typeof window === 'undefined' ? 'http://localhost:8080' : window.location.origin;
 }
@@ -16,12 +20,25 @@ function trimTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
-export function normalizeRequestBaseUrl(url: string, origin: string): string {
+function shouldUpgradeSameHostHttpUrl(url: URL, origin: URL): boolean {
+  return origin.protocol === 'https:' && url.protocol === 'http:' && url.hostname === origin.hostname;
+}
+
+export function normalizeRequestBaseUrl(
+  url: string,
+  origin: string,
+  options: NormalizeRequestBaseUrlOptions = {},
+): string {
   const trimmed = url.trim();
   if (!trimmed) return trimTrailingSlashes(origin);
 
   try {
-    return trimTrailingSlashes(new URL(trimmed, `${origin.replace(/\/+$/, '')}/`).toString());
+    const originUrl = new URL(`${origin.replace(/\/+$/, '')}/`);
+    const requestUrl = new URL(trimmed, originUrl);
+    if (options.upgradeSameHostHttpToHttps && shouldUpgradeSameHostHttpUrl(requestUrl, originUrl)) {
+      requestUrl.protocol = originUrl.protocol;
+    }
+    return trimTrailingSlashes(requestUrl.toString());
   } catch {
     return trimTrailingSlashes(trimmed);
   }
@@ -49,7 +66,9 @@ export function resolveRequestBaseUrl({
     firstServerUrl(pathItem?.servers) ??
     firstServerUrl(swaggerDoc?.servers);
   if (serverUrl) {
-    return normalizeRequestBaseUrl(serverUrl, origin);
+    return normalizeRequestBaseUrl(serverUrl, origin, {
+      upgradeSameHostHttpToHttps: true,
+    });
   }
 
   return normalizeRequestBaseUrl(origin, origin);


### PR DESCRIPTION
## 关联 Issue

无。来自维护者对 OpenAPI3 demo 调试地址协议与显示问题的反馈。

## 变更内容

- 调试器解析 OpenAPI `servers` 时，如果当前页面是 `https`，而 server 是同 host 的 `http`，则仅将协议升级为 `https`，避免 HTTPS 页面生成 HTTP 调试地址。
- 保持跨 host server、显式 Host 覆盖的原始协议，不做 localhost 或 dev 环境隐式改写。
- 调整调试页顶部请求地址栏布局，让较长的 baseUrl 更容易完整查看，并给 baseUrl/path 输入框补充原生 `title`。
- 补充 `requestBaseUrl` 单测覆盖同 host 协议升级、跨 host 保持原样、Host 覆盖保持原样。

## 根因说明

OpenAPI JSON 中的 `servers` 可能由后端根据反向代理后的请求自动生成。若后端只感知到 host，但未正确感知外部协议，就可能返回同 host 的 `http` server。前端在 HTTPS 页面直接使用该值会导致调试地址协议降级。

## 协作说明

本次为维护者交互反馈下的窄范围前端修复，未单独创建 GitHub Issue。当前运行环境未额外启动独立 worker/reviewer；PR 保持草稿状态，等待人工 review 后再进入合并流程。

## 验证

- `bun run test src/pages/api/requestBaseUrl.test.ts --run`
- `./scripts/test-front-core.sh`
- `git diff --check`

## 风险

- 该改动只处理 HTTPS 页面中同 host 的 `http` server 协议升级，不修复后端或反向代理的 forwarded headers 配置问题。
- 本地 dev 调试仍应使用本地 demo 后端，或显式 Host 覆盖，不在前端解析逻辑中自动改写外部 server。
