### PR TITLE
chore: 增加 Vue3 独立验证脚本

### DIFF
--- a/knife4j-vue3/README.md
+++ b/knife4j-vue3/README.md
@@ -42,11 +42,17 @@ bun run build
 
 ## 验证命令
 
-修改 Java 模块或本目录产物集成逻辑后，至少运行：
+修改本目录 Vue3 / OAS2 UI 后，优先从仓库根目录运行：
+
+```bash
+./scripts/test-vue3.sh
+```
+
+该脚本会进入 `knife4j-vue3/`，执行 `bun install --frozen-lockfile` 与 `bun run build:Knife4jSpringUi`，
+并检查 `dist/doc.html`、`dist/webjars/`、`dist/webjars/oauth/oauth2.html` 是否生成。
+
+修改 Java 模块或本目录产物集成逻辑后，还需运行：
 
 ```bash
 ./scripts/test-java.sh
 ```
-
-（本目录自身暂未纳入 `./scripts/test-front-core.sh`；若纯改 `knife4j-vue3/src/**` 且未触碰 Java 集成，
-可本地 `bun run build` 验证后再推进 CI。）

--- a/scripts/test-vue3.sh
+++ b/scripts/test-vue3.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../knife4j-vue3"
+
+bun install --frozen-lockfile
+bun run build:Knife4jSpringUi
+
+required_files=(
+  "dist/doc.html"
+  "dist/webjars/oauth/oauth2.html"
+)
+
+for file in "${required_files[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "Missing expected Vue3 build artifact: $file" >&2
+    exit 1
+  fi
+done
+
+if [ ! -d "dist/webjars" ]; then
+  echo "Missing expected Vue3 build artifact: dist/webjars" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 关联 Issue

- #402

## 变更内容

- 新增 `scripts/test-vue3.sh`，提供 Vue3/OAS2 UI 的独立构建验证入口。
- 脚本执行 `bun install --frozen-lockfile` 与 `bun run build:Knife4jSpringUi`，并断言 `dist/doc.html`、`dist/webjars/`、`dist/webjars/oauth/oauth2.html` 存在。
- 更新 `knife4j-vue3/README.md`，将纯 Vue3/OAS2 UI 改动的推荐验证命令收敛为 `./scripts/test-vue3.sh`。
- 本轮未修改 `.github/workflows/build.yml`，不改变 `doc.html` 运行时行为。

## Worker / Reviewer

- Worker：按 #402 范围实现，仅触碰 `scripts/test-vue3.sh` 与 `knife4j-vue3/README.md`。
- Reviewer：已审查新增脚本、执行位、README 口径和范围纪律，结论为 `approve`，无发现。

## 验证

- `./scripts/test-vue3.sh`：通过。
- `git diff --check`：通过。

## 风险

- 无已知风险。CI 独立 Vue3 job 属于 #402 可选项，本 PR 暂不添加，避免扩大范围。