### PR TITLE
固化发布流程的 GitHub Release 门禁

### DIFF
--- a/.agent/RUNBOOK.md
+++ b/.agent/RUNBOOK.md
@@ -154,6 +154,26 @@ coordinator 或 worker 在 push 完带 `agent/` 前缀的分支或新开/更新 
 
 如果某个子项目（如 `knife4j-ui-react`）CI 跑的步骤本地脚本没覆盖，应该扩展脚本而不是绕过。
 
+## 正式发布验收（强制）
+
+发布构件前仍必须获得维护者明确确认；确认后由 tag push 触发 `.github/workflows/release.yml`。
+
+Release workflow 必须在 Maven Central 发布成功后创建或更新 GitHub Release，并调用 `scripts/verify-github-release.sh` 校验：
+
+- GitHub Release `vX.Y.Z` 存在。
+- GitHub Release body 与 `docs-site/release-notes/index.md` 中 `X.Y.Z` 对应小节一致。
+
+正式发布完成条件：
+
+- `vX.Y.Z` tag 已推送。
+- `Release` workflow 成功。
+- `Build and Deploy Demo` workflow 成功。
+- Maven Central 目标构件可访问。
+- GitHub Release `vX.Y.Z` 存在。
+- GitHub Release body 与 docs-site release note 对应小节一致。
+
+如果缺少 GitHub Release，不能把发布报告为完成；应先补齐 Release 或修复 workflow，再写回发布状态。
+
 ## PR 期望
 
 每个 PR 或自治工作报告都应包含：

--- a/.agent/SERVER_PLAYBOOK.md
+++ b/.agent/SERVER_PLAYBOOK.md
@@ -177,10 +177,24 @@ PR 描述格式规范：
 建议在以下时机通知维护者：
 
 - 新 PR 已创建
+- Release workflow 完成但 GitHub Release 缺失
 - 任务进入 `blocked`
 - reviewer 给出 `block`
 - reviewer 门禁因运行时限制无法执行
 - 发现需要人工决策的兼容性或发布问题
+
+## 发布后检查点
+
+发布构件前必须先有维护者明确确认。tag 推送后不要只等待 Maven Central：
+
+1. 确认 `vX.Y.Z` tag 存在并指向预期 merge commit。
+2. 监控 `Release` workflow 到终态。
+3. 监控 `Build and Deploy Demo` workflow 到终态。
+4. 确认 Maven Central 目标构件可访问。
+5. 确认 GitHub Release `vX.Y.Z` 存在。
+6. 确认 GitHub Release body 来自 `docs-site/release-notes/index.md` 对应版本小节。
+
+如果第 5 或第 6 项失败，发布尚未完成；不要只凭 tag 或 Maven Central 结果向维护者报告“发布完成”。
 
 ## 不要做的事
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref_name, '-rc') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc') }}
     permissions:
-      contents: read
+      contents: write
     env:
       CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
       CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
@@ -58,9 +58,49 @@ jobs:
         run: bun install --frozen-lockfile
         working-directory: knife4j-front
 
+      - name: Prepare GitHub Release notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          release_notes="$RUNNER_TEMP/github-release-notes.md"
+          {
+            scripts/extract-release-note.sh "$version"
+            echo ""
+            echo "## Links"
+            echo ""
+            echo "- 文档站：https://knife4j-next.baizhukui.com/release-notes/"
+            echo "- Maven Central：https://repo1.maven.org/maven2/com/baizhukui/"
+          } > "$release_notes"
+          echo "GITHUB_RELEASE_NOTES=$release_notes" >> "$GITHUB_ENV"
+        working-directory: .
+
       - name: Publish to Maven Central
         run: |
           release_modules="$(sed -E 's/[[:space:]]*#.*$//' ../scripts/release-modules.txt | sed '/^[[:space:]]*$/d' | paste -sd, -)"
           mvn -B -ntp -Prelease deploy \
             -pl "$release_modules" \
             -am
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="knife4j-next ${GITHUB_REF_NAME#v}"
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --notes-file "$GITHUB_RELEASE_NOTES"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --notes-file "$GITHUB_RELEASE_NOTES" \
+              --verify-tag
+          fi
+        working-directory: .
+
+      - name: Verify GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/verify-github-release.sh "$GITHUB_REF_NAME" "$GITHUB_RELEASE_NOTES"
+        working-directory: .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,21 @@ User/Maintainer -> Coordinator -> Worker -> Reviewer -> Worker(如需返工) -> 
 - 进行影响面不清楚的大范围依赖升级
 - 处理含糊的产品方向决策
 
+## 发布完成条件
+
+发布构件前必须获得维护者明确确认。维护者确认后，tag push 会触发 `.github/workflows/release.yml`；该 workflow 必须在 Maven Central 发布成功后创建或更新 GitHub Release。
+
+发布不能只以 tag 或 Maven Central 成功为终点。完整发布必须同时满足：
+
+- `vX.Y.Z` tag 已推送。
+- `Release` workflow 成功。
+- `Build and Deploy Demo` workflow 成功。
+- Maven Central 目标构件可访问。
+- GitHub Release `vX.Y.Z` 存在。
+- GitHub Release body 与 `docs-site/release-notes/index.md` 中对应版本小节一致。
+
+如果 GitHub Release 缺失，发布状态仍视为未完成，必须修复 workflow 或补齐 Release 后再报告完成。
+
 ## 验证规则
 
 每个任务必须明确：

--- a/knife4j/RELEASE.md
+++ b/knife4j/RELEASE.md
@@ -1,13 +1,13 @@
 # Release
 
-This fork publishes Maven artifacts from GitHub Actions to Maven Central by using the Central Portal publishing plugin.
+本 fork 通过 GitHub Actions 和 Central Portal Publishing Plugin 发布 Maven Central 构件，并在同一个 Release workflow 中创建 GitHub Release。
 
-## One-time setup
+## 一次性配置
 
-1. Register and verify the `com.baizhukui` namespace in Sonatype Central Portal.
-2. Generate a Central Portal user token.
-3. Create a GPG key pair for artifact signing.
-4. Add these GitHub repository secrets:
+1. 在 Sonatype Central Portal 注册并验证 `com.baizhukui` namespace。
+2. 生成 Central Portal user token。
+3. 创建用于构件签名的 GPG key pair。
+4. 配置 GitHub repository secrets：
 
 - `CENTRAL_USERNAME`
 - `CENTRAL_PASSWORD`
@@ -16,12 +16,27 @@ This fork publishes Maven artifacts from GitHub Actions to Maven Central by usin
 
 ## CI workflows
 
-- `.github/workflows/build.yml` runs `mvn verify` for pull requests and pushes to `main`.
-- `.github/workflows/release.yml` publishes when a tag matching `v*` is pushed.
+- `.github/workflows/build.yml` 在 PR 和 `master` push 时运行 `mvn verify` 等验证。
+- `.github/workflows/release.yml` 在推送 `v*` tag 时发布 Maven Central 构件，并创建 GitHub Release。
 
 ## Release flow
 
-1. Make sure the version in `knife4j/pom.xml` is correct.
-2. Commit and push the release changes.
-3. Create and push a tag such as `v5.0.3`.
-4. Wait for the GitHub Actions `Release` workflow to finish publishing.
+1. 确认 `knife4j/pom.xml` 和所有子模块版本正确。
+2. 在 `docs-site/release-notes/index.md` 增加对应版本小节，例如 `### 5.0.3`。
+3. 提交并合并 release prep PR，等待 PR CI 和 `master` push CI 通过。
+4. 创建并推送 tag，例如 `v5.0.3`。
+5. 等待 GitHub Actions `Release` workflow 完成发布。
+6. 等待 `Build and Deploy Demo` workflow 完成 demo 镜像发布。
+7. 验收发布完成条件：
+   - `vX.Y.Z` tag 已推送。
+   - `Release` workflow 成功。
+   - `Build and Deploy Demo` workflow 成功。
+   - Maven Central 目标构件可访问。
+   - GitHub Release `vX.Y.Z` 存在。
+   - GitHub Release body 与 `docs-site/release-notes/index.md` 中对应版本小节一致。
+
+## GitHub Release 内容来源
+
+GitHub Release body 由 `.github/workflows/release.yml` 调用 `scripts/extract-release-note.sh` 从 `docs-site/release-notes/index.md` 自动抽取。
+
+如果 release note 中没有当前 tag 对应的小节，Release workflow 必须失败，不允许发布一个没有 GitHub Release 说明的版本。

--- a/scripts/extract-release-note.sh
+++ b/scripts/extract-release-note.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <version-or-tag> [release-notes-file]" >&2
+  exit 2
+fi
+
+version="${1#v}"
+notes_file="${2:-docs-site/release-notes/index.md}"
+
+if [ ! -f "$notes_file" ]; then
+  echo "Release notes file not found: $notes_file" >&2
+  exit 1
+fi
+
+awk -v version="$version" '
+  BEGIN {
+    found = 0
+    emitted = 0
+    heading = "^###[ \t]+" version "([ \t]|$|<)"
+  }
+
+  $0 ~ heading {
+    found = 1
+    emitted++
+    print "## " version
+    next
+  }
+
+  found && /^###[ \t]+/ {
+    exit
+  }
+
+  found {
+    emitted++
+    print
+  }
+
+  END {
+    if (!found) {
+      printf("Release note section not found for version %s\n", version) > "/dev/stderr"
+      exit 1
+    }
+    if (emitted <= 1) {
+      printf("Release note section is empty for version %s\n", version) > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$notes_file"

--- a/scripts/verify-github-release.sh
+++ b/scripts/verify-github-release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <tag> [expected-body-file] [repo]" >&2
+  exit 2
+fi
+
+tag="$1"
+expected_body_file="${2:-}"
+repo="${3:-${GITHUB_REPOSITORY:-}}"
+
+if [ -z "$repo" ]; then
+  echo "Repository is required; pass owner/name or set GITHUB_REPOSITORY." >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI 'gh' is required to verify GitHub Release." >&2
+  exit 1
+fi
+
+if ! gh release view "$tag" --repo "$repo" --json tagName,name >/dev/null; then
+  echo "GitHub Release does not exist for tag $tag in $repo." >&2
+  exit 1
+fi
+
+if [ -n "$expected_body_file" ]; then
+  if [ ! -f "$expected_body_file" ]; then
+    echo "Expected release body file not found: $expected_body_file" >&2
+    exit 1
+  fi
+
+  actual_body="$(mktemp)"
+  gh release view "$tag" --repo "$repo" --json body --jq .body > "$actual_body"
+  if ! diff -u "$expected_body_file" "$actual_body"; then
+    echo "GitHub Release body differs from expected release notes for $tag." >&2
+    exit 1
+  fi
+fi
+
+echo "GitHub Release OK: $repo@$tag"


### PR DESCRIPTION
## 变更内容

- 在 `.github/workflows/release.yml` 中把 Release job 限定为 `v*` tag，并将 `contents` 权限提升为 `write`，用于创建 GitHub Release。
- 新增 `scripts/extract-release-note.sh`，从 `docs-site/release-notes/index.md` 自动抽取当前 tag 对应版本小节；如果缺失版本小节，workflow 会在 Maven Central 发布前失败。
- 新增 `scripts/verify-github-release.sh`，校验 GitHub Release 存在，并可校验 Release body 与抽取出的 release note 一致。
- Release workflow 在 Maven Central 发布成功后自动创建或更新 GitHub Release，并在最后校验 Release 存在且内容一致。
- 更新 `AGENTS.md`、`.agent/RUNBOOK.md`、`.agent/SERVER_PLAYBOOK.md` 和 `knife4j/RELEASE.md`，把“GitHub Release 存在且内容一致”列入正式发布完成条件。

## 验证

- `bash -n scripts/extract-release-note.sh scripts/verify-github-release.sh`：通过。
- `scripts/extract-release-note.sh v5.0.3`：通过，可抽取 `5.0.3` 小节。
- `scripts/extract-release-note.sh 9.9.9`：按预期失败，提示缺少 release note 小节。
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML OK"'`：通过。
- `git diff --check`：通过。
- PR CI Build run `25866440562`：通过。
  - `front-core-test`：通过。
  - `docs-build`：通过。
  - `java-build-test`：通过，包含 `Smoke-tests evidence summary` 成功。

## 协作门禁

- 未启动独立 worker：当前运行环境没有使用子 agent；本次为明确授权的发布流程/脚本/runbook 固化，由 coordinator 直接实施。
- 未启动独立 reviewer：本 PR 保持 draft，等待维护者 review 后再合并。

## 注意事项

- 该改动只影响合并后的后续 tag 发布；已经推送的 `v5.0.3` tag 不会自动回放新 workflow。
- 当前 `v5.0.3` Release workflow 仍在旧流程的 `Publish to Maven Central` 阶段，发布成功后仍需要单独补 GitHub Release。