### PR TITLE
release: 移除 Release 正文自动追加 Links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,7 @@ jobs:
         run: |
           version="${GITHUB_REF_NAME#v}"
           release_notes="$RUNNER_TEMP/github-release-notes.md"
-          {
-            scripts/extract-release-note.sh "$version"
-            echo ""
-            echo "## Links"
-            echo ""
-            echo "- 文档站：https://knife4j-next.baizhukui.com/release-notes/"
-            echo "- Maven Central：https://repo1.maven.org/maven2/com/baizhukui/"
-          } > "$release_notes"
+          scripts/extract-release-note.sh "$version" > "$release_notes"
           echo "GITHUB_RELEASE_NOTES=$release_notes" >> "$GITHUB_ENV"
         working-directory: .
 


### PR DESCRIPTION
## 关联 Issue

- Closes #393

## 变更内容

- 调整 `.github/workflows/release.yml` 的 `Prepare GitHub Release notes` 步骤。
- GitHub Release notes 文件现在只来自 `scripts/extract-release-note.sh "$version"`。
- 移除 workflow 自动追加的 `Links` 区块，使后续 Release body 与 `docs-site/release-notes/index.md` 对应版本小节保持严格一致。

## 验证

- `scripts/extract-release-note.sh 5.0.5`：通过，输出 `5.0.5` 小节。
- `bash -n scripts/extract-release-note.sh scripts/verify-github-release.sh scripts/verify-release-modules.sh`：通过。
- `git diff --check`：通过。

## 协作门禁

- worker：跳过。本任务是维护者在发布后明确要求继续处理的 release workflow 收口，改动限定为 `.github/workflows/release.yml` 中生成 release notes 的一行逻辑；当前 Codex 系统也只允许在用户显式要求子 agent 时启动子 agent。
- reviewer：跳过。未声称已独立审查；本 PR 保持 draft，等待维护者 review。issue 暂不切到 `status:review`。

## 风险说明

- 不修改 Maven Central 发布命令、发布凭据、模块清单或 tag 触发条件。
- 后续 GitHub Release 不再带 workflow 自动追加的文档站和 Maven Central 链接，Release body 会与 release note 小节严格一致。