### PR TITLE
fix: 清理 Vue3 运行时调试输出

### DIFF
--- a/knife4j-vue3/src/components/common/ContextMenu.vue
+++ b/knife4j-vue3/src/components/common/ContextMenu.vue
@@ -31,7 +31,9 @@ export default {
       left: 0,
       top: 0,
       target: null,
-      selectedKeys: []
+      selectedKeys: [],
+      windowMousedownHandler: null,
+      windowContextmenuHandler: null
     };
   },
   computed: {
@@ -43,8 +45,14 @@ export default {
     }
   },
   created() {
-    window.addEventListener("mousedown", e => this.closeMenu(e));
-    window.addEventListener("contextmenu", e => this.setPosition(e));
+    this.windowMousedownHandler = e => this.closeMenu(e);
+    this.windowContextmenuHandler = e => this.setPosition(e);
+    window.addEventListener("mousedown", this.windowMousedownHandler);
+    window.addEventListener("contextmenu", this.windowContextmenuHandler);
+  },
+  beforeUnmount() {
+    window.removeEventListener("mousedown", this.windowMousedownHandler);
+    window.removeEventListener("contextmenu", this.windowContextmenuHandler);
   },
   methods: {
     closeMenu(e) {

--- a/knife4j-vue3/src/layouts/BasicLayout.vue
+++ b/knife4j-vue3/src/layouts/BasicLayout.vue
@@ -489,9 +489,7 @@ function getCacheGitVersion(gitVal) {
   return cacheApis;
 }
 
-const handleMenuClick = (item) => {
-  console.log(item)
-}
+const handleMenuClick = () => undefined
 const currentUser = computed(() => {
   return headersStore.userCurrent;
 })

--- a/knife4j-vue3/src/views/api/Debug.vue
+++ b/knife4j-vue3/src/views/api/Debug.vue
@@ -574,7 +574,6 @@ export default {
           }
         })
       }
-      console.log(tempArrays)
       return {
         update: tempUpdateFlag,
         data: tempArrays,
@@ -646,7 +645,6 @@ export default {
       this.headerColumn = inst.table.debugRequestHeaderColumns;
       this.formColumn = inst.table.debugFormDataRequestColumns;
       this.urlFormColumn = inst.table.debugUrlFormRequestColumns;
-      console.log(this.headerColumn, this.formColumn, this.urlFormColumn)
     },
     debugUrlChange(e) {
       this.debugUrl = e.target.value;
@@ -768,7 +766,6 @@ export default {
       // console.log(this.globalParameters)
       // 本都缓存读取到参数，初始化header参数
       this.globalParameters.forEach(param => {
-        console.log(param)
         if (param.in == "header") {
           var newHeader = {
             id: KUtils.randomMd5(),

--- a/knife4j-vue3/src/views/api/OpenApi.vue
+++ b/knife4j-vue3/src/views/api/OpenApi.vue
@@ -118,9 +118,8 @@ export default {
         message.info(successMessage);
       })
       clipboard.on("error", (e) => {
-        console.log(e)
+        console.error(e)
         const inst = this.getCurrentI18nInstance()
-        console.log(inst)
         // "复制地址失败"
         const failMessage = inst.message.copy.open.fail
         message.info(failMessage);

--- a/knife4j-vue3/src/views/settings/GlobalParameters.vue
+++ b/knife4j-vue3/src/views/settings/GlobalParameters.vue
@@ -124,7 +124,6 @@ export default {
     const key = this.groupId;
     // this.$localStore.setItem(Constants.globalParameter, 'test')
     localStore.getItem(Constants.globalParameter).then((val) => {
-      console.log(val)
       if (val != null) {
         if (val[key] != undefined && val[key] != null) {
           this.globalParameters = val[key];

--- a/knife4j-vue3/src/views/settings/SwaggerModels.vue
+++ b/knife4j-vue3/src/views/settings/SwaggerModels.vue
@@ -19,7 +19,7 @@
 <script>
 import KUtils from "@/core/utils";
 import Constants from "@/store/constants";
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useGlobalsStore } from '@/store/modules/global.js'
 import { useI18n } from 'vue-i18n'
 import { useknife4jModels } from '@/store/knife4jModels.js'
@@ -125,7 +125,6 @@ export default {
               )
               originalModel = swagger.value.analysisDefinitionRefTableModel(props.data.instance.id, originalModel);
               // console.log("初始化完成")
-              console.log(originalModel.children);
               // console("查找原始model:" + model.name);
               if (KUtils.checkUndefined(originalModel)) {
                 // 存在
@@ -170,18 +169,12 @@ export default {
           }
         });
 
-        console.log(modelNames.value)
       }
       // 第二次复制
       expanRows.value = true;
     }
 
     initModelNames()
-    watch(() => modelNames.value, () => {
-      for (let model of modelNames.value) {
-        console.log(model.data)
-      }
-    })
 
     return {
       columns,


### PR DESCRIPTION
## 关联 Issue

- #405

## 变更内容

- 为 `ContextMenu` 的全局 `mousedown` / `contextmenu` 监听保存 handler 引用，并在组件卸载时移除，避免组件生命周期外残留监听。
- 清理 `BasicLayout`、`Debug`、`GlobalParameters`、`SwaggerModels` 中确定无业务意义的运行时 `console.log` 调试输出。
- 将 `OpenApi` 复制失败路径的错误输出收敛为 `console.error`，保留真实异常路径，删除无意义的 i18n 实例输出。

## Worker / Reviewer

- Worker：短命 worker 完成实现，范围仅限 issue 指定的 6 个 Vue3 文件；未触碰 `Knife4jAsync.js`、API 调试请求构造、React/OAS3、Java、CI 或发布流程。
- Reviewer：独立 reviewer 审查当前 diff、issue 范围与验证结果，结论为 `approve`，无发现。

## 验证

- `./scripts/test-vue3.sh`：本机默认临时目录下因 `bun` tempdir 权限失败（`AccessDenied`），判定为本地环境限制。
- `TMPDIR=/private/tmp BUN_INSTALL_CACHE_DIR=/private/tmp/bun-cache ./scripts/test-vue3.sh`：通过。
- `git diff --check`：通过。

## 风险与范围

- 未完成有后端数据页的右键菜单实操验证；代码层面右键菜单打开、选择、关闭路径未改，只补充同一 handler 的卸载清理。
- 注释中的历史 `console.log` 未作为运行时输出清理，避免把本任务扩大成大范围注释整理。
- 不涉及 UI 文案、交互能力、API 调试请求构造或 `Knife4jAsync.js` 主流程。