### PR TITLE
fix: 统一 Jakarta Swagger 依赖版本

### DIFF
--- a/docs-site/reference/version-ref.md
+++ b/docs-site/reference/version-ref.md
@@ -41,7 +41,7 @@ title: 版本对照
 | Spring Framework | `6.2.0` |
 | Spring Boot | `3.4.0` |
 | springdoc-openapi Jakarta | `2.8.9` |
-| Swagger v3 models | `2.2.26` |
+| Swagger v3 Jakarta models | `2.2.47` |
 | Servlet Jakarta API | `6.1.0` |
 
 > smoke-tests 中 `boot3-jakarta-app` 使用 Boot `3.4.5`，`boot35-jakarta-app` 使用 Boot `3.5.0`，均通过验证。

--- a/knife4j/knife4j-dependencies/pom.xml
+++ b/knife4j/knife4j-dependencies/pom.xml
@@ -60,7 +60,17 @@
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-annotations-jakarta</artifactId>
-                <version>${knife4j-swagger-models-v3.version}</version>
+                <version>${knife4j-swagger-models-v3-jakarta.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-models-jakarta</artifactId>
+                <version>${knife4j-swagger-models-v3-jakarta.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core-jakarta</artifactId>
+                <version>${knife4j-swagger-models-v3-jakarta.version}</version>
             </dependency>
 
             <dependency>

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -63,6 +63,7 @@
         <knife4j-springdoc-openapi-jakarta.version>2.8.9</knife4j-springdoc-openapi-jakarta.version>
         <knife4j-springdoc-openapi-boot4.version>3.0.3</knife4j-springdoc-openapi-boot4.version>
         <knife4j-swagger-models-v3.version>2.2.26</knife4j-swagger-models-v3.version>
+        <knife4j-swagger-models-v3-jakarta.version>2.2.47</knife4j-swagger-models-v3-jakarta.version>
         <knife4j-swagger-models-v3-boot4.version>2.2.47</knife4j-swagger-models-v3-boot4.version>
 
         <knife4j-servlet.version>4.0.1</knife4j-servlet.version>
@@ -167,6 +168,21 @@
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-models</artifactId>
                 <version>${knife4j-swagger-models-v3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations-jakarta</artifactId>
+                <version>${knife4j-swagger-models-v3-jakarta.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-models-jakarta</artifactId>
+                <version>${knife4j-swagger-models-v3-jakarta.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core-jakarta</artifactId>
+                <version>${knife4j-swagger-models-v3-jakarta.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/io.swagger/swagger-models -->


### PR DESCRIPTION
## 关联 Issue

Closes #400

## 问题原因

`knife4j-dependencies` BOM 只管理了 `swagger-annotations-jakarta`，且版本跟随通用 Swagger v3 `2.2.26`；同时没有显式管理 `swagger-models-jakarta` 与 `swagger-core-jakarta`。用户项目导入 BOM 后，Jakarta 线可能把 springdoc 需要的 Swagger v3 运行期依赖降级，进而触发 `Schema.$dynamicRef()` 的 `NoSuchMethodError`。

## 变更内容

- 新增 `knife4j-swagger-models-v3-jakarta.version=2.2.47`。
- 父 POM 与 `knife4j-dependencies` BOM 统一管理 `swagger-annotations-jakarta`、`swagger-models-jakarta`、`swagger-core-jakarta` 为 `2.2.47`。
- 同步更新 `docs-site/reference/version-ref.md` 中 Boot 3.x Jakarta 线的版本说明。

## Worker / Reviewer

- Worker：已完成最小范围 Maven 依赖管理修复，未触碰 release workflow、坐标或无关依赖。
- Reviewer：独立审查当前 diff，结论 `approve`，无发现、无验证缺口、无范围漂移。

## 验证

- `mvn -f knife4j/pom.xml -pl knife4j-dependencies help:effective-pom -Doutput=/private/tmp/knife4j-dependencies-effective-pom.xml -DskipTests`
- `mvn -f knife4j/pom.xml -pl knife4j-openapi3-boot4-spring-boot-starter dependency:tree -Dincludes=io.swagger.core.v3 -DskipTests`
- `mvn -f knife4j/pom.xml -pl knife4j-openapi3-jakarta-spring-boot-starter dependency:tree -Dincludes=io.swagger.core.v3 -DskipTests`
- `./scripts/test-java.sh`，尾部证据：`==> Smoke-tests evidence OK (7 modules)`
- `./scripts/test-docs.sh`
- `git diff --check`

## 风险

- 风险较低。改动仅限 Java/Maven 依赖版本管理与版本对照文档，非 Jakarta Swagger v3 线仍保留 `2.2.26`。