### PR TITLE
修复 GitHub Release 正文校验换行误报

### DIFF
--- a/scripts/verify-github-release.sh
+++ b/scripts/verify-github-release.sh
@@ -32,7 +32,7 @@ if [ -n "$expected_body_file" ]; then
   fi
 
   actual_body="$(mktemp)"
-  gh release view "$tag" --repo "$repo" --json body --jq .body > "$actual_body"
+  gh release view "$tag" --repo "$repo" --json body --template '{{.body}}' > "$actual_body"
   if ! diff -u "$expected_body_file" "$actual_body"; then
     echo "GitHub Release body differs from expected release notes for $tag." >&2
     exit 1


### PR DESCRIPTION
## 背景

`v5.0.4` 发布时，Maven Central 发布和 GitHub Release 创建都已完成，但 `Release` workflow 最后的 `Verify GitHub Release` 步骤失败。日志 diff 只显示 GitHub Release 实际 body 比预期文件多了一个末尾空行。

根因是 `scripts/verify-github-release.sh` 使用 `gh release view --json body --jq .body` 写入临时文件；`--jq` 输出会额外追加结尾换行，导致正文内容本身一致时仍然被 `diff` 判定为不一致。

## 变更

- 将 GitHub Release body 读取方式改为 `--template '{{.body}}'`，按 body 原文写入临时文件。
- 保持后续 `diff -u` 的严格正文比对，不放宽校验规则。

## 验证

- `bash -n scripts/verify-github-release.sh scripts/extract-release-note.sh`
- `git diff --check`
- 使用修复后的脚本校验真实 `v5.0.4` Release body：`GitHub Release OK: songxychn/knife4j-next@v5.0.4`

## 发布状态说明

本次修复不重新发布 Maven 构件。`v5.0.4` 的 Maven Central 构件和 GitHub Release 已存在，当前 PR 只修正后续发布校验误报。