### PR TITLE
docs: 整理 README 结构

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,62 @@
 # knife4j-next
 
-`knife4j-next` 是一个面向社区持续维护的 `knife4j` fork，目标是以更稳定的发布节奏继续维护 `doc.html` 这套 API
-文档增强体验，并逐步推进下一代前端与文档体系。
+`knife4j-next` 是一个面向社区持续维护的 `knife4j` fork。它服务于仍依赖 `doc.html` 体验和相关 starter
+模块的用户，目标是在保持兼容性的前提下，提供更稳定的维护节奏、发布流程和下一代前端演进路径。
 
-这个仓库当前优先解决的问题是：
+## 项目定位
+
+| 项目 | 说明 |
+|---|---|
+| 仓库来源 | fork 自 `xiaoymin/knife4j` |
+| 当前定位 | 社区维护分支，不是 upstream 官方仓库 |
+| Java 主坐标 | `com.baizhukui` |
+| 当前稳定版本 | `5.0.7` |
+| 默认访问入口 | `http://ip:port/doc.html` |
+| 文档站 | [knife4jnext.com](https://knife4jnext.com) |
+
+`doc.html` 仍然是默认访问入口，这一点保持与原项目兼容。
+
+当前维护重点：
 
 - 跟进 Spring Boot 2.7 / 3.x / 4.x 与 Spring Framework 5.3 / 6.x / 7.x 的兼容性
 - 修复社区长期积压的回归与聚合场景问题
 - 建立清晰、可重复的发布流程
 - 为 React 方向的下一代前端做增量演进，而不是一次性推倒重来
 
-## 产品示例
+## 快速开始
+
+### 选择 Starter
+
+版本统一使用当前稳定版本 `5.0.7`。
+
+| 使用场景 | Maven `artifactId` |
+|---|---|
+| Spring Boot 2.x / Swagger 2 / OAS2 | `knife4j-openapi2-spring-boot-starter` |
+| Spring Boot 2.x / OpenAPI 3 / Javax | `knife4j-openapi3-spring-boot-starter` |
+| Spring Boot 3.x / Jakarta | `knife4j-openapi3-jakarta-spring-boot-starter` |
+| Spring Boot 4.x / Jakarta | `knife4j-openapi3-boot4-spring-boot-starter` |
+| Spring Cloud Gateway | `knife4j-gateway-spring-boot-starter` |
+| Spring Cloud Gateway / Spring Boot 4.x | `knife4j-gateway-boot4-spring-boot-starter` |
+
+### Maven 依赖
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <version>5.0.7</version>
+</dependency>
+```
+
+如果你的使用场景不是 Spring Boot 3.x / Jakarta，将 `artifactId` 替换为上表对应的 starter。
+
+启动应用后访问：
+
+```text
+http://ip:port/doc.html
+```
+
+## 界面预览
 
 ### OpenAPI 文档概览
 
@@ -24,125 +70,32 @@
 
 ![在线调试](./static/debug-ui.png)
 
-## 项目状态
+## 仓库结构
 
-- 仓库来源：fork 自 `xiaoymin/knife4j`
-- 当前定位：社区维护分支，不是 upstream 官方仓库
-- Java 主坐标：`com.baizhukui`
-- 当前稳定版本：`5.0.7`
-- 对外访问入口：`http://ip:port/doc.html`
-
-> `doc.html` 仍然是默认访问入口，这一点保持与原项目兼容。
-
-## Star History
-
-<p align="center">
-  <a href="https://www.star-history.com/songxychn/knife4j-next">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=songxychn/knife4j-next&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=songxychn/knife4j-next&type=date&legend=top-left" />
-      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=songxychn/knife4j-next&type=date&legend=top-left" />
-    </picture>
-  </a>
-</p>
-
-## 仓库模块
-
-| 模块                | 说明                                                                        |
-|-------------------|---------------------------------------------------------------------------|
-| `knife4j`         | Java 主工程，包含 starter、UI webjar、聚合组件、Gateway starter、WebFlux starter 与依赖管理 |
-| `docs-site`           | 当前文档站（VitePress）——项目对外文档的主入口                          |
-| `knife4j-front`       | React 前端工作区（Bun workspace），活跃子模块为 `knife4j-core`（TypeScript 解析库）和 `knife4j-ui-react`（OAS3 主线 UI，打包进 `knife4j-openapi3-ui` webjar） |
+| 模块 | 说明 |
+|---|---|
+| `knife4j` | Java 主工程，包含 starter、UI webjar、聚合组件、Gateway starter、WebFlux starter 与依赖管理 |
 | `knife4j-smoke-tests` | smoke 测试，覆盖 Boot 2.x OAS2/OAS3、Boot 3.4/3.5 Jakarta、Boot 4.x WebMVC 与 Boot 4.x Gateway 等组合 |
-| `knife4j-vue`         | upstream 旧版的历史 Vue 2 前端实现，仅作为行为参考留存，不再预期改动                   |
-| `knife4j-vue3`    | OAS2 兼容维护 UI（Vue 3 + Vite），打包进 `knife4j-openapi2-ui` webjar，只接收回归修复与显示层 bug |
-| `knife4j-insight` | 独立渲染/聚合方向的扩展方案                                                            |
+| `docs-site` | 当前文档站，基于 VitePress 构建 |
+| `knife4j-front` | React 前端工作区，活跃子模块为 `knife4j-core` 和 `knife4j-ui-react` |
+| `knife4j-vue3` | OAS2 兼容维护 UI，打包进 `knife4j-openapi2-ui` webjar |
+| `knife4j-vue` | upstream 旧版 Vue 2 前端实现，仅作为行为参考留存 |
+| `knife4j-insight` | 独立渲染/聚合方向的扩展方案 |
 
-## 当前维护策略
+## 维护策略
 
-- Java 后端（`knife4j/`）：优先做兼容性修复、回归修复和发布维护，当前稳定版本线 `5.0.7`
-- **前端分工**（详见 `.agent/PROJECT.md`）：
-  - **OAS3 主线**：`knife4j-front/knife4j-ui-react`（React + Vite）→ `knife4j-openapi3-ui` webjar → `knife4j-openapi3-*-spring-boot-starter` 系列、`knife4j-gateway-*spring-boot-starter`、`knife4j-aggregation-jakarta-spring-boot-starter`。所有新功能、UX 改进在这里落地。
-  - **OAS2 兼容维护**：`knife4j-vue3`（Vue 3 + Vite）→ `knife4j-openapi2-ui` webjar → `knife4j-openapi2-spring-boot-starter`、`knife4j-aggregation-spring-boot-starter`。只接收回归修复与显示层 bug，不做功能扩张。
-- `knife4j-vue`：upstream 旧版 Vue 2 前端，仅作为行为参考留存，不再预期改动。
-- `knife4j-front` 下的 `knife4j-cli`、`knife4j-extension` 及浏览器扩展目前仅有占位，暂未启动开发。
-- 文档站：`docs-site/`（VitePress）是当前维护目标。
+| 方向 | 源码 | 产物 / 使用方 | 策略 |
+|---|---|---|---|
+| Java 后端 | `knife4j/` | starter、UI webjar、聚合组件 | 优先做兼容性修复、回归修复和发布维护 |
+| OAS3 主线 UI | `knife4j-front/knife4j-ui-react` | `knife4j-openapi3-ui` webjar | 承接新功能、UX 改进和调试器增强 |
+| OAS3 解析核心 | `knife4j-front/knife4j-core` | React UI 内部依赖 | 服务于 OAS3 主线，不为 OAS2 扩展 |
+| OAS2 兼容 UI | `knife4j-vue3` | `knife4j-openapi2-ui` webjar | 只接收回归修复、安全补丁与显示层 bug |
+| 历史 Vue 2 UI | `knife4j-vue` | 无新增维护目标 | 仅作为 upstream 行为参考留存 |
+| 文档站 | `docs-site/` | [knife4jnext.com](https://knife4jnext.com) | 当前对外文档主入口 |
 
-## 快速开始
+`knife4j-front` 下的 `knife4j-cli`、`knife4j-extension` 及浏览器扩展目前仅有占位，暂未启动开发。
 
-### Spring Boot 2.x
-
-```xml
-
-<dependency>
-    <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>5.0.7</version>
-</dependency>
-```
-
-### Spring Boot 3.x (Jakarta)
-
-```xml
-
-<dependency>
-    <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.7</version>
-</dependency>
-```
-
-### Spring Boot 4.x (Jakarta)
-
-```xml
-
-<dependency>
-    <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.0.7</version>
-</dependency>
-```
-
-### Spring Boot 2.x (OpenAPI3 / Javax)
-
-```xml
-
-<dependency>
-    <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.0.7</version>
-</dependency>
-```
-
-### Spring Cloud Gateway
-
-```xml
-
-<dependency>
-    <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-gateway-spring-boot-starter</artifactId>
-    <version>5.0.7</version>
-</dependency>
-```
-
-### Spring Cloud Gateway (Spring Boot 4.x)
-
-```xml
-
-<dependency>
-    <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-gateway-boot4-spring-boot-starter</artifactId>
-    <version>5.0.7</version>
-</dependency>
-```
-
-启动应用后，默认通过以下地址访问：
-
-```text
-http://ip:port/doc.html
-```
-
-## 本地启动
+## 本地开发
 
 ### Java Demo
 
@@ -182,29 +135,17 @@ bun install --frozen-lockfile
 bun run dev
 ```
 
-## 本地测试
+## 验证命令
 
-### Java 主工程
+| 改动范围 | 推荐命令 |
+|---|---|
+| Java 主工程 | `./scripts/test-java.sh` |
+| React 前端 / `knife4j-core` | `./scripts/test-front-core.sh` |
+| 文档站 | `./scripts/test-docs.sh` |
+| 跨多个区域 | `./scripts/test-all.sh` |
 
-```bash
-./scripts/test-java.sh
-```
-
-该脚本会进入 `knife4j/`，执行 `spotless:check`、带测试的 Maven `verify`，并检查 smoke 测试证据。不要用单独的
+`./scripts/test-java.sh` 会进入 `knife4j/`，执行 `spotless:check`、带测试的 Maven `verify`，并检查 smoke 测试证据。不要用单独的
 `mvn -B -ntp verify` 替代提交前验证。
-
-### 前端与文档
-
-```bash
-./scripts/test-front-core.sh
-./scripts/test-docs.sh
-```
-
-跨多个区域的改动可运行：
-
-```bash
-./scripts/test-all.sh
-```
 
 ## 文档与链接
 
@@ -216,20 +157,31 @@ bun run dev
 - 迁移指南：[knife4j/MIGRATION.md](./knife4j/MIGRATION.md)
 - 文档站源码：[docs-site](./docs-site)
 
-文档站基于 VitePress 构建，源码位于 `docs-site/`。涉及历史功能细节时，仍可参考 upstream 文档站 `https://doc.xiaominfo.com/`；该站点不由本仓库维护。
+涉及历史功能细节时，仍可参考 upstream 文档站 `https://doc.xiaominfo.com/`；该站点不由本仓库维护。
+
+## Star History
+
+<p align="center">
+  <a href="https://www.star-history.com/songxychn/knife4j-next">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=songxychn/knife4j-next&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=songxychn/knife4j-next&type=date&legend=top-left" />
+      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=songxychn/knife4j-next&type=date&legend=top-left" />
+    </picture>
+  </a>
+</p>
 
 ## 与 upstream 的关系
 
-本仓库尊重并感谢原项目 `xiaoymin/knife4j` 的长期贡献。`knife4j-next` 的目标不是抹去
-upstream，而是在其长时间未稳定发布的阶段，为现有用户提供一个更可预期的社区维护分支，并逐步补齐：
+本仓库尊重并感谢原项目 `xiaoymin/knife4j` 的长期贡献。`knife4j-next` 的目标不是抹去 upstream，而是在其长时间未稳定发布的阶段，为现有用户提供一个更可预期的社区维护分支，并逐步补齐：
 
 - 兼容性修复
 - 迁移说明
 - 文档与版本说明
 - 更清晰的前端演进路线
 
-## 注意事项
+## 迁移提醒
 
-- 本仓库当前仍可能保留部分历史文档、图片、站点配置和旧链接，后续会逐步替换为 fork 自己的叙事与入口
-- 如果你正在从 upstream 迁移，短期内最重要的变化是 Maven `groupId` 已切换为 `com.baizhukui`；详见 [迁移指南](./knife4j/MIGRATION.md)
-- `knife4j-front` 下的 `knife4j-cli`、`knife4j-extension` 及各浏览器扩展子目录目前仅有占位 README，尚未开始实际开发
+- 本仓库当前仍可能保留部分历史文档、图片、站点配置和旧链接，后续会逐步替换为 fork 自己的叙事与入口。
+- 如果你正在从 upstream 迁移，短期内最重要的变化是 Maven `groupId` 已切换为 `com.baizhukui`；详见 [迁移指南](./knife4j/MIGRATION.md)。
+- `knife4j-front` 下的 `knife4j-cli`、`knife4j-extension` 及各浏览器扩展子目录目前仅有占位 README，尚未开始实际开发。


### PR DESCRIPTION
## 关联 Issue

无。维护者直接请求整理 README 结构。

## 变更内容

- 重排根 `README.md` 的章节顺序：项目定位、快速开始、界面预览、仓库结构、维护策略、本地开发、验证命令、文档链接、Star History、upstream 关系、迁移提醒。
- 将 starter 选择从多段重复 XML 改为一张场景与 `artifactId` 对照表，并保留一个 Maven 依赖模板。
- 将仓库模块、维护策略和验证命令整理为更容易扫描的表格。
- 保留 Star History 曲线，并将其下移到链接区域之后，减少首屏信息打断。

## 验证

- `git diff --check`
- `git diff origin/master..HEAD --check`

## 协作说明

- 跳过 worker：纯根 README 文档整理，不改变代码、发布流程或兼容性承诺。
- 跳过 reviewer：当前创建 draft PR，等待人工 review 后再合并。

## 风险

- README 内容结构有主观呈现取舍，建议维护者按最终叙事偏好 review。
- Star History 仍依赖 `api.star-history.com` 外链服务渲染曲线；服务不可用时 README 图片可能加载失败，不影响项目代码和发布流程。