### PR TITLE
增加 Boot3 Gateway smoke 覆盖

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
             echo ""
             echo "| module | tests | failures | errors |"
             echo "| --- | ---: | ---: | ---: |"
-            for module in boot2-app boot2-openapi3-app boot3-app boot3-jakarta-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
+            for module in boot2-app boot2-openapi3-app boot3-app boot3-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
               dir="$root/$module/target/surefire-reports"
               if [ ! -d "$dir" ]; then
                 echo "| $module | (missing) | - | - |"

--- a/docs-site/reference/compatibility.md
+++ b/docs-site/reference/compatibility.md
@@ -51,7 +51,7 @@ title: 兼容矩阵
 
 | Starter | Boot 2.7 | Boot 3.x | Boot 4.0 | 说明 | 验证状态 |
 | --- | --- | --- | --- | --- | --- |
-| `knife4j-gateway-spring-boot-starter` | ❌ | ✅ | ❌ | Spring Cloud Gateway 聚合 | ⚠️ 手动验证 |
+| `knife4j-gateway-spring-boot-starter` | ❌ | ✅ | ❌ | Spring Cloud Gateway 聚合 | [boot3-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-gateway-app) |
 | `knife4j-gateway-boot4-spring-boot-starter` | ❌ | ❌ | ✅ | Spring Cloud Gateway 5 聚合 | [boot4-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot4-gateway-app) |
 | `knife4j-aggregation-spring-boot-starter` | ✅ | ❌ | ❌ | 独立聚合（Boot 2.x） | ⚠️ 手动验证 |
 | `knife4j-aggregation-jakarta-spring-boot-starter` | ❌ | ✅ | ❌ | 独立聚合（Boot 3.x） | ⚠️ 手动验证 |

--- a/knife4j/knife4j-smoke-tests/boot3-gateway-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-gateway-app/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>5.0.7</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-boot3-gateway-app</artifactId>
+    <name>knife4j-smoke-boot3-gateway-app</name>
+
+    <properties>
+        <knife4j-java.version>17</knife4j-java.version>
+        <knife4j-spring3.version>6.2.7</knife4j-spring3.version>
+        <knife4j-spring-boot3.version>3.4.5</knife4j-spring-boot3.version>
+        <knife4j-spring-cloud3.version>2024.0.1</knife4j-spring-cloud3.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${knife4j-spring-boot3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${knife4j-spring-cloud3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-gateway-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/knife4j/knife4j-smoke-tests/boot3-gateway-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3gateway/Boot3GatewayDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot3-gateway-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3gateway/Boot3GatewayDocHttpSmokeTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot3gateway;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class Boot3GatewayDocHttpSmokeTest {
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void shouldServeDocHtmlAndManualSwaggerConfigOnBoot3Gateway() throws IOException {
+        context = new SpringApplicationBuilder(TestGatewayApplication.class)
+                .web(WebApplicationType.REACTIVE)
+                .properties(
+                        "server.port=0",
+                        "spring.main.banner-mode=off",
+                        "knife4j.gateway.enabled=true",
+                        "knife4j.gateway.strategy=MANUAL",
+                        "knife4j.gateway.routes[0].name=用户中心",
+                        "knife4j.gateway.routes[0].service-name=user-service",
+                        "knife4j.gateway.routes[0].url=/user-service/v3/api-docs",
+                        "knife4j.gateway.routes[0].context-path=/user-service",
+                        "knife4j.gateway.routes[0].order=1",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(docHtml.body.contains("webjars/knife4j-ui-react/"));
+
+        HttpResponse swaggerConfig = get(port, "/v3/api-docs/swagger-config");
+        Assert.assertEquals(200, swaggerConfig.statusCode);
+        Assert.assertTrue(swaggerConfig.body.contains("\"configUrl\""));
+        Assert.assertTrue(swaggerConfig.body.contains("/v3/api-docs/swagger-config"));
+        Assert.assertTrue(swaggerConfig.body.contains("\"urls\""));
+        Assert.assertTrue(swaggerConfig.body.contains("用户中心"));
+        Assert.assertTrue(swaggerConfig.body.contains("/user-service/v3/api-docs"));
+        Assert.assertTrue(swaggerConfig.body.contains("\"contextPath\":\"/user-service\""));
+    }
+
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static class HttpResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+
+    @SpringBootApplication
+    public static class TestGatewayApplication {
+    }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -25,6 +25,7 @@
         <module>boot2-openapi3-app</module>
         <module>boot3-jakarta-app</module>
         <module>boot3-app</module>
+        <module>boot3-gateway-app</module>
         <module>boot35-jakarta-app</module>
         <module>boot4-jakarta-app</module>
         <module>boot4-gateway-app</module>

--- a/scripts/test-java.sh
+++ b/scripts/test-java.sh
@@ -31,6 +31,7 @@ SMOKE_MODULES=(
   "boot2-openapi3-app"
   "boot3-app"
   "boot3-jakarta-app"
+  "boot3-gateway-app"
   "boot35-jakarta-app"
   "boot4-jakarta-app"
   "boot4-gateway-app"


### PR DESCRIPTION
## 关联 Issue

Closes #413

剩余独立聚合 starter smoke 覆盖已拆到 #417。

## 变更内容

- 新增 `knife4j-smoke-tests/boot3-gateway-app`，覆盖 Boot 3.x `knife4j-gateway-spring-boot-starter`。
- smoke 测试启动 Reactive Gateway 应用，验证 `/doc.html` 返回 200 且加载 React UI webjar。
- smoke 测试验证 `/v3/api-docs/swagger-config` 返回 200，并包含手工聚合分组信息。
- 将新模块纳入 Maven reactor、`scripts/test-java.sh` smoke evidence gate 和 CI smoke evidence summary。
- 更新兼容矩阵，把 Boot 3.x Gateway 验证状态指向 `boot3-gateway-app`。

## Worker / Reviewer

- Worker：已完成 Boot 3.x Gateway smoke 小切片；未修改 starter 运行时代码；未处理 aggregation starter。
- Reviewer：独立 reviewer 结论为 approve；findings、validation_gaps、scope_drift 均为 none。

## 验证

- `git diff --check`
- `bash -n scripts/test-java.sh`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH mvn -B -ntp -pl knife4j-smoke-tests/boot3-gateway-app -am -Dknife4j-skipTests=false test`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH ./scripts/test-java.sh`

完整 Java 验证已通过，尾部 smoke evidence 为 `==> Smoke-tests evidence OK (8 modules)`，其中 `boot3-gateway-app: tests=1 failures=0 errors=0`。

## 风险

- 本 PR 只补齐 Boot 3.x Gateway smoke，不扩大 Gateway starter 能力承诺。
- 独立聚合 starter 仍未覆盖，后续由 #417 跟踪。
