### PR TITLE
修复接口调试标签状态丢失

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -138,15 +138,7 @@ const AppInner: React.FC = () => {
   /** Keep the outer API tab key aligned with the selected operation child page. */
   useEffect(() => {
     if (activeGroup.apis.length === 0) return;
-
-    // `useLocation().pathname` is URL-encoded; ApiItem.key stores the decoded
-    // form (e.g. Chinese tag names), so normalize before matching.
-    let pathname: string;
-    try {
-      pathname = decodeURIComponent(location.pathname);
-    } catch {
-      pathname = location.pathname;
-    }
+    const pathname = location.pathname;
 
     if (!isOperationRouteKey(pathname)) return;
 

--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -12,6 +12,12 @@ import { SUPPORTED_LANGS, type SupportedLang } from './types/settings';
 import SidebarSearchMenu from './compoents/SidebarSearchMenu';
 import SettingsDrawer from './compoents/SettingsDrawer';
 import knife4jMark from './assets/logo/knife4j-next-mark.svg';
+import {
+  findOperationRouteKey,
+  isOperationRouteKey,
+  routeKeyToMenuKey,
+  upsertOperationRoutePane,
+} from './utils/operationTabs';
 
 const { Header, Sider, Content, Footer } = Layout;
 type TargetKey = React.MouseEvent | React.KeyboardEvent | string;
@@ -32,23 +38,6 @@ const normalizeLang = (raw: string | undefined): SupportedLang => {
   if (lower.startsWith('en')) return 'en-US';
   return 'zh-CN';
 };
-
-/**
- * Strip the trailing `/doc` or `/debug` mode segment from a route key to
- * obtain the corresponding sidebar menu key.
- */
-const routeKeyToMenuKey = (key: string) =>
-  key.endsWith('/doc')
-    ? key.slice(0, -4)
-    : key.endsWith('/debug')
-      ? key.slice(0, -6)
-      : key.endsWith('/openapi')
-        ? key.slice(0, -8)
-        : key.endsWith('/script')
-          ? key.slice(0, -7)
-          : key.includes('/schema')
-            ? key.replace(/\/schema\/.*$/, '/schema')
-            : key;
 
 const schemaRouteInfo = (key: string): { menuKey: string; labelSchema?: string } | null => {
   const match = key.match(/^\/([^/]+)\/schema(?:\/(.+))?$/);
@@ -146,14 +135,8 @@ const AppInner: React.FC = () => {
     }
   }, [items, activeKey]);
 
-  /**
-   * If the URL points at an operation route but the corresponding tab was
-   * not restored from sessionStorage (e.g. direct deep-link from another
-   * place), inject it once `activeGroup.apis` is loaded.
-   */
-  const restoredRef = useRef(false);
+  /** Keep the outer API tab key aligned with the selected operation child page. */
   useEffect(() => {
-    if (restoredRef.current) return;
     if (activeGroup.apis.length === 0) return;
 
     // `useLocation().pathname` is URL-encoded; ApiItem.key stores the decoded
@@ -165,25 +148,14 @@ const AppInner: React.FC = () => {
       pathname = location.pathname;
     }
 
-    const isApiRoute =
-      pathname.endsWith('/doc') ||
-      pathname.endsWith('/debug') ||
-      pathname.endsWith('/openapi') ||
-      pathname.endsWith('/script');
-    if (!isApiRoute) {
-      restoredRef.current = true;
-      return;
-    }
+    if (!isOperationRouteKey(pathname)) return;
 
     const menuKey = routeKeyToMenuKey(pathname);
     const api = activeGroup.apis.find((a) => a.key === menuKey);
     if (!api) return; // apis loaded but this one didn't match; wait for other groups
 
-    restoredRef.current = true;
     const title = `${api.method.toUpperCase()} ${api.summary}`;
-    setItems((prev) =>
-      prev.some((p) => p.key === pathname) ? prev : [...prev, { label: title, children: '', key: pathname }],
-    );
+    setItems((prev) => upsertOperationRoutePane(prev, pathname, title, (key, label) => ({ label, children: '', key })));
     setActiveKey(pathname);
     setSelectedKey(menuKey);
   }, [activeGroup.apis, location.pathname]);
@@ -252,7 +224,8 @@ const AppInner: React.FC = () => {
     const rawKey = String(info.key);
     const schemaInfo = schemaRouteInfo(rawKey);
     const markdownDoc: MarkdownDocItem | undefined = markdownDocs.find((doc) => doc.key === rawKey);
-    const newActiveKey = schemaInfo || markdownDoc ? rawKey : `${rawKey}/doc`;
+    const existingOperationKey = schemaInfo || markdownDoc ? null : findOperationRouteKey(items, rawKey);
+    const newActiveKey = schemaInfo || markdownDoc ? rawKey : (existingOperationKey ?? `${rawKey}/doc`);
     const tabExists = items.some((pane) => pane.key === newActiveKey);
     if (!tabExists) {
       const api: ApiItem | undefined = activeGroup.apis.find((a) => a.key === rawKey);

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   AutoComplete,
@@ -1708,6 +1708,8 @@ export default function ApiDebug() {
   const [builtRequest, setBuiltRequest] = useState<BuiltRequest | null>(null);
   const [sseEvents, setSseEvents] = useState<SseEvent[] | null>(null);
   const sseAbortRef = useRef<AbortController | null>(null);
+  const activeDebugCacheKeyRef = useRef<string | null>(null);
+  const requestSeqRef = useRef(0);
 
   // ── requestBody 多内容类型状态 ──
   const [selectedContentType, setSelectedContentType] = useState('');
@@ -1715,7 +1717,7 @@ export default function ApiDebug() {
   const fileFieldsRef = useRef<Record<string, File[]>>({});
   const [rawMode, setRawMode] = useState<RawMode>('text');
   const [resetNonce, setResetNonce] = useState(0);
-  const debugCacheHydratedRef = useRef<string | null>(null);
+  const [hydratedDebugCacheKey, setHydratedDebugCacheKey] = useState<string | null>(null);
   const skipNextDebugCacheWriteRef = useRef(false);
 
   // ── TASK-028: 校验错误与预览 ──
@@ -1729,6 +1731,10 @@ export default function ApiDebug() {
     if (!debugModel || !operation) return null;
     return buildInitialDebugState(debugModel, operation, defaultBaseUrl);
   }, [debugModel, operation, defaultBaseUrl]);
+
+  useLayoutEffect(() => {
+    activeDebugCacheKeyRef.current = debugCacheKey;
+  }, [debugCacheKey]);
 
   const applyInitialDebugState = (initial: InitialDebugState, options: { resetActiveTab?: boolean } = {}) => {
     setBaseUrl(initial.baseUrl);
@@ -1760,17 +1766,21 @@ export default function ApiDebug() {
     const cached = settings.enableRequestCache && debugCacheKey !== null ? readDebugCache(debugCacheKey) : null;
     const nextInitial = restoreInitialDebugStateFromCache(initialDebugState, cached, debugModel);
     skipNextDebugCacheWriteRef.current = true;
-    debugCacheHydratedRef.current = debugCacheKey;
+    requestSeqRef.current += 1;
+    sseAbortRef.current?.abort();
+    sseAbortRef.current = null;
     const cachedSession = debugCacheKey !== null ? readDebugSessionState(debugCacheKey) : null;
     applyInitialDebugState(nextInitial, { resetActiveTab: true });
+    setLoading(false);
     setResponse(cachedSession?.response ?? null);
     setError(cachedSession?.error ?? null);
     setBuiltRequest(cachedSession?.builtRequest ?? null);
     setSseEvents(cachedSession?.sseEvents ?? null);
+    setHydratedDebugCacheKey(debugCacheKey);
   }, [debugCacheKey, debugModel, initialDebugState, settings.enableRequestCache]);
 
   useEffect(() => {
-    if (debugCacheKey === null || debugCacheHydratedRef.current !== debugCacheKey) return;
+    if (debugCacheKey === null || hydratedDebugCacheKey !== debugCacheKey) return;
     if (!response && !error && !builtRequest && sseEvents === null) {
       removeDebugSessionState(debugCacheKey);
       return;
@@ -1781,10 +1791,10 @@ export default function ApiDebug() {
       builtRequest,
       sseEvents,
     });
-  }, [builtRequest, debugCacheKey, error, response, sseEvents]);
+  }, [builtRequest, debugCacheKey, error, hydratedDebugCacheKey, response, sseEvents]);
 
   useEffect(() => {
-    if (!settings.enableRequestCache || debugCacheKey === null || debugCacheHydratedRef.current !== debugCacheKey) {
+    if (!settings.enableRequestCache || debugCacheKey === null || hydratedDebugCacheKey !== debugCacheKey) {
       return;
     }
     if (skipNextDebugCacheWriteRef.current) {
@@ -1821,6 +1831,7 @@ export default function ApiDebug() {
     rawMode,
     selectedContentType,
     settings.enableRequestCache,
+    hydratedDebugCacheKey,
   ]);
 
   const updateValue = (param: DebugParam, next: string) => {
@@ -2128,6 +2139,11 @@ export default function ApiDebug() {
     // multipart 场景：需要手动构建 FormData（requestBuilder 只处理文本字段）
     const category = getCurrentCategory();
     const isMultipart = category === 'multipart';
+    const requestDebugCacheKey = debugCacheKey;
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
+    const isCurrentDebugRequest = () =>
+      activeDebugCacheKeyRef.current === requestDebugCacheKey && requestSeqRef.current === requestSeq;
 
     setLoading(true);
     // Revoke any previous object URL to avoid memory leaks across consecutive sends.
@@ -2142,8 +2158,9 @@ export default function ApiDebug() {
     setSseEvents(null);
     setBuiltRequest(built);
     const start = Date.now();
+    let abortController: AbortController | null = null;
     try {
-      const abortController = new AbortController();
+      abortController = new AbortController();
       sseAbortRef.current = abortController;
 
       const init: RequestInit = {
@@ -2204,6 +2221,7 @@ export default function ApiDebug() {
       res.headers.forEach((value, key) => {
         responseHeaders[key] = value;
       });
+      if (!isCurrentDebugRequest()) return;
 
       const contentType = responseHeaders['content-type'] ?? '';
 
@@ -2230,6 +2248,7 @@ export default function ApiDebug() {
         setSseEvents([]);
 
         const processChunk = (chunk: string) => {
+          if (!isCurrentDebugRequest()) return;
           buffer += chunk;
           const lines = buffer.split('\n');
           buffer = lines.pop() ?? '';
@@ -2247,21 +2266,28 @@ export default function ApiDebug() {
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
+            if (!isCurrentDebugRequest()) return;
             processChunk(decoder.decode(value, { stream: true }));
           }
           // flush remaining buffer
           if (buffer.trim().startsWith('data:')) {
             const data = buffer.trim().slice(5).trimStart();
-            if (data) setSseEvents((prev) => [...(prev ?? []), { data, timestamp: Date.now() }]);
+            if (data && isCurrentDebugRequest()) {
+              setSseEvents((prev) => [...(prev ?? []), { data, timestamp: Date.now() }]);
+            }
           }
         } catch (err: unknown) {
-          if (err instanceof Error && err.name === 'AbortError') {
+          if (!isCurrentDebugRequest()) {
+            return;
+          } else if (err instanceof Error && err.name === 'AbortError') {
             // user aborted — not an error
           } else {
             setError(err instanceof Error ? err.message : String(err));
           }
         } finally {
-          sseAbortRef.current = null;
+          if (sseAbortRef.current === abortController) {
+            sseAbortRef.current = null;
+          }
         }
         return;
       }
@@ -2276,6 +2302,12 @@ export default function ApiDebug() {
         built.url,
         contentDisposition,
       );
+      if (!isCurrentDebugRequest()) {
+        if (objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+        }
+        return;
+      }
 
       setResponse({
         status: res.status,
@@ -2291,12 +2323,17 @@ export default function ApiDebug() {
         kind,
       });
     } catch (reason: unknown) {
+      if (!isCurrentDebugRequest()) return;
       if (!(reason instanceof Error && reason.name === 'AbortError')) {
         setError(reason instanceof Error ? reason.message : String(reason));
       }
     } finally {
-      setLoading(false);
-      sseAbortRef.current = null;
+      if (isCurrentDebugRequest()) {
+        setLoading(false);
+      }
+      if (sseAbortRef.current === abortController) {
+        sseAbortRef.current = null;
+      }
     }
   };
 

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -62,6 +62,7 @@ import {
   type DebugCacheRawMode,
   type DebugCacheState,
 } from './debugCache';
+import { readDebugSessionState, removeDebugSessionState, writeDebugSessionState } from './debugSessionState';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
@@ -1760,10 +1761,27 @@ export default function ApiDebug() {
     const nextInitial = restoreInitialDebugStateFromCache(initialDebugState, cached, debugModel);
     skipNextDebugCacheWriteRef.current = true;
     debugCacheHydratedRef.current = debugCacheKey;
+    const cachedSession = debugCacheKey !== null ? readDebugSessionState(debugCacheKey) : null;
     applyInitialDebugState(nextInitial, { resetActiveTab: true });
-    setResponse(null);
-    setError(null);
+    setResponse(cachedSession?.response ?? null);
+    setError(cachedSession?.error ?? null);
+    setBuiltRequest(cachedSession?.builtRequest ?? null);
+    setSseEvents(cachedSession?.sseEvents ?? null);
   }, [debugCacheKey, debugModel, initialDebugState, settings.enableRequestCache]);
+
+  useEffect(() => {
+    if (debugCacheKey === null || debugCacheHydratedRef.current !== debugCacheKey) return;
+    if (!response && !error && !builtRequest && sseEvents === null) {
+      removeDebugSessionState(debugCacheKey);
+      return;
+    }
+    writeDebugSessionState(debugCacheKey, {
+      response,
+      error,
+      builtRequest,
+      sseEvents,
+    });
+  }, [builtRequest, debugCacheKey, error, response, sseEvents]);
 
   useEffect(() => {
     if (!settings.enableRequestCache || debugCacheKey === null || debugCacheHydratedRef.current !== debugCacheKey) {
@@ -2293,6 +2311,9 @@ export default function ApiDebug() {
     if (settings.enableRequestCache && debugCacheKey !== null) {
       removeDebugCache(debugCacheKey);
       skipNextDebugCacheWriteRef.current = true;
+    }
+    if (debugCacheKey !== null) {
+      removeDebugSessionState(debugCacheKey);
     }
     if (response?.objectUrl) {
       try {

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearDebugSessionStatesForTest,
+  readDebugSessionState,
+  removeDebugSessionState,
+  writeDebugSessionState,
+  type DebugSessionState,
+} from './debugSessionState';
+
+function makeState(): DebugSessionState {
+  return {
+    response: {
+      status: 200,
+      statusText: 'OK',
+      method: 'GET',
+      duration: 12,
+      contentType: 'application/json',
+      size: 13,
+      headers: { 'content-type': 'application/json' },
+      rawText: '{"ok":true}',
+      kind: 'json',
+    },
+    error: null,
+    builtRequest: {
+      url: 'http://localhost:8080/pets',
+      method: 'GET',
+      headers: {},
+    },
+    sseEvents: null,
+  };
+}
+
+describe('debugSessionState', () => {
+  afterEach(() => {
+    clearDebugSessionStatesForTest();
+  });
+
+  it('keeps response state isolated by operation cache key', () => {
+    const firstKey = 'default|Pet|list|GET|/pets';
+    const secondKey = 'default|Pet|create|POST|/pets';
+    const firstState = makeState();
+    const secondState = {
+      ...makeState(),
+      response: { ...makeState().response!, status: 201, method: 'POST' },
+    };
+
+    writeDebugSessionState(firstKey, firstState);
+    writeDebugSessionState(secondKey, secondState);
+
+    expect(readDebugSessionState(firstKey)).toEqual(firstState);
+    expect(readDebugSessionState(secondKey)).toEqual(secondState);
+  });
+
+  it('removes stale response state for one operation only', () => {
+    const firstKey = 'default|Pet|list|GET|/pets';
+    const secondKey = 'default|Pet|create|POST|/pets';
+
+    writeDebugSessionState(firstKey, makeState());
+    writeDebugSessionState(secondKey, makeState());
+    removeDebugSessionState(firstKey);
+
+    expect(readDebugSessionState(firstKey)).toBeNull();
+    expect(readDebugSessionState(secondKey)).not.toBeNull();
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   clearDebugSessionStatesForTest,
   readDebugSessionState,
@@ -30,9 +30,22 @@ function makeState(): DebugSessionState {
   };
 }
 
+function makeObjectUrlState(objectUrl: string): DebugSessionState {
+  return {
+    ...makeState(),
+    response: {
+      ...makeState().response!,
+      kind: 'binary',
+      rawText: '',
+      objectUrl,
+    },
+  };
+}
+
 describe('debugSessionState', () => {
   afterEach(() => {
     clearDebugSessionStatesForTest();
+    vi.restoreAllMocks();
   });
 
   it('keeps response state isolated by operation cache key', () => {
@@ -61,5 +74,50 @@ describe('debugSessionState', () => {
 
     expect(readDebugSessionState(firstKey)).toBeNull();
     expect(readDebugSessionState(secondKey)).not.toBeNull();
+  });
+
+  it('revokes object URLs when removing response state', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const key = 'default|Pet|download|GET|/pets/export';
+
+    writeDebugSessionState(key, makeObjectUrlState('blob:http://localhost/download'));
+    removeDebugSessionState(key);
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/download');
+  });
+
+  it('revokes the previous object URL when overwriting with a different response', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const key = 'default|Pet|download|GET|/pets/export';
+
+    writeDebugSessionState(key, makeObjectUrlState('blob:http://localhost/old'));
+    writeDebugSessionState(key, makeObjectUrlState('blob:http://localhost/new'));
+
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/old');
+    expect(readDebugSessionState(key)?.response?.objectUrl).toBe('blob:http://localhost/new');
+  });
+
+  it('does not revoke an object URL when writing the same response URL again', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    const key = 'default|Pet|download|GET|/pets/export';
+
+    writeDebugSessionState(key, makeObjectUrlState('blob:http://localhost/stable'));
+    writeDebugSessionState(key, makeObjectUrlState('blob:http://localhost/stable'));
+
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('revokes all cached object URLs when clearing session states', () => {
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+
+    writeDebugSessionState('first', makeObjectUrlState('blob:http://localhost/first'));
+    writeDebugSessionState('second', makeObjectUrlState('blob:http://localhost/second'));
+    clearDebugSessionStatesForTest();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/first');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/second');
+    expect(readDebugSessionState('first')).toBeNull();
+    expect(readDebugSessionState('second')).toBeNull();
   });
 });

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.ts
@@ -10,18 +10,38 @@ export interface DebugSessionState {
 
 const debugSessionStates = new Map<string, DebugSessionState>();
 
+function revokeResponseObjectUrl(response: DebugResponsePayload | null | undefined): void {
+  const objectUrl = response?.objectUrl;
+  if (!objectUrl) return;
+  try {
+    globalThis.URL?.revokeObjectURL?.(objectUrl);
+  } catch {
+    // Best effort only: failing to revoke must not break tab state cleanup.
+  }
+}
+
+function revokeSessionObjectUrl(state: DebugSessionState | null | undefined): void {
+  revokeResponseObjectUrl(state?.response);
+}
+
 export function readDebugSessionState(cacheKey: string): DebugSessionState | null {
   return debugSessionStates.get(cacheKey) ?? null;
 }
 
 export function writeDebugSessionState(cacheKey: string, state: DebugSessionState): void {
+  const previousState = debugSessionStates.get(cacheKey);
+  if (previousState?.response?.objectUrl !== state.response?.objectUrl) {
+    revokeSessionObjectUrl(previousState);
+  }
   debugSessionStates.set(cacheKey, state);
 }
 
 export function removeDebugSessionState(cacheKey: string): void {
+  revokeSessionObjectUrl(debugSessionStates.get(cacheKey));
   debugSessionStates.delete(cacheKey);
 }
 
 export function clearDebugSessionStatesForTest(): void {
+  debugSessionStates.forEach((state) => revokeSessionObjectUrl(state));
   debugSessionStates.clear();
 }

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugSessionState.ts
@@ -1,0 +1,27 @@
+import type { BuiltRequest } from 'knife4j-core';
+import type { DebugResponsePayload, SseEvent } from './ResponsePanel';
+
+export interface DebugSessionState {
+  response: DebugResponsePayload | null;
+  error: string | null;
+  builtRequest: BuiltRequest | null;
+  sseEvents: SseEvent[] | null;
+}
+
+const debugSessionStates = new Map<string, DebugSessionState>();
+
+export function readDebugSessionState(cacheKey: string): DebugSessionState | null {
+  return debugSessionStates.get(cacheKey) ?? null;
+}
+
+export function writeDebugSessionState(cacheKey: string, state: DebugSessionState): void {
+  debugSessionStates.set(cacheKey, state);
+}
+
+export function removeDebugSessionState(cacheKey: string): void {
+  debugSessionStates.delete(cacheKey);
+}
+
+export function clearDebugSessionStatesForTest(): void {
+  debugSessionStates.clear();
+}

--- a/knife4j-front/knife4j-ui-react/src/utils/operationTabs.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/operationTabs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { findOperationRouteKey, routeKeyToMenuKey, upsertOperationRoutePane } from './operationTabs';
+
+interface Pane {
+  key: string;
+  label: string;
+  children: string;
+}
+
+const createPane = (key: string, label: string): Pane => ({ key, label, children: '' });
+
+describe('operationTabs', () => {
+  it('maps operation child routes back to their sidebar menu key', () => {
+    expect(routeKeyToMenuKey('/default/Pet/list/doc')).toBe('/default/Pet/list');
+    expect(routeKeyToMenuKey('/default/Pet/list/debug')).toBe('/default/Pet/list');
+    expect(routeKeyToMenuKey('/default/Pet/list/openapi')).toBe('/default/Pet/list');
+    expect(routeKeyToMenuKey('/default/Pet/list/script')).toBe('/default/Pet/list');
+  });
+
+  it('finds an existing operation tab regardless of the selected child page', () => {
+    const items = [createPane('/group/home', 'Home'), createPane('/default/Pet/list/debug', 'GET list')];
+
+    expect(findOperationRouteKey(items, '/default/Pet/list')).toBe('/default/Pet/list/debug');
+  });
+
+  it('replaces the operation tab key when the selected child page changes', () => {
+    const items = [
+      createPane('/group/home', 'Home'),
+      createPane('/default/Pet/list/doc', 'GET list'),
+      createPane('/default/Store/list/doc', 'GET stores'),
+    ];
+
+    expect(upsertOperationRoutePane(items, '/default/Pet/list/debug', 'GET list', createPane)).toEqual([
+      createPane('/group/home', 'Home'),
+      createPane('/default/Pet/list/debug', 'GET list'),
+      createPane('/default/Store/list/doc', 'GET stores'),
+    ]);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/utils/operationTabs.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/operationTabs.test.ts
@@ -15,12 +15,22 @@ describe('operationTabs', () => {
     expect(routeKeyToMenuKey('/default/Pet/list/debug')).toBe('/default/Pet/list');
     expect(routeKeyToMenuKey('/default/Pet/list/openapi')).toBe('/default/Pet/list');
     expect(routeKeyToMenuKey('/default/Pet/list/script')).toBe('/default/Pet/list');
+    expect(routeKeyToMenuKey('/default/%E7%94%A8%E6%88%B7%E6%8E%A5%E5%8F%A3/UserController_list/debug')).toBe(
+      '/default/%E7%94%A8%E6%88%B7%E6%8E%A5%E5%8F%A3/UserController_list',
+    );
   });
 
   it('finds an existing operation tab regardless of the selected child page', () => {
-    const items = [createPane('/group/home', 'Home'), createPane('/default/Pet/list/debug', 'GET list')];
+    const items = [
+      createPane('/group/home', 'Home'),
+      createPane('/default/Pet/list/debug', 'GET list'),
+      createPane('/default/%E7%94%A8%E6%88%B7%E6%8E%A5%E5%8F%A3/UserController_list/debug', 'GET list'),
+    ];
 
     expect(findOperationRouteKey(items, '/default/Pet/list')).toBe('/default/Pet/list/debug');
+    expect(findOperationRouteKey(items, '/default/%E7%94%A8%E6%88%B7%E6%8E%A5%E5%8F%A3/UserController_list')).toBe(
+      '/default/%E7%94%A8%E6%88%B7%E6%8E%A5%E5%8F%A3/UserController_list/debug',
+    );
   });
 
   it('replaces the operation tab key when the selected child page changes', () => {

--- a/knife4j-front/knife4j-ui-react/src/utils/operationTabs.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/operationTabs.ts
@@ -1,0 +1,53 @@
+const OPERATION_MODE_SUFFIXES = ['/doc', '/debug', '/openapi', '/script'] as const;
+
+/**
+ * Strip the trailing operation mode segment from a route key to obtain the
+ * corresponding sidebar menu key.
+ */
+export const routeKeyToMenuKey = (key: string) =>
+  key.endsWith('/doc')
+    ? key.slice(0, -4)
+    : key.endsWith('/debug')
+      ? key.slice(0, -6)
+      : key.endsWith('/openapi')
+        ? key.slice(0, -8)
+        : key.endsWith('/script')
+          ? key.slice(0, -7)
+          : key.includes('/schema')
+            ? key.replace(/\/schema\/.*$/, '/schema')
+            : key;
+
+export function isOperationRouteKey(key: string): boolean {
+  return OPERATION_MODE_SUFFIXES.some((suffix) => key.endsWith(suffix));
+}
+
+export function findOperationRouteKey(items: Array<{ key: string }>, menuKey: string): string | null {
+  return items.find((item) => isOperationRouteKey(item.key) && routeKeyToMenuKey(item.key) === menuKey)?.key ?? null;
+}
+
+export function upsertOperationRoutePane<T extends { key: string; label: string }>(
+  items: T[],
+  routeKey: string,
+  label: string,
+  createPane: (key: string, label: string) => T,
+): T[] {
+  const existingRouteIndex = items.findIndex((item) => item.key === routeKey);
+  if (existingRouteIndex >= 0) {
+    const existingRoutePane = items[existingRouteIndex];
+    if (existingRoutePane.label === label) return items;
+    return items.map((item, index) => (index === existingRouteIndex ? ({ ...item, label } as T) : item));
+  }
+
+  const menuKey = routeKeyToMenuKey(routeKey);
+  const operationRouteIndex = items.findIndex(
+    (item) => isOperationRouteKey(item.key) && routeKeyToMenuKey(item.key) === menuKey,
+  );
+
+  if (operationRouteIndex >= 0) {
+    return items.map((item, index) =>
+      index === operationRouteIndex ? ({ ...item, key: routeKey, label } as T) : item,
+    );
+  }
+
+  return [...items, createPane(routeKey, label)];
+}


### PR DESCRIPTION
## 关联 Issue

- Fixes #395

## 变更内容

- 将同一接口的 `doc`、`debug`、`openapi`、`script` 子页视为同一个外层接口标签，并在子页切换时同步更新标签 key。
- 点击已打开接口时复用该接口最近停留的子页，避免从接口 2 切回接口 1 时自动回到 `doc`。
- 为 `ApiDebug` 增加按接口维度隔离的内存响应状态，切换接口标签后再返回可以保留上次响应、错误信息、构造请求和 SSE 事件展示。
- 保留 #386 已有请求参数缓存逻辑，不修改 Vue3/OAS2、Java、文档、发布或 CI。

## 协作门禁

- worker：已执行，完成 React/OAS3 标签状态与调试响应状态的最小修复，并补充纯逻辑测试。
- reviewer：已执行，独立 reviewer 结论为 `approve`，无发现、无验证缺口、无范围漂移。

## 验证

- `bun run test --run src/utils/operationTabs.test.ts src/pages/api/debugSessionState.test.ts`
- `./scripts/test-front-core.sh`
- `git diff --check`

## 风险

- 响应结果保留为页面生命周期内的内存状态，不跨浏览器刷新持久化；请求参数缓存仍沿用现有 `enableRequestCache` 行为。