### PR TITLE
修复 release note 抽取章节边界

### DIFF
--- a/scripts/extract-release-note.sh
+++ b/scripts/extract-release-note.sh
@@ -32,6 +32,14 @@ awk -v version="$version" '
     exit
   }
 
+  found && /^##[ \t]+/ {
+    exit
+  }
+
+  found && /^---$/ {
+    exit
+  }
+
   found {
     emitted++
     print


### PR DESCRIPTION
## 背景

PR #381 引入 GitHub Release body 自动抽取后，Codex review 指出一个边界问题：当目标版本位于 `knife4j-next 版本` 列表末尾时，例如 `5.0.0`，`scripts/extract-release-note.sh` 只等待下一个 `###` 标题才停止，会把后续 `## 历史版本` 和上游说明一起抽进 Release body。

## 变更内容

- 调整 `scripts/extract-release-note.sh` 的抽取终止条件。
- 命中目标版本后，遇到下一个 `###` 版本标题、上一级 `##` 章节标题，或章节分隔线 `---` 都会停止。
- 保持当前版本小节的正常抽取行为不变。

## 验证

- `bash -n scripts/extract-release-note.sh scripts/verify-github-release.sh`：通过。
- `scripts/extract-release-note.sh 5.0.0`：只输出 `5.0.0` 小节，不再包含 `## 历史版本`。
- `scripts/extract-release-note.sh 5.0.3`：当前版本小节抽取正常。
- `scripts/extract-release-note.sh 9.9.9`：按预期失败，提示缺少 release note 小节。
- `git diff --check`：通过。

## 协作门禁

- 本次是维护者明确要求处理的脚本边界修复，范围仅限 `scripts/extract-release-note.sh`。
- 未启动独立 worker/reviewer；PR 先保持 draft，等待维护者或后续 reviewer 做独立审查。

## 风险

- 不修改发布凭据、Maven Central 上传逻辑或 tag 触发逻辑。
- 影响范围仅为 GitHub Release body 的 release note 小节抽取。
