### PR TITLE
fix: 瘦身 Vue3 Markdown 预览产物

### DIFF
--- a/knife4j-vue3/src/assets/css/markdown-preview.css
+++ b/knife4j-vue3/src/assets/css/markdown-preview.css
@@ -1,0 +1,489 @@
+.markdown-body {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  color: #333;
+  overflow: hidden;
+  font-family: "Microsoft YaHei", Helvetica, "Meiryo UI", "Malgun Gothic", "Segoe UI", "Trebuchet MS", Monaco, monospace, Tahoma, "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  word-wrap: break-word;
+}
+
+.markdown-body * {
+  box-sizing: border-box;
+}
+
+.markdown-body a {
+  color: #4183c4;
+  text-decoration: none;
+  background: transparent;
+}
+
+.markdown-body a:hover,
+.markdown-body a:active {
+  outline: 0;
+  text-decoration: underline;
+}
+
+.markdown-body strong {
+  font-weight: bold;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  position: relative;
+  margin-top: 1em;
+  margin-bottom: 16px;
+  font-weight: bold;
+  line-height: 1.4;
+}
+
+.markdown-body h1 {
+  padding-bottom: 0.3em;
+  font-size: 2.25em;
+  line-height: 1.2;
+  border-bottom: 1px solid #eee;
+}
+
+.markdown-body h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.75em;
+  line-height: 1.225;
+  border-bottom: 1px solid #eee;
+}
+
+.markdown-body h3 {
+  font-size: 1.5em;
+  line-height: 1.43;
+}
+
+.markdown-body h4 {
+  font-size: 1.25em;
+}
+
+.markdown-body h5,
+.markdown-body h6 {
+  font-size: 1em;
+}
+
+.markdown-body h6 {
+  color: #777;
+}
+
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.markdown-body blockquote {
+  padding: 0 15px;
+  color: #777;
+  border-left: 4px solid #ddd;
+}
+
+.markdown-body blockquote > :first-child,
+.markdown-body > :first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body blockquote > :last-child,
+.markdown-body > :last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  padding-left: 2em;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body li > p {
+  margin-top: 16px;
+}
+
+.markdown-body dl {
+  padding: 0;
+}
+
+.markdown-body dl dt {
+  padding: 0;
+  margin-top: 16px;
+  font-size: 1em;
+  font-style: italic;
+  font-weight: bold;
+}
+
+.markdown-body dl dd {
+  padding: 0 16px;
+  margin-bottom: 16px;
+}
+
+.markdown-body hr {
+  height: 0;
+  margin: 15px 0;
+  overflow: hidden;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid #ddd;
+}
+
+.markdown-body img {
+  max-width: 100%;
+  border: 0;
+}
+
+.markdown-body table {
+  width: 100%;
+  overflow: auto;
+  word-break: keep-all;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.markdown-body table th {
+  font-weight: bold;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid #ddd;
+}
+
+.markdown-body table tr {
+  background-color: #fff;
+  border-top: 1px solid #ccc;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+
+.markdown-body code,
+.markdown-body kbd,
+.markdown-body pre {
+  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+}
+
+.markdown-body code {
+  padding: 0.2em 0;
+  margin: 0;
+  font-size: 85%;
+  background-color: rgba(0, 0, 0, 0.04);
+  border-radius: 3px;
+}
+
+.markdown-body code:before,
+.markdown-body code:after {
+  letter-spacing: -0.2em;
+  content: "\00a0";
+}
+
+.markdown-body pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  word-wrap: normal;
+  background-color: #f7f7f7;
+  border-radius: 3px;
+}
+
+.markdown-body pre > code {
+  display: inline;
+  max-width: initial;
+  padding: 0;
+  margin: 0;
+  overflow: initial;
+  font-size: 100%;
+  line-height: inherit;
+  word-break: normal;
+  word-wrap: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body pre code:before,
+.markdown-body pre code:after {
+  content: normal;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  font: 11px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  line-height: 10px;
+  color: #555;
+  vertical-align: middle;
+  background-color: #fcfcfc;
+  border: solid 1px #ccc;
+  border-bottom-color: #bbb;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 #bbb;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+}
+
+.markdown-body .task-list-item + .task-list-item {
+  margin-top: 3px;
+}
+
+.markdown-body .task-list-item input {
+  float: left;
+  margin: 0.3em 0 0.25em -1.6em;
+  vertical-align: middle;
+}
+
+.markdown-body .highlight {
+  margin-bottom: 16px;
+}
+
+.markdown-body .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.markdown-body .pl-c {
+  color: #969896;
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-mdh,
+.markdown-body .pl-mm,
+.markdown-body .pl-mp,
+.markdown-body .pl-mr,
+.markdown-body .pl-s1 .pl-v,
+.markdown-body .pl-s3,
+.markdown-body .pl-sc,
+.markdown-body .pl-sv {
+  color: #0086b3;
+}
+
+.markdown-body .pl-e,
+.markdown-body .pl-en {
+  color: #795da3;
+}
+
+.markdown-body .pl-s1 .pl-s2,
+.markdown-body .pl-smi,
+.markdown-body .pl-smp,
+.markdown-body .pl-stj,
+.markdown-body .pl-vo,
+.markdown-body .pl-vpf {
+  color: #333;
+}
+
+.markdown-body .pl-ent {
+  color: #63a35c;
+}
+
+.markdown-body .pl-k,
+.markdown-body .pl-s,
+.markdown-body .pl-st {
+  color: #a71d5d;
+}
+
+.markdown-body .pl-pds,
+.markdown-body .pl-s1,
+.markdown-body .pl-s1 .pl-pse .pl-s2,
+.markdown-body .pl-sr,
+.markdown-body .pl-sr .pl-cce,
+.markdown-body .pl-sr .pl-sra,
+.markdown-body .pl-sr .pl-sre,
+.markdown-body .pl-src {
+  color: #df5000;
+}
+
+.markdown-body .pl-mo,
+.markdown-body .pl-v {
+  color: #1d3e81;
+}
+
+.markdown-body .pl-id {
+  color: #b52a1d;
+}
+
+.markdown-body .pl-ii {
+  color: #f8f8f8;
+  background-color: #b52a1d;
+}
+
+.markdown-body .pl-sr .pl-cce {
+  color: #63a35c;
+  font-weight: bold;
+}
+
+.markdown-body .pl-ml {
+  color: #693a17;
+}
+
+.markdown-body .pl-mh,
+.markdown-body .pl-mh .pl-en,
+.markdown-body .pl-ms {
+  color: #1d3e81;
+  font-weight: bold;
+}
+
+.markdown-body .pl-mq {
+  color: #008080;
+}
+
+.markdown-body .pl-mi {
+  color: #333;
+  font-style: italic;
+}
+
+.markdown-body .pl-mb {
+  color: #333;
+  font-weight: bold;
+}
+
+.markdown-body .pl-md,
+.markdown-body .pl-mdhf {
+  color: #bd2c00;
+  background-color: #ffecec;
+}
+
+.markdown-body .pl-mdht,
+.markdown-body .pl-mi1 {
+  color: #55a532;
+  background-color: #eaffea;
+}
+
+.markdown-body .pl-mdr {
+  color: #795da3;
+  font-weight: bold;
+}
+
+.editormd-preview-container,
+.editormd-html-preview {
+  width: 100%;
+  padding: 20px;
+  overflow: auto;
+  font-size: 14px;
+  line-height: 1.6;
+  text-align: left;
+  background-color: #fff;
+}
+
+.editormd-preview-container p code,
+.editormd-html-preview p code {
+  margin-right: 4px;
+  margin-left: 5px;
+}
+
+.editormd-preview-container abbr,
+.editormd-html-preview abbr {
+  background: #ffffdd;
+}
+
+.editormd-preview-container pre,
+.editormd-html-preview pre {
+  border: 1px solid #ddd;
+}
+
+.editormd-preview-container pre code,
+.editormd-html-preview pre code {
+  padding: 0;
+}
+
+.editormd-preview-container table thead tr,
+.editormd-html-preview table thead tr {
+  background-color: #f8f8f8;
+}
+
+.editormd-preview-container p.editormd-tex,
+.editormd-html-preview p.editormd-tex {
+  text-align: center;
+}
+
+.editormd-preview-container span.editormd-tex,
+.editormd-html-preview span.editormd-tex {
+  margin: 0 5px;
+}
+
+.editormd-preview-container .emoji,
+.editormd-html-preview .emoji {
+  width: 24px;
+  height: 24px;
+}
+
+.editormd-preview-container .katex,
+.editormd-html-preview .katex {
+  font-size: 1.4em;
+}
+
+.editormd-preview-container .sequence-diagram,
+.editormd-preview-container .flowchart,
+.editormd-preview-container .mermaid,
+.editormd-html-preview .sequence-diagram,
+.editormd-html-preview .flowchart,
+.editormd-html-preview .mermaid {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.editormd-preview-container .sequence-diagram svg,
+.editormd-preview-container .flowchart svg,
+.editormd-preview-container .mermaid svg,
+.editormd-html-preview .sequence-diagram svg,
+.editormd-html-preview .flowchart svg,
+.editormd-html-preview .mermaid svg {
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.editormd-preview-container .sequence-diagram text,
+.editormd-preview-container .flowchart text,
+.editormd-html-preview .sequence-diagram text,
+.editormd-html-preview .flowchart text {
+  font-family: "Microsoft YaHei", "Malgun Gothic", "Segoe UI", Helvetica, Arial !important;
+  font-size: 15px !important;
+}
+
+.markdown-body .editormd-toc-menu ul {
+  padding-left: 0;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+  line-height: 1.6;
+}
+
+hr.editormd-page-break {
+  height: 2px;
+  font-size: 0;
+  border: 1px dotted #ccc;
+}

--- a/knife4j-vue3/src/components/GlobalFooter/index.vue
+++ b/knife4j-vue3/src/components/GlobalFooter/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="globalFooter">
     <a-row v-if="settings.enableFooterCustom">
-      <markdown v-if="settings.enableFooterCustom" :source="settings.footerCustomContent" />
+      <component :is="'MarkdownPreview'" v-if="settings.enableFooterCustom" :source="settings.footerCustomContent" />
     </a-row>
     <div style="text-align: center" v-else-if="settings.enableFooter">
       <div class="copyright">Apache License 2.0 | Copyright
@@ -11,14 +11,15 @@
   </div>
 </template>
 <script>
-import { computed } from 'vue'
+import { computed, defineAsyncComponent } from 'vue'
 import { useGlobalsStore } from '@/store/modules/global.js'
-import Markdown from '../Markdown/index.vue'
 import { CopyrightOutlined } from '@ant-design/icons-vue'
+
+const MarkdownPreview = defineAsyncComponent(() => import('../Markdown/index.vue'))
 
 export default {
   name: "GlobalFooter",
-  components: { Markdown, CopyrightOutlined },
+  components: { MarkdownPreview, CopyrightOutlined },
   props: {
     links: {
       type: Array,
@@ -41,4 +42,3 @@ export default {
 <style lang="less" scoped>
 @import "./index.less";
 </style>
-

--- a/knife4j-vue3/src/components/Markdown/index.vue
+++ b/knife4j-vue3/src/components/Markdown/index.vue
@@ -4,6 +4,7 @@
 </template>
 
 <script>
+import "@/assets/css/markdown-preview.css";
 import { marked } from 'marked';
 import mermaid from 'mermaid';
 

--- a/knife4j-vue3/src/layouts/BasicLayout.vue
+++ b/knife4j-vue3/src/layouts/BasicLayout.vue
@@ -61,26 +61,28 @@ import ThreeMenu from "@/components/SiderMenu/ThreeMenu.vue";
 //右键菜单
 import ContextMenu from "@/components/common/ContextMenu.vue";
 import constant from "@/store/constants";
-import { computed, markRaw, onUpdated, reactive, shallowRef, watch, onMounted } from 'vue'
+import { computed, defineAsyncComponent, markRaw, onUpdated, reactive, shallowRef, watch, onMounted } from 'vue'
 import { useGlobalsStore } from '@/store/modules/global.js'
 import { useHeadersStore } from '@/store/modules/header.js'
 import { useRoute, useRouter } from 'vue-router'
 import localStore from '@/store/local.js'
 import { useI18n } from 'vue-i18n'
 import Main from '@/views/index/Main.vue'
-import Othermarkdown from '@/views/othermarkdown/index.vue'
-import Authorize from '@/views/settings/Authorize.vue'
-import GlobalParameters from '@/views/settings/GlobalParameters.vue'
-import Settings from '@/views/settings/Settings.vue'
-import SwaggerModels from '@/views/settings/SwaggerModels.vue'
-import OfficelineDocument from '@/views/settings/OfficelineDocument.vue'
-import ApiInfo from '@/views/api/index.vue'
+
+const OtherMarkdown = defineAsyncComponent(() => import('@/views/othermarkdown/index.vue'))
+const Authorize = defineAsyncComponent(() => import('@/views/settings/Authorize.vue'))
+const GlobalParameters = defineAsyncComponent(() => import('@/views/settings/GlobalParameters.vue'))
+const Settings = defineAsyncComponent(() => import('@/views/settings/Settings.vue'))
+const SwaggerModels = defineAsyncComponent(() => import('@/views/settings/SwaggerModels.vue'))
+const OfficelineDocument = defineAsyncComponent(() => import('@/views/settings/OfficelineDocument.vue'))
+const ApiInfo = defineAsyncComponent(() => import('@/views/api/index.vue'))
 
 const constMenuWidth = 320;
 
 const componentMap = {
   'Main': Main,
-  'Othermarkdown': Othermarkdown,
+  'OtherMarkdown': OtherMarkdown,
+  'Othermarkdown': OtherMarkdown,
   'Authorize': Authorize,
   'GlobalParameters': GlobalParameters,
   'Settings': Settings,

--- a/knife4j-vue3/src/main.js
+++ b/knife4j-vue3/src/main.js
@@ -1,4 +1,4 @@
-import { createApp } from 'vue'
+import { createApp, defineAsyncComponent } from 'vue'
 import './style/knife4j.less'
 import App from './App.vue'
 import { setupStore } from './store/index.js'
@@ -37,14 +37,15 @@ const MyIcon = createFromIconfontCN({
  * 供用户在模板中以组件标签直接引用（如 <ApiInfo>, <Authorize>）
  */
 import Main from '@/views/index/Main.vue'
-import ApiInfo from '@/views/api/index.vue'
-import Authorize from '@/views/settings/Authorize.vue'
-import SwaggerModels from '@/views/settings/SwaggerModels.vue'
-import GlobalParameters from '@/views/settings/GlobalParameters.vue'
-import Settings from '@/views/settings/Settings.vue'
-import OfficelineDocument from '@/views/settings/OfficelineDocument.vue'
-import OtherMarkdown from '@/views/othermarkdown/index.vue'
 import MethodType from '@/components/common/MethodApi.vue'
+
+const ApiInfo = defineAsyncComponent(() => import('@/views/api/index.vue'))
+const Authorize = defineAsyncComponent(() => import('@/views/settings/Authorize.vue'))
+const SwaggerModels = defineAsyncComponent(() => import('@/views/settings/SwaggerModels.vue'))
+const GlobalParameters = defineAsyncComponent(() => import('@/views/settings/GlobalParameters.vue'))
+const Settings = defineAsyncComponent(() => import('@/views/settings/Settings.vue'))
+const OfficelineDocument = defineAsyncComponent(() => import('@/views/settings/OfficelineDocument.vue'))
+const OtherMarkdown = defineAsyncComponent(() => import('@/views/othermarkdown/index.vue'))
 
 /***
  * 响应数据拦截器（与 knife4j-vue main.js 行为一致）
@@ -67,6 +68,7 @@ app.component('GlobalParameters', GlobalParameters)
 app.component('Settings', Settings)
 app.component('OfficelineDocument', OfficelineDocument)
 app.component('OtherMarkdown', OtherMarkdown)
+app.component('Othermarkdown', OtherMarkdown)
 app.component('MethodType', MethodType)
 setupStore(app)
 setupI18n(app)

--- a/knife4j-vue3/src/views/index/Main.vue
+++ b/knife4j-vue3/src/views/index/Main.vue
@@ -1,7 +1,7 @@
 <template>
   <a-layout-content class="knife4j-body-content" v-if="swaggerCurrentInstance">
     <a-row class="markdown-body editormd-preview-container" v-if="settings?.enableHomeCustom">
-      <Markdown :source="settings.homeCustomLocation || ''" />
+      <component :is="'MarkdownPreview'" :source="settings.homeCustomLocation || ''" />
     </a-row>
     <div class="home-page" v-else>
       <section class="home-hero">
@@ -156,7 +156,7 @@ export default {
     }
   },
   components: {
-    "Markdown": defineAsyncComponent(() => import('@/components/Markdown/index.vue')),
+    "MarkdownPreview": defineAsyncComponent(() => import('@/components/Markdown/index.vue')),
     ApiOutlined,
     CloudServerOutlined,
     CodeOutlined,

--- a/knife4j-vue3/src/views/othermarkdown/index.vue
+++ b/knife4j-vue3/src/views/othermarkdown/index.vue
@@ -1,15 +1,16 @@
 <template>
   <a-layout-content class="knife4j-body-content">
     <a-row class="markdown-body editormd-preview-container">
-      <Markdown :source="content" />
+      <component :is="'MarkdownPreview'" :source="content" />
     </a-row>
   </a-layout-content>
 </template>
 <script>
-import "@/assets/css/editormd.css";
+import { defineAsyncComponent } from "vue";
 import KUtils from "@/core/utils";
 import localStore from "@/store/local.js";
-import Markdown from "@/components/Markdown/index.vue";
+
+const MarkdownPreview = defineAsyncComponent(() => import("@/components/Markdown/index.vue"));
 
 export default {
   props: {
@@ -18,7 +19,7 @@ export default {
     }
   },
   components: {
-    Markdown
+    MarkdownPreview
   },
   data() {
     return {


### PR DESCRIPTION
## 关联 Issue

- #403

## 变更内容

- 将只读 Markdown 预览从完整 `editormd.css` 收敛到轻量 `markdown-preview.css`，避免旧 FontAwesome/editormd 字体资源进入构建产物。
- 将 `OtherMarkdown`、设置页、接口页等非首屏组件的全局注册和布局映射改为 `defineAsyncComponent`，保留 `OtherMarkdown` / `Othermarkdown` key 兼容。
- 将主页自定义 Markdown、页脚自定义 Markdown、OtherMarkdown 内部 Markdown 预览改为异步组件，避免 Markdown/Mermaid 被首屏静态拉入。

## Worker / Reviewer

- Worker handoff：实现范围集中在 Vue3 Markdown/OtherMarkdown 预览样式与入口注册，未修改 React/OAS3、Markdown 语法支持或 sanitize 策略。
- Reviewer handoff：独立 reviewer 审查当前 diff，结论为 `approve`，无发现。

## 验证

- `env TMPDIR=/private/tmp BUN_INSTALL_CACHE_DIR=/private/tmp/bun-cache ./scripts/test-vue3.sh`：通过。
- `find knife4j-vue3/dist/webjars \( -iname '*fontawesome*' -o -iname '*editormd*' \) -print`：无输出。
- `git diff --check`：通过。

## 产物对比

- 改动前：`doc-5979a817.css` 447.97 kB / gzip 64.65 kB；`doc-3a345965.js` 2,804.96 kB / gzip 737.13 kB。
- 改动后：`doc-70c3d111.css` 285.37 kB / gzip 35.17 kB；`doc-79f3bb05.js` 1,127.00 kB / gzip 333.72 kB。

## 风险

- 构建仍存在既有 warning：`OnlineDocument.vue` 混合导入、`Main.vue` 仍作为首屏静态导入、既有 eval 警告；本 PR 不扩散处理。
- 未改变 Markdown 语法支持范围，也未调整 `v-html` / sanitize 策略。