### PR TITLE
fix: 移除 Document 动态 eval 正则

### DIFF
--- a/knife4j-vue3/src/views/api/Document.vue
+++ b/knife4j-vue3/src/views/api/Document.vue
@@ -184,6 +184,18 @@
  import { message } from 'ant-design-vue'
  import { UnlockOutlined } from '@ant-design/icons-vue'
 
+ function escapeRegExp(value) {
+   return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+ }
+
+ function matchesIgnoreParameterName(name, key) {
+   const escapedKey = escapeRegExp(key);
+   return (
+     new RegExp(`^(${escapedKey}$|${escapedKey}[.\\[])`).test(name) ||
+     new RegExp(escapedKey, "g").test(name)
+   );
+ }
+
  export default {
    name: "Document",
    components: {
@@ -482,7 +494,7 @@
                                `${param.name}.${name}`
                              ) ||
                              ignoreParameterAllKeys.some(key =>
-                               new RegExp(`^(${key}$|${key}[.[])`).test(name) || eval('/' + key + '/g').test(name)
+                               matchesIgnoreParameterName(name, key)
                              )
                            ) //  处理 json 提交
                          );


### PR DESCRIPTION
## 关联 Issue

- Multica BAI-8：Vue3 去掉 Document.vue 构建期 eval 警告

## 变更内容

- 在 `knife4j-vue3/src/views/api/Document.vue` 增加 `escapeRegExp` 和匹配封装。
- 将请求参数过滤中的 `eval('/' + key + '/g')` 替换为转义后的 `new RegExp()`。
- 同步转义该分支里的动态前缀正则，避免 `.`、`[`、`$` 等特殊字符破坏匹配。

## 验证

- `bun install --frozen-lockfile`
- `bun run build`
- `bun -e ...` 手动覆盖 `a.b`、`items[0]`、`foo[`、`price$` 等特殊字符 key 匹配用例

构建通过；`Document.vue` 不再输出 eval 警告。当前构建仍会报告既有依赖 `node_modules/js-md5/src/md5.js` 内部 eval 警告，非本次改动范围。

## 协作门禁

- worker：本运行环境没有独立 worker handoff 工具，本次按窄范围例外由 coordinator 直接处理。
- reviewer：未做独立 reviewer handoff，PR 保持 draft，等待维护者/人工 review。

## 风险

- 改动限制在 OAS2 Vue3 文档参数过滤逻辑；行为上将动态 key 按字面量匹配，避免特殊字符被当作正则语法解释。