### PR TITLE
新增 Boot4 Gateway 聚合 starter

### DIFF
--- a/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/utils/PathUtils.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/utils/PathUtils.java
@@ -19,12 +19,12 @@ package com.github.xiaoymin.knife4j.spring.gateway.utils;
 
 import com.github.xiaoymin.knife4j.spring.gateway.conf.GlobalConstants;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
 
 import java.net.URI;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -82,11 +82,10 @@ public class PathUtils {
         String contextPath = request.getPath().contextPath().value();
         if (!StringUtils.hasLength(contextPath)) {
             // 从header中获取
-            List<String> referer = request.getHeaders().get("Referer");
-            if (referer != null && !referer.isEmpty()) {
-                String value = referer.get(0);
-                log.debug("Referer:{}", value);
-                contextPath = PathUtils.getContextPath(value);
+            String referer = request.getHeaders().getFirst(HttpHeaders.REFERER);
+            if (StringUtils.hasLength(referer)) {
+                log.debug("Referer:{}", referer);
+                contextPath = PathUtils.getContextPath(referer);
             } else {
                 contextPath = DEFAULT_CONTEXT_PATH;
             }

--- a/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/utils/PathUtilsTest.java
+++ b/knife4j/knife4j-gateway-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/gateway/test/utils/PathUtilsTest.java
@@ -18,13 +18,24 @@
 package com.github.xiaoymin.knife4j.spring.gateway.test.utils;
 
 import com.github.xiaoymin.knife4j.spring.gateway.utils.PathUtils;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.RequestPath;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import reactor.core.publisher.Flux;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author <a href="xiaoymin@foxmail.com">xiaoymin@foxmail.com</a>
@@ -107,5 +118,104 @@ public class PathUtilsTest {
         log.info("path1:{}", PathUtils.append("/bbb", "user-service", "/v2/api-dcos"));
         log.info("path1:{}", PathUtils.append(null, "user-service", "/v2/api-dcos"));
         log.info("path1:{}", PathUtils.append("user-service", "user-service", "/v2/api-dcos"));
+    }
+
+    @Test
+    public void test_getDefaultContextPath_fromRefererHeader() {
+        ServerHttpRequest request = request("", "http://localhost:8080/gateway/doc.html");
+
+        Assert.assertEquals("/gateway", PathUtils.getDefaultContextPath(request));
+    }
+
+    @Test
+    public void test_getDefaultContextPath_prefersRequestContextPath() {
+        ServerHttpRequest request = request("/api", "http://localhost:8080/gateway/doc.html");
+
+        Assert.assertEquals("/api", PathUtils.getDefaultContextPath(request));
+    }
+
+    @Test
+    public void test_getDefaultContextPath_defaultsToRoot() {
+        ServerHttpRequest request = request("", null);
+
+        Assert.assertEquals("/", PathUtils.getDefaultContextPath(request));
+    }
+
+    @Test
+    public void test_getDefaultContextPath_doesNotLinkToRemovedHttpHeadersGetObject() throws IOException {
+        try (
+                InputStream input = PathUtils.class.getResourceAsStream("/"
+                        + PathUtils.class.getName().replace('.', '/') + ".class")) {
+            Assert.assertNotNull(input);
+            String classBytes = new String(input.readAllBytes(), StandardCharsets.ISO_8859_1);
+
+            Assert.assertFalse("PathUtils must not compile against HttpHeaders.get(Object), which is absent in Spring 7",
+                    classBytes.contains("org/springframework/http/HttpHeaders")
+                            && classBytes.contains("(Ljava/lang/Object;)Ljava/util/List;"));
+        }
+    }
+
+    private ServerHttpRequest request(String contextPath, String referer) {
+        URI uri = URI.create("http://localhost:8080" + contextPath + "/v3/api-docs/swagger-config");
+        HttpHeaders headers = new HttpHeaders();
+        if (referer != null) {
+            headers.add(HttpHeaders.REFERER, referer);
+        }
+        return new TestServerHttpRequest(uri, contextPath, headers);
+    }
+
+    private static final class TestServerHttpRequest implements ServerHttpRequest {
+
+        private final URI uri;
+
+        private final RequestPath path;
+
+        private final HttpHeaders headers;
+
+        private TestServerHttpRequest(URI uri, String contextPath, HttpHeaders headers) {
+            this.uri = uri;
+            this.path = RequestPath.parse(uri, contextPath);
+            this.headers = headers;
+        }
+
+        @Override
+        public String getId() {
+            return "test";
+        }
+
+        @Override
+        public RequestPath getPath() {
+            return path;
+        }
+
+        @Override
+        public MultiValueMap<String, String> getQueryParams() {
+            return new LinkedMultiValueMap<>();
+        }
+
+        @Override
+        public MultiValueMap<String, HttpCookie> getCookies() {
+            return new LinkedMultiValueMap<>();
+        }
+
+        @Override
+        public String getMethodValue() {
+            return "GET";
+        }
+
+        @Override
+        public URI getURI() {
+            return uri;
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public Flux<DataBuffer> getBody() {
+            return Flux.empty();
+        }
     }
 }


### PR DESCRIPTION
## 变更

- 新增 `knife4j-gateway-boot4-spring-boot-starter`，面向 Spring Boot 4.x + Spring Cloud Gateway 5.x 聚合场景，使用 `spring-cloud-starter-gateway-server-webflux` 并通过 Spring Cloud `2025.1.1` BOM 管理。
- 复用现有 gateway 聚合源码重新编译，避免把 `knife4j-gateway-spring-boot-starter` 原地升级到 Gateway 5，降低对 Boot 3.x 用户的影响。
- 新增 `knife4j-smoke-tests/boot4-gateway-app`，验证 Boot4 Gateway 下 `/doc.html` 和 `/v3/api-docs/swagger-config` 能返回聚合配置。
- 移除 gateway 路由解析代码对 Netty 内部 `StringUtil` 的依赖，并保留本 PR 已有的 `Referer` 读取改为 `HttpHeaders.getFirst(HttpHeaders.REFERER)` 的 Spring 7 兼容修复。
- 同步 `knife4j-dependencies` BOM、`scripts/release-modules.txt`、Java smoke evidence gate、CI summary 和文档矩阵。

## 验证

- `mvn -B -ntp -pl knife4j-gateway-boot4-spring-boot-starter,knife4j-smoke-tests/boot4-gateway-app -am -Dknife4j-skipTests=false test`
- `scripts/verify-release-modules.sh`
- `git diff --check`
- `./scripts/test-java.sh`
- `./scripts/test-docs.sh`

## 流程说明

当前运行时没有按仓库约定启动独立 worker / reviewer；本 PR 保持 draft，issue 继续停留在 `status:in-progress`。待独立审查和 PR CI 都通过后，再切换到 `status:review`。