### PR TITLE
ui-react: 支持 Knife4j 扩展字段驱动排序

### DIFF
--- a/docs-site/reference/annotations.md
+++ b/docs-site/reference/annotations.md
@@ -142,7 +142,7 @@ title: 注解速查表
 public class UserController { ... }
 ```
 
-> ⚠️ **React UI 注意**：`order` 排序在 React 前端暂不生效，`author`/`authors` 展示暂未实现。本仓库 `knife4j-vue3`（OAS2 starter）完整支持。
+> **React UI 注意**：`order` 会通过 `x-order` 写入 OpenAPI spec，React 前端已按该字段排序；`author`/`authors` 展示暂未实现。
 
 ### 3.2 `@ApiOperationSupport` — 接口增强
 
@@ -180,7 +180,7 @@ public UserVO create(@RequestBody UserCreateRequest req) { ... }
 @ApiOperationSupport(includeParameters = {"name", "email"})
 ```
 
-> ⚠️ **React UI 注意**：`order` 排序在 React 前端暂不生效，`author`/`authors` 展示暂未实现。`ignoreParameters`/`includeParameters` 依赖后端 OpenAPI customizer 修改 schema，React 前端可以消费其结果。
+> **React UI 注意**：`order` 会通过 `x-order` 写入 OpenAPI spec，React 前端已按该字段排序；`author`/`authors` 展示暂未实现。`ignoreParameters`/`includeParameters` 依赖后端 OpenAPI customizer 修改 schema，React 前端可以消费其结果。
 
 ### 3.3 `@DynamicParameter` / `@DynamicParameters` / `@DynamicResponseParameters` — 动态模型
 
@@ -349,13 +349,13 @@ public class UserController {
 
 ## 七、React UI 功能覆盖现状
 
-Knife4j 专有注解的后端增强逻辑通过 `Knife4jOpenApiCustomizer` / `Knife4jOperationCustomizer` 修改 OpenAPI spec，React 前端理论上可以消费修改后的 spec。但以下增强在 **React 前端 UI 层面**暂未实现：
+Knife4j 专有注解的后端增强逻辑通过 `Knife4jOpenApiCustomizer` / `Knife4jOperationCustomizer` 修改 OpenAPI spec。React 前端通过消费修改后的 spec 支持其中一部分增强：
 
 | 增强功能 | 后端是否生效 | Vue 3 UI（OAS2） | React UI（OAS3） | 说明 |
 | --- | --- | --- | --- | --- |
-| `@ApiSupport.order` Tag 排序 | ✅ 写入 spec | ✅ | ❌ | React 侧边栏暂不按 order 排序 |
+| `@ApiSupport.order` Tag 排序 | ✅ 写入 spec | ✅ | ✅ | React 按 `x-order` 排序，缺失时保持原排序策略 |
 | `@ApiSupport.author/authors` | ✅ 写入 spec | ✅ | ❌ | React 暂不展示开发者信息 |
-| `@ApiOperationSupport.order` 操作排序 | ✅ 写入 spec | ✅ | ❌ | React 操作列表暂不按 order 排序 |
+| `@ApiOperationSupport.order` 操作排序 | ✅ 写入 spec | ✅ | ✅ | React 按 `x-order` 排序，缺失时保持原排序策略 |
 | `@ApiOperationSupport.author/authors` | ✅ 写入 spec | ✅ | ❌ | React 暂不展示开发者信息 |
 | `ignoreParameters` / `includeParameters` | ✅ 修改 schema | ✅ | ⚠️ | 后端已修改 schema，React 能读到结果 |
 | `@DynamicParameter` 系列 | ⚠️ 仅 openapi2 | ✅ | ❌ | 4.0 起放弃维护 |
@@ -393,9 +393,9 @@ private String name;
 
 1. 确认 `knife4j.enable=true` 已配置。
 2. 确认使用的是 WebMvc Starter（非 WebFlux，WebFlux 不支持后端增强）。
-3. React 前端暂不支持按 `order` 排序，切换到本仓库 `knife4j-vue3`（OAS2 starter）验证。
+3. 确认使用的是 OAS3 WebMvc starter，并且 `/v3/api-docs` 的 `tags` 或 operation 中已写入 `x-order`。
+4. 如果 OpenAPI spec 中没有 `x-order`，先检查 `springdoc.group-configs.packages-to-scan` 是否覆盖到对应 Controller。
 
 ### `@Ignore` vs `@Hidden` 用哪个？
 
 功能重叠，推荐优先使用 OpenAPI 3 标准的 `@Hidden`。`@Ignore` 的额外好处是可附带忽略原因说明，但当前无 UI 消费此信息。
-

--- a/docs-site/roadmap/index.md
+++ b/docs-site/roadmap/index.md
@@ -85,9 +85,9 @@ title: 路线图
 
 | 功能 | Vue3 | React | 缺口说明 |
 | --- | --- | --- | --- |
-| `@ApiSupport.order` Tag 排序 | ✅ | ⬜ | 后端已生效，UI 不排序 |
+| `@ApiSupport.order` Tag 排序 | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
 | `@ApiSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
-| `@ApiOperationSupport.order` 操作排序 | ✅ | ⬜ | 后端已生效，UI 不排序 |
+| `@ApiOperationSupport.order` 操作排序 | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
 | `@ApiOperationSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
 | 自定义 Markdown 文档 | ✅ | ✅ | React 读取 `x-openapi.x-markdownFiles` 并在侧边栏渲染 |
 | 全局搜索（跨分组） | ✅ | 🔲 | React 仅搜索当前分组 |
@@ -131,7 +131,6 @@ title: 路线图
 
 1. **继续补齐 `knife4j.setting.*` UI 开关联动**：React 前端已读取部分 `x-openapi.x-setting` 字段，剩余字段按功能逐项接入
 2. **补齐 Postman 导出**
-3. **`@ApiSupport.order` / `@ApiOperationSupport.order` 排序**
-4. **补齐 multipart/form-data 文件上传细节**
+3. **补齐 multipart/form-data 文件上传细节**
 
 如果你想参与某个任务的实现，欢迎提 Issue 或 PR。详见 [GitHub 仓库](https://github.com/songxychn/knife4j-next)。

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchSwaggerUiConfig, parseGroupsFromConfig } from './knife4jClient';
+import type { SwaggerDoc } from '../types/swagger';
+import { fetchSwaggerUiConfig, parseGroupsFromConfig, parseMenuTags } from './knife4jClient';
 
 function jsonResponse(body: unknown, ok = true): Response {
   return {
@@ -38,5 +39,162 @@ describe('knife4jClient', () => {
 
   it('uses the single springdoc url when swagger-config has no urls array', () => {
     expect(parseGroupsFromConfig({ url: '/api/openapi' })).toEqual([{ name: 'default', url: '/api/openapi' }]);
+  });
+
+  it('sorts tags and operations by Knife4j x-order extensions', () => {
+    const doc: SwaggerDoc = {
+      openapi: '3.0.1',
+      info: { title: 'demo', version: '1.0.0' },
+      tags: [
+        { name: 'users', description: 'User APIs', 'x-order': 20 },
+        { name: 'pets', description: 'Pet APIs', 'x-order': 10 },
+      ],
+      paths: {
+        '/pets/search': {
+          get: {
+            tags: ['pets'],
+            summary: 'Search pets',
+            operationId: 'searchPets',
+            'x-order': 20,
+          },
+        },
+        '/pets': {
+          post: {
+            tags: ['pets'],
+            summary: 'Create pet',
+            operationId: 'createPet',
+            'x-order': 10,
+          },
+        },
+        '/users': {
+          get: {
+            tags: ['users'],
+            summary: 'List users',
+            operationId: 'listUsers',
+            'x-order': 10,
+          },
+        },
+      },
+    };
+
+    const menuTags = parseMenuTags(doc);
+
+    expect(menuTags.map((tag) => tag.tag)).toEqual(['pets', 'users']);
+    expect(menuTags[0].operations.map((operation) => operation.operationId)).toEqual(['createPet', 'searchPets']);
+  });
+
+  it('keeps a stable fallback when Knife4j x-order values tie or are invalid', () => {
+    const doc: SwaggerDoc = {
+      openapi: '3.0.1',
+      info: { title: 'demo', version: '1.0.0' },
+      tags: [
+        { name: 'users', 'x-order': 10 },
+        { name: 'pets', 'x-order': '10' },
+        { name: 'reports', 'x-order': 'invalid' },
+        { name: 'audit', 'x-order': 'NaN' },
+      ],
+      paths: {
+        '/users/search': {
+          get: {
+            tags: ['users'],
+            summary: 'Search users',
+            operationId: 'searchUsers',
+            'x-order': 20,
+          },
+        },
+        '/users/create': {
+          post: {
+            tags: ['users'],
+            summary: 'Create user',
+            operationId: 'createUser',
+            'x-order': '20',
+          },
+        },
+        '/users/export': {
+          get: {
+            tags: ['users'],
+            summary: 'Export users',
+            operationId: 'exportUsers',
+            'x-order': 'invalid',
+          },
+        },
+        '/users/import': {
+          post: {
+            tags: ['users'],
+            summary: 'Import users',
+            operationId: 'importUsers',
+            'x-order': 'NaN',
+          },
+        },
+      },
+    };
+
+    const menuTags = parseMenuTags(doc);
+
+    expect(menuTags.map((tag) => tag.tag)).toEqual(['users', 'pets', 'reports', 'audit']);
+    expect(menuTags[0].operations.map((operation) => operation.operationId)).toEqual([
+      'searchUsers',
+      'createUser',
+      'exportUsers',
+      'importUsers',
+    ]);
+  });
+
+  it('preserves source order when Knife4j x-order and sorter options are absent', () => {
+    const doc: SwaggerDoc = {
+      openapi: '3.0.1',
+      info: { title: 'demo', version: '1.0.0' },
+      tags: [{ name: 'users' }, { name: 'pets' }],
+      paths: {
+        '/z-users': {
+          get: {
+            tags: ['users'],
+            summary: 'List users',
+            operationId: 'listUsers',
+          },
+        },
+        '/a-users': {
+          post: {
+            tags: ['users'],
+            summary: 'Create user',
+            operationId: 'createUser',
+          },
+        },
+      },
+    };
+
+    const menuTags = parseMenuTags(doc);
+
+    expect(menuTags.map((tag) => tag.tag)).toEqual(['users', 'pets']);
+    expect(menuTags[0].operations.map((operation) => operation.operationId)).toEqual(['listUsers', 'createUser']);
+  });
+
+  it('falls back to configured sorters when Knife4j x-order is absent', () => {
+    const doc: SwaggerDoc = {
+      openapi: '3.0.1',
+      info: { title: 'demo', version: '1.0.0' },
+      tags: [{ name: 'users' }, { name: 'pets' }],
+      paths: {
+        '/z-users': {
+          get: {
+            tags: ['users'],
+            summary: 'List users',
+            operationId: 'listUsers',
+          },
+        },
+        '/a-users': {
+          post: {
+            tags: ['users'],
+            summary: 'Create user',
+            operationId: 'createUser',
+          },
+        },
+      },
+    };
+
+    const menuTags = parseMenuTags(doc, { tagsSorter: 'alpha', operationsSorter: 'alpha' });
+
+    expect(menuTags.map((tag) => tag.tag)).toEqual(['pets', 'users']);
+    expect(menuTags[1].operations.map((operation) => operation.operationId)).toEqual(['createUser', 'listUsers']);
   });
 });

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types/swagger';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
+const KNIFE4J_ORDER_EXTENSION = 'x-order';
 
 /** HTTP method 在 swagger-ui 'method' sorter 下的固定顺序 */
 const METHOD_ORDER: Record<string, number> = {
@@ -155,15 +156,51 @@ function sortOperations(ops: MenuOperation[], sorter: OperationsSorter): MenuOpe
   return sorted;
 }
 
+function parseKnife4jOrder(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const order = Number(value);
+    return Number.isFinite(order) ? order : null;
+  }
+  return null;
+}
+
+function sortByKnife4jOrder<T>(items: T[], getOrder: (item: T) => unknown): T[] | null {
+  const indexed = items.map((item, index) => ({
+    item,
+    index,
+    order: parseKnife4jOrder(getOrder(item)),
+  }));
+
+  if (!indexed.some((entry) => entry.order !== null)) {
+    return null;
+  }
+
+  return indexed
+    .sort((a, b) => {
+      if (a.order !== null && b.order !== null && a.order !== b.order) {
+        return a.order - b.order;
+      }
+      if (a.order !== null && b.order === null) return -1;
+      if (a.order === null && b.order !== null) return 1;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.item);
+}
+
 /** 将 SwaggerDoc 解析为侧边栏菜单结构 */
 export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): MenuTag[] {
   const tagsSorter = options.tagsSorter ?? 'preserve';
   const operationsSorter = options.operationsSorter ?? 'preserve';
 
   const tagMap = new Map<string, MenuTag>();
+  const tagOrders = new Map<string, unknown>();
 
   // 初始化 tag 列表（保持 doc.tags 原始顺序）
   (doc.tags ?? []).forEach((t) => {
+    tagOrders.set(t.name, t[KNIFE4J_ORDER_EXTENSION]);
     tagMap.set(t.name, { tag: t.name, description: t.description, operations: [] });
   });
 
@@ -193,13 +230,23 @@ export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): M
 
   let tags = Array.from(tagMap.values());
 
-  // 按策略对 operations 排序
-  if (operationsSorter !== 'preserve') {
-    tags = tags.map((t) => ({ ...t, operations: sortOperations(t.operations, operationsSorter) }));
-  }
+  // 优先按 Knife4j 扩展字段排序；未提供时回落到现有 springdoc / 用户 sorter 策略。
+  tags = tags.map((t) => {
+    const orderedOperations = sortByKnife4jOrder(t.operations, (op) => op.operation[KNIFE4J_ORDER_EXTENSION]);
+    if (orderedOperations) {
+      return { ...t, operations: orderedOperations };
+    }
+    if (operationsSorter !== 'preserve') {
+      return { ...t, operations: sortOperations(t.operations, operationsSorter) };
+    }
+    return t;
+  });
 
-  // 按策略对 tag 排序
-  if (tagsSorter === 'alpha') {
+  // 优先按 Knife4j 扩展字段排序；未提供时回落到现有 springdoc / 用户 sorter 策略。
+  const orderedTags = sortByKnife4jOrder(tags, (t) => tagOrders.get(t.tag));
+  if (orderedTags) {
+    tags = orderedTags;
+  } else if (tagsSorter === 'alpha') {
     tags = [...tags].sort((a, b) => a.tag.localeCompare(b.tag));
   }
 

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -74,6 +74,8 @@ export interface SwaggerServer {
 export interface SwaggerTag {
   name: string;
   description?: string;
+  /** Knife4j extension emitted from @ApiSupport.order. */
+  'x-order'?: number | string;
 }
 
 export interface SchemaObject {
@@ -152,6 +154,8 @@ export interface OperationObject {
   security?: Record<string, string[]>[];
   /** OAS3 operation 级 servers */
   servers?: SwaggerServer[];
+  /** Knife4j extension emitted from @ApiOperationSupport.order. */
+  'x-order'?: number | string;
 }
 
 export interface PathItemObject {


### PR DESCRIPTION
## 关联 Issue

- Closes #415

## 变更内容

- React UI 读取 OpenAPI spec 中的 `x-order` 扩展字段，用于 tag 与同 tag 下 operation 排序。
- 文档不含有效 `x-order` 时保持原有 `tagsSorter` / `operationsSorter` 行为。
- 补充单元测试覆盖正常排序、字段缺失 fallback、相同值稳定顺序、非法值 fallback。
- 同步 roadmap 与注解参考页，避免继续描述 React 不支持 `order`。

## worker handoff

- worker 已确认后端字段为 `x-order`，未猜字段名。
- worker 实现 React `parseMenuTags` 排序逻辑，并补充测试。
- worker 返工补齐相同值与非法值 fallback 测试。

## reviewer handoff

- 首轮 reviewer 发现 `docs-site/reference/annotations.md` 仍存在旧描述，已修复。
- 复核结论：无发现，`recommendation: approve`。

## 验证

- `./scripts/test-front-core.sh` 通过：`knife4j-core` 15 suites / 185 tests passed；`knife4j-ui-react` 9 files / 42 tests passed；format / lint / build passed。
- `./scripts/test-docs.sh` 通过。
- `git diff --check` 通过。

## 风险

- 同一列表中只要存在有效 `x-order`，React 会优先按 `x-order` 排序；缺少或非法 `x-order` 的项跟随有效项后并保持原始顺序。
- 完全没有有效 `x-order` 时保持原有 sorter 行为。
