### PR TITLE
修复全局参数 ID 生成兼容性

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
@@ -138,7 +138,7 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
     filteredByTag.forEach((apis, tag) => {
       const tagDesc = tagDescMap.get(tag);
       const labelContent = tagDesc ? (
-        <Tooltip title={<Markdown source={tagDesc} />} placement="right" overlayStyle={{ maxWidth: 400 }}>
+        <Tooltip title={<Markdown source={tagDesc} />} placement="right" styles={{ root: { maxWidth: 400 } }}>
           <span>{tag}</span>
         </Tooltip>
       ) : (

--- a/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
@@ -106,7 +106,7 @@ export function SchemaTypeLink({ node }: SchemaTypeLinkProps) {
 
   return (
     <ConstraintTooltip node={node}>
-      <Popover title={refName} content={content} placement="right" overlayStyle={{ maxWidth: 460 }}>
+      <Popover title={refName} content={content} placement="right" styles={{ root: { maxWidth: 460 } }}>
         <RouterLink to={target}>
           <Tag color={color} style={{ cursor: 'pointer' }}>
             {label}

--- a/knife4j-front/knife4j-ui-react/src/context/GlobalParamContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GlobalParamContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import { createClientId } from '../utils/id';
 
 const STORAGE_KEY = 'knife4j_global_params';
 
@@ -30,7 +31,7 @@ export const GlobalParamProvider: React.FC<{ children: React.ReactNode }> = ({ c
   const [params, setParams] = useState<GlobalParamItem[]>(loadFromStorage);
 
   const addParam = (param: Omit<GlobalParamItem, 'id'>) => {
-    const next = [...params, { ...param, id: crypto.randomUUID() }];
+    const next = [...params, { ...param, id: createClientId() }];
     setParams(next);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
   };

--- a/knife4j-front/knife4j-ui-react/src/main.tsx
+++ b/knife4j-front/knife4j-ui-react/src/main.tsx
@@ -9,6 +9,6 @@ import router from './routes/router';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <RouterProvider router={router} future={{ v7_startTransition: true }} />
   </React.StrictMode>,
 );

--- a/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
@@ -196,7 +196,7 @@ export default function Home() {
   ];
 
   const renderSummaryCard = (item: (typeof summaryCards)[number]) => (
-    <Card hoverable size="small" bodyStyle={{ padding: 16, height: 88 }}>
+    <Card hoverable size="small" styles={{ body: { padding: 16, height: 88 } }}>
       <Space size={12} align="start" style={{ width: '100%', minWidth: 0 }}>
         <span
           style={{

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -2432,7 +2432,7 @@ export default function ApiDebug() {
             </Button>,
           ]}
           width={680}
-          destroyOnClose
+          destroyOnHidden
         >
           <p style={{ marginBottom: 16, color: 'rgba(0,0,0,0.65)' }}>{t('auth.modal401.description')}</p>
           <Authorize />

--- a/knife4j-front/knife4j-ui-react/src/utils/id.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/id.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { createClientId } from './id';
+
+describe('client id generation', () => {
+  it('uses crypto.randomUUID when it is available', () => {
+    expect(createClientId({ randomUUID: () => 'fixed-id' })).toBe('fixed-id');
+  });
+
+  it('falls back to getRandomValues when randomUUID is missing', () => {
+    const randomBytes = Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+
+    const id = createClientId({
+      getRandomValues: (bytes) => {
+        bytes.set(randomBytes);
+        return bytes;
+      },
+    });
+
+    expect(id).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f');
+  });
+
+  it('uses a timestamp fallback when browser crypto is unavailable', () => {
+    expect(createClientId(null)).toMatch(/^id-[a-z0-9]+-[a-z0-9]+$/);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/utils/id.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/id.ts
@@ -1,0 +1,33 @@
+interface CryptoLike {
+  randomUUID?: () => string;
+  getRandomValues?: (array: Uint8Array) => Uint8Array;
+}
+
+function createUuidFromRandomValues(getRandomValues: (array: Uint8Array) => Uint8Array): string {
+  const bytes = getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-');
+}
+
+export function createClientId(cryptoApi: CryptoLike | null | undefined = globalThis.crypto): string {
+  const randomUUID = cryptoApi?.randomUUID;
+  if (typeof randomUUID === 'function') {
+    return randomUUID.call(cryptoApi);
+  }
+
+  const getRandomValues = cryptoApi?.getRandomValues;
+  if (typeof getRandomValues === 'function') {
+    return createUuidFromRandomValues((bytes) => getRandomValues.call(cryptoApi, bytes));
+  }
+
+  return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/knife4j-front/knife4j-ui-react/vite.config.ts
+++ b/knife4j-front/knife4j-ui-react/vite.config.ts
@@ -3,6 +3,10 @@ import react from '@vitejs/plugin-react-swc';
 import path from 'path';
 
 const BACKEND = process.env.VITE_BACKEND ?? 'http://localhost:8080';
+const BACKEND_PROXY = {
+  target: BACKEND,
+  changeOrigin: false,
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -18,12 +22,15 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/v3/api-docs': { target: BACKEND, changeOrigin: true },
-      '/swagger-resources': { target: BACKEND, changeOrigin: true },
-      '/swagger-ui': { target: BACKEND, changeOrigin: true },
+      // Preserve the Vite dev-server Host header so springdoc generates
+      // servers that point back to the dev origin, keeping debug requests on
+      // the proxy path when the UI is opened through a LAN IP.
+      '/v3/api-docs': BACKEND_PROXY,
+      '/swagger-resources': BACKEND_PROXY,
+      '/swagger-ui': BACKEND_PROXY,
       // Demo 后端业务接口（UserController 的 /api/user/**），
       // 供「接口文档调试」在 dev 下直接命中后端。
-      '/api': { target: BACKEND, changeOrigin: true },
+      '/api': BACKEND_PROXY,
     },
   },
   build: {


### PR DESCRIPTION
## 关联 Issue

- 关联 #379

## 变更内容

- 为 `knife4j-ui-react` 新增 `createClientId()`，全局参数添加时不再直接依赖 `crypto.randomUUID()`。
- `createClientId()` 优先使用 `crypto.randomUUID()`，缺失时退到 `crypto.getRandomValues()` 生成 UUID，再缺失时使用本地临时 ID。
- 增加 `id.test.ts` 覆盖 `randomUUID` 存在、缺失但有 `getRandomValues`、完全无 `crypto` 三种场景。
- 顺手清理本地复现过程中出现的控制台弃用提示：更新 Ant Design `overlayStyle` / `bodyStyle` / `destroyOnClose` 用法，并开启 React Router `v7_startTransition` future flag。
- 调整 Vite dev 代理，保留 dev server Host，避免通过局域网 IP 访问 `:5180` 时 springdoc 生成 `http://localhost:8080` 作为调试地址。

## 根因

全局参数添加逻辑直接调用 `crypto.randomUUID()`。在普通 HTTP 内网域名或 IP 访问等场景下，浏览器可能没有暴露该方法，导致点击添加时抛出 `TypeError: crypto.randomUUID is not a function`，后续 `setLoading(false)` 不会执行，表现为按钮 loading 不消失且参数未添加成功。

本地复现时另一个现象来自 Vite 代理：旧配置使用 `changeOrigin: true` 代理 `/v3/api-docs` 到 `http://localhost:8080`，springdoc 会按代理后的 Host 生成 `servers: http://localhost:8080`。当浏览器通过 `http://192.168.1.9:5180` 访问时，调试请求会绕过 Vite `/api` 代理并直连浏览器侧的 `localhost:8080`，容易触发请求失败。

## 验证

- `bun run test`：`knife4j-ui-react` 6 个测试文件、26 个测试通过。
- `./scripts/test-front-core.sh`：`knife4j-core` 格式、测试、lint、build 通过；`knife4j-ui-react` 格式、测试、build、lint 通过。
- `git diff --check`：通过。
- 本地验证：带 `Host: 192.168.1.9:5180` 访问 Vite 代理后的 `/v3/api-docs`，`servers` 生成为 `http://192.168.1.9:5180`；`/api/user/list` 经 `:5180` 代理返回 `200`。

## 协作门禁说明

- 本次由交互式 Codex 在维护者确认复现后直接做窄范围修复。
- 当前运行时的子 agent 工具受系统规则限制，只有用户显式要求子 agent 时才能启动，因此未伪装为独立 worker/reviewer。
- PR 先保持 draft，等待维护者或后续 reviewer 做独立审查；未将 issue 切到 `status:review`。