### PR TITLE
修复调试页请求参数缓存丢失

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -25,6 +25,7 @@ import { SendOutlined, DeleteOutlined, PlusOutlined, ReloadOutlined, UploadOutli
 import type { ColumnsType } from 'antd/es/table';
 import type { UploadFile } from 'antd/es/upload/interface';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 import type {
   BodyContent,
   BuiltRequest,
@@ -52,6 +53,15 @@ import ResponsePanel, { type DebugResponsePayload, type SseEvent } from './Respo
 import Authorize from '../Authorize';
 import { COMMON_HEADER_NAMES } from '../../constants/httpHeaders';
 import { currentOrigin, resolveRequestBaseUrl } from './requestBaseUrl';
+import {
+  DEBUG_CACHE_VERSION,
+  readDebugCache,
+  removeDebugCache,
+  writeDebugCache,
+  type DebugCacheCustomParamRow,
+  type DebugCacheRawMode,
+  type DebugCacheState,
+} from './debugCache';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
@@ -335,9 +345,9 @@ const RAW_MODES = [
   { value: 'javascript', label: 'JavaScript(application/javascript)' },
   { value: 'xml', label: 'XML(application/xml)' },
   { value: 'html', label: 'HTML(text/html)' },
-] as const;
+] as const satisfies ReadonlyArray<{ value: DebugCacheRawMode; label: string }>;
 
-type RawMode = (typeof RAW_MODES)[number]['value'];
+type RawMode = DebugCacheRawMode;
 
 /** raw mode → Content-Type 映射 */
 const RAW_CONTENT_TYPES: Record<RawMode, string> = {
@@ -590,11 +600,7 @@ function formatBodyByRawMode(value: string, mode: RawMode): string | undefined {
 
 // ─── Custom headers section ───────────────────────────
 
-interface CustomParamRow {
-  id: string;
-  name: string;
-  value: string;
-}
+type CustomParamRow = DebugCacheCustomParamRow;
 
 interface CustomParamsSectionProps {
   title: string;
@@ -1519,6 +1525,9 @@ interface InitialDebugState {
   body: string;
   formFields: Record<string, string>;
   rawMode: RawMode;
+  customQueryParams: CustomParamRow[];
+  customHeaders: CustomParamRow[];
+  customCookies: CustomParamRow[];
 }
 
 function inferRawMode(bodyContent: BodyContent | undefined): RawMode {
@@ -1570,6 +1579,81 @@ function buildInitialDebugState(
     body: firstBody?.exampleValue ?? '',
     formFields: initialFormFieldsFor(firstBody),
     rawMode: inferRawMode(firstBody),
+    customQueryParams: [],
+    customHeaders: [],
+    customCookies: [],
+  };
+}
+
+const DEBUG_HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']);
+
+function mergeCachedStringRecord(
+  initial: Record<string, string>,
+  cached: Record<string, string>,
+): Record<string, string> {
+  const next = { ...initial };
+  for (const key of Object.keys(next)) {
+    if (cached[key] !== undefined) {
+      next[key] = cached[key];
+    }
+  }
+  return next;
+}
+
+function mergeCachedBooleanRecord(
+  initial: Record<string, boolean>,
+  cached: Record<string, boolean>,
+): Record<string, boolean> {
+  const next = { ...initial };
+  for (const key of Object.keys(next)) {
+    if (cached[key] !== undefined) {
+      next[key] = cached[key];
+    }
+  }
+  return next;
+}
+
+function mergeCachedFormFields(bodyContent: BodyContent | undefined, cached: Record<string, string>) {
+  const next = initialFormFieldsFor(bodyContent);
+  const allowedFields = new Set(Object.keys(next));
+  for (const [key, value] of Object.entries(cached)) {
+    if (allowedFields.has(key)) {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+function restoreInitialDebugStateFromCache(
+  initial: InitialDebugState,
+  cached: DebugCacheState | null,
+  debugModel: OperationDebugModel,
+): InitialDebugState {
+  if (!cached) return initial;
+
+  const cachedMethod = cached.method.toUpperCase();
+  const cachedBody = debugModel.bodyContents.find(
+    (bodyContent) => bodyContent.mediaType === cached.selectedContentType,
+  );
+  const selectedBody = cachedBody ?? debugModel.bodyContents[0];
+  const restoreCachedBody = Boolean(cachedBody);
+
+  return {
+    ...initial,
+    baseUrl: cached.baseUrl || initial.baseUrl,
+    method: DEBUG_HTTP_METHODS.has(cachedMethod) ? cachedMethod : initial.method,
+    path: cached.path || initial.path,
+    paramValues: mergeCachedStringRecord(initial.paramValues, cached.paramValues),
+    paramEnabled: mergeCachedBooleanRecord(initial.paramEnabled, cached.paramEnabled),
+    selectedContentType: selectedBody?.mediaType ?? '',
+    body: restoreCachedBody ? cached.body : (selectedBody?.exampleValue ?? initial.body),
+    formFields: restoreCachedBody
+      ? mergeCachedFormFields(selectedBody, cached.formFields)
+      : initialFormFieldsFor(selectedBody),
+    rawMode: restoreCachedBody ? cached.rawMode : inferRawMode(selectedBody),
+    customQueryParams: cached.customQueryParams,
+    customHeaders: cached.customHeaders,
+    customCookies: cached.customCookies,
   };
 }
 
@@ -1577,8 +1661,15 @@ function buildInitialDebugState(
 
 export default function ApiDebug() {
   const { t } = useTranslation();
+  const { group, tag, operaterId } = useParams();
   const { loading: docLoading, swaggerDoc, operation } = useCurrentOperation();
   const { settings } = useSettings();
+  const operationMethod = operation?.method;
+  const operationPath = operation?.path;
+  const debugCacheKey = useMemo(() => {
+    if (!group || !tag || !operaterId || !operationMethod || !operationPath) return null;
+    return [group, tag, operaterId, operationMethod, operationPath].join('|');
+  }, [group, operaterId, operationMethod, operationPath, tag]);
   const defaultBaseUrl = useMemo(
     () =>
       resolveRequestBaseUrl({
@@ -1623,6 +1714,8 @@ export default function ApiDebug() {
   const fileFieldsRef = useRef<Record<string, File[]>>({});
   const [rawMode, setRawMode] = useState<RawMode>('text');
   const [resetNonce, setResetNonce] = useState(0);
+  const debugCacheHydratedRef = useRef<string | null>(null);
+  const skipNextDebugCacheWriteRef = useRef(false);
 
   // ── TASK-028: 校验错误与预览 ──
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
@@ -1647,9 +1740,9 @@ export default function ApiDebug() {
     setFormFields(initial.formFields);
     fileFieldsRef.current = {};
     setRawMode(initial.rawMode);
-    setCustomQueryParams([]);
-    setCustomHeaders([]);
-    setCustomCookies([]);
+    setCustomQueryParams(initial.customQueryParams);
+    setCustomHeaders(initial.customHeaders);
+    setCustomCookies(initial.customCookies);
     setBuiltRequest(null);
     setSseEvents(null);
     setValidationErrors([]);
@@ -1662,11 +1755,55 @@ export default function ApiDebug() {
 
   // 当 debugModel 变化时，同步初始化表单状态
   useEffect(() => {
-    if (!initialDebugState) return;
-    applyInitialDebugState(initialDebugState, { resetActiveTab: true });
+    if (!initialDebugState || !debugModel) return;
+    const cached = settings.enableRequestCache && debugCacheKey !== null ? readDebugCache(debugCacheKey) : null;
+    const nextInitial = restoreInitialDebugStateFromCache(initialDebugState, cached, debugModel);
+    skipNextDebugCacheWriteRef.current = true;
+    debugCacheHydratedRef.current = debugCacheKey;
+    applyInitialDebugState(nextInitial, { resetActiveTab: true });
     setResponse(null);
     setError(null);
-  }, [initialDebugState]);
+  }, [debugCacheKey, debugModel, initialDebugState, settings.enableRequestCache]);
+
+  useEffect(() => {
+    if (!settings.enableRequestCache || debugCacheKey === null || debugCacheHydratedRef.current !== debugCacheKey) {
+      return;
+    }
+    if (skipNextDebugCacheWriteRef.current) {
+      skipNextDebugCacheWriteRef.current = false;
+      return;
+    }
+    writeDebugCache(debugCacheKey, {
+      version: DEBUG_CACHE_VERSION,
+      baseUrl,
+      method,
+      path,
+      paramValues,
+      paramEnabled,
+      selectedContentType,
+      body,
+      formFields,
+      rawMode,
+      customQueryParams,
+      customHeaders,
+      customCookies,
+    });
+  }, [
+    baseUrl,
+    body,
+    customCookies,
+    customHeaders,
+    customQueryParams,
+    debugCacheKey,
+    formFields,
+    method,
+    paramEnabled,
+    paramValues,
+    path,
+    rawMode,
+    selectedContentType,
+    settings.enableRequestCache,
+  ]);
 
   const updateValue = (param: DebugParam, next: string) => {
     setParamValues((prev) => ({ ...prev, [paramKey(param)]: next }));
@@ -2153,6 +2290,10 @@ export default function ApiDebug() {
   const handleReset = () => {
     if (!initialDebugState) return;
     handleSseAbort();
+    if (settings.enableRequestCache && debugCacheKey !== null) {
+      removeDebugCache(debugCacheKey);
+      skipNextDebugCacheWriteRef.current = true;
+    }
     if (response?.objectUrl) {
       try {
         URL.revokeObjectURL(response.objectUrl);

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugCache.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugCache.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEBUG_CACHE_VERSION,
+  debugCacheStorageKey,
+  readDebugCache,
+  removeDebugCache,
+  writeDebugCache,
+  type DebugCacheState,
+  type DebugCacheStorage,
+} from './debugCache';
+
+class MemoryStorage implements DebugCacheStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+function makeState(): DebugCacheState {
+  return {
+    version: DEBUG_CACHE_VERSION,
+    baseUrl: 'http://localhost:8080',
+    method: 'POST',
+    path: '/users/{id}',
+    paramValues: {
+      'path:id': '42',
+      'query:name': 'alice',
+    },
+    paramEnabled: {
+      'path:id': true,
+      'query:name': false,
+    },
+    selectedContentType: 'application/json',
+    body: '{"name":"alice"}',
+    formFields: {
+      name: 'alice',
+    },
+    rawMode: 'json',
+    customQueryParams: [{ id: 'custom-query', name: 'debug', value: '1' }],
+    customHeaders: [{ id: 'custom-header', name: 'X-Trace', value: 'trace-1' }],
+    customCookies: [{ id: 'custom-cookie', name: 'sid', value: 'abc' }],
+  };
+}
+
+describe('debugCache', () => {
+  it('round-trips the debug cache under an encoded per-operation key', () => {
+    const storage = new MemoryStorage();
+    const cacheKey = 'default|用户|创建用户|POST|/users/{id}';
+    const state = makeState();
+
+    writeDebugCache(cacheKey, state, storage);
+
+    expect(storage.values.has(debugCacheStorageKey(cacheKey))).toBe(true);
+    expect(readDebugCache(cacheKey, storage)).toEqual(state);
+  });
+
+  it('normalizes malformed cache payloads before restoring them', () => {
+    const storage = new MemoryStorage();
+    const cacheKey = 'default|demo';
+    storage.setItem(
+      debugCacheStorageKey(cacheKey),
+      JSON.stringify({
+        version: DEBUG_CACHE_VERSION,
+        baseUrl: 'http://localhost:8080',
+        method: 'POST',
+        path: '/users',
+        paramValues: { 'query:name': 'alice', broken: 1 },
+        paramEnabled: { 'query:name': true, broken: 'yes' },
+        selectedContentType: 'application/json',
+        body: '{"name":"alice"}',
+        formFields: { name: 'alice', ignored: false },
+        rawMode: 'bogus',
+        customQueryParams: [
+          { id: 'q1', name: 'debug', value: '1' },
+          { id: 'bad', name: 2, value: 'x' },
+        ],
+        customHeaders: [{ id: 'h1', name: 'X-Trace', value: 'trace-1' }],
+        customCookies: 'not-array',
+      }),
+    );
+
+    expect(readDebugCache(cacheKey, storage)).toEqual({
+      version: DEBUG_CACHE_VERSION,
+      baseUrl: 'http://localhost:8080',
+      method: 'POST',
+      path: '/users',
+      paramValues: { 'query:name': 'alice' },
+      paramEnabled: { 'query:name': true },
+      selectedContentType: 'application/json',
+      body: '{"name":"alice"}',
+      formFields: { name: 'alice' },
+      rawMode: 'text',
+      customQueryParams: [{ id: 'q1', name: 'debug', value: '1' }],
+      customHeaders: [{ id: 'h1', name: 'X-Trace', value: 'trace-1' }],
+      customCookies: [],
+    });
+  });
+
+  it('ignores unsupported versions and removes cache entries', () => {
+    const storage = new MemoryStorage();
+    const cacheKey = 'default|demo';
+    storage.setItem(debugCacheStorageKey(cacheKey), JSON.stringify({ ...makeState(), version: 0 }));
+
+    expect(readDebugCache(cacheKey, storage)).toBeNull();
+
+    writeDebugCache(cacheKey, makeState(), storage);
+    removeDebugCache(cacheKey, storage);
+
+    expect(readDebugCache(cacheKey, storage)).toBeNull();
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugCache.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugCache.ts
@@ -1,0 +1,145 @@
+export const DEBUG_CACHE_VERSION = 1;
+
+const STORAGE_PREFIX = 'knife4j-next:debug-cache:';
+
+export type DebugCacheRawMode = 'text' | 'json' | 'javascript' | 'xml' | 'html';
+
+export interface DebugCacheCustomParamRow {
+  id: string;
+  name: string;
+  value: string;
+}
+
+export interface DebugCacheState {
+  version: typeof DEBUG_CACHE_VERSION;
+  baseUrl: string;
+  method: string;
+  path: string;
+  paramValues: Record<string, string>;
+  paramEnabled: Record<string, boolean>;
+  selectedContentType: string;
+  body: string;
+  formFields: Record<string, string>;
+  rawMode: DebugCacheRawMode;
+  customQueryParams: DebugCacheCustomParamRow[];
+  customHeaders: DebugCacheCustomParamRow[];
+  customCookies: DebugCacheCustomParamRow[];
+}
+
+export interface DebugCacheStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+const RAW_MODES = new Set<DebugCacheRawMode>(['text', 'json', 'javascript', 'xml', 'html']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function readStringRecord(value: unknown): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (!isRecord(value)) return result;
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'string') {
+      result[key] = item;
+    }
+  }
+  return result;
+}
+
+function readBooleanRecord(value: unknown): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  if (!isRecord(value)) return result;
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'boolean') {
+      result[key] = item;
+    }
+  }
+  return result;
+}
+
+function readRawMode(value: unknown): DebugCacheRawMode {
+  return typeof value === 'string' && RAW_MODES.has(value as DebugCacheRawMode) ? (value as DebugCacheRawMode) : 'text';
+}
+
+function readCustomRows(value: unknown): DebugCacheCustomParamRow[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (row): row is DebugCacheCustomParamRow =>
+      isRecord(row) && typeof row.id === 'string' && typeof row.name === 'string' && typeof row.value === 'string',
+  );
+}
+
+function getDebugCacheStorage(): DebugCacheStorage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDebugCacheState(value: unknown): DebugCacheState | null {
+  if (!isRecord(value) || value.version !== DEBUG_CACHE_VERSION) return null;
+  return {
+    version: DEBUG_CACHE_VERSION,
+    baseUrl: readString(value.baseUrl),
+    method: readString(value.method),
+    path: readString(value.path),
+    paramValues: readStringRecord(value.paramValues),
+    paramEnabled: readBooleanRecord(value.paramEnabled),
+    selectedContentType: readString(value.selectedContentType),
+    body: readString(value.body),
+    formFields: readStringRecord(value.formFields),
+    rawMode: readRawMode(value.rawMode),
+    customQueryParams: readCustomRows(value.customQueryParams),
+    customHeaders: readCustomRows(value.customHeaders),
+    customCookies: readCustomRows(value.customCookies),
+  };
+}
+
+export function debugCacheStorageKey(cacheKey: string): string {
+  return `${STORAGE_PREFIX}${encodeURIComponent(cacheKey)}`;
+}
+
+export function readDebugCache(
+  cacheKey: string,
+  storage: DebugCacheStorage | null = getDebugCacheStorage(),
+): DebugCacheState | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(debugCacheStorageKey(cacheKey));
+    if (!raw) return null;
+    return normalizeDebugCacheState(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeDebugCache(
+  cacheKey: string,
+  state: DebugCacheState,
+  storage: DebugCacheStorage | null = getDebugCacheStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(debugCacheStorageKey(cacheKey), JSON.stringify({ ...state, version: DEBUG_CACHE_VERSION }));
+  } catch {
+    // localStorage can be disabled or full; debug caching should never block the UI.
+  }
+}
+
+export function removeDebugCache(cacheKey: string, storage: DebugCacheStorage | null = getDebugCacheStorage()): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(debugCacheStorageKey(cacheKey));
+  } catch {
+    // ignore storage failures
+  }
+}

--- a/knife4j-front/knife4j-ui-react/src/types/settings.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/settings.ts
@@ -27,7 +27,7 @@ export interface AppSettings {
   enableHost: boolean;
   /** Host override text (used when enableHost=true). */
   enableHostText: string;
-  /** Whether request parameter cache is enabled. Reserved until the cache behavior is wired. */
+  /** Whether the debug panel restores the last filled request parameters for each operation. */
   enableRequestCache: boolean;
   /** Whether dynamic parameters are enabled. Reserved until dynamic parameter behavior is wired. */
   enableDynamicParameter: boolean;


### PR DESCRIPTION
## 关联 Issue

- Fixes #386

## 变更内容

- 为 React 调试页接入已有的 `enableRequestCache` 开关，按接口维度恢复上次填写的 path、query、header、cookie、body 和自定义参数。
- 新增 `debugCache` helper，使用版本号和类型过滤读取缓存，避免坏数据影响调试页渲染。
- `重置` 会清理当前接口缓存；OpenAPI 文档的 body content-type 变化时不会套用旧 body/form 字段。
- 更新设置类型注释，去掉“预留未接线”的过期说明。

## 协作门禁

- worker：跳过。原因是当前 Codex 运行策略不允许在用户未显式授权时启动子 agent，本次由 coordinator 直接实现；风险是缺少独立实现 handoff。
- reviewer：跳过。原因同上，本 PR 未声称已独立审查；issue 暂不切到 `status:review`，等待维护者 review/CI 结果。

## 验证

- `bun run --filter knife4j-ui-react test src/pages/api/debugCache.test.ts`
- `env TMPDIR=/private/tmp BUN_INSTALL_CACHE_DIR=/private/tmp/bun-cache ./scripts/test-front-core.sh`
- `git diff --check`
- 浏览器冒烟：本地 mock backend + Vite，填入 path/query/header/body 并发送后，打开第二个接口标签，再回到第一个接口调试页，已填写值可以恢复。

## 风险

- multipart 文件对象不缓存，只缓存可序列化的文本参数；这符合浏览器文件对象不能持久化恢复的限制。
- 未执行独立 reviewer agent 审查，需维护者在 PR 中完成最终审查。