### PR TITLE
fix(aggregation-jakarta): 防止 cloud route 缺少 servicePath 时 swagger-config 报 500 (#421)

### DIFF
--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/utils/PathUtils.java
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/utils/PathUtils.java
@@ -103,6 +103,11 @@ public class PathUtils {
      * @since v4.2.0
      */
     public static String processContextPath(String contextPath) {
+        // 兼容 issue #421：Cloud 路由未配置 servicePath 时，SwaggerRoute.servicePath 可能为 null，
+        // 直接调用 endsWith 会抛 NPE，最终导致 /v3/api-docs/swagger-config 返回 500。
+        if (contextPath == null) {
+            return "";
+        }
         String validateContextPath = contextPath;
         if (DEFAULT_CONTEXT_PATH.equals(validateContextPath)) {
             validateContextPath = "";

--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcherSwaggerConfigTest.java
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcherSwaggerConfigTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.aggre.core;
+
+import com.github.xiaoymin.knife4j.aggre.cloud.CloudRoute;
+import com.github.xiaoymin.knife4j.aggre.conf.GlobalConstants;
+import com.github.xiaoymin.knife4j.aggre.core.cache.RouteInMemoryCache;
+import com.github.xiaoymin.knife4j.aggre.core.common.ExecutorEnum;
+import com.github.xiaoymin.knife4j.aggre.core.pojo.SwaggerRoute;
+import com.github.xiaoymin.knife4j.aggre.repository.CloudRepository;
+import com.github.xiaoymin.knife4j.aggre.spec.v2.OpenAPI2Resource;
+import com.github.xiaoymin.knife4j.aggre.spec.v3.OpenAPI3Response;
+import com.github.xiaoymin.knife4j.aggre.spring.support.CloudSetting;
+import com.github.xiaoymin.knife4j.aggre.spring.support.OpenAPIV3Setting;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+/**
+ * 回归 issue #421：聚合 starter 最简 cloud 配置访问 {@code /v3/api-docs/swagger-config} 返回 500。
+ *
+ * <p>原因是 {@link com.github.xiaoymin.knife4j.aggre.cloud.CloudRoute} 未配置 {@code servicePath}
+ * 时，{@link SwaggerRoute#getServicePath()} 为 {@code null}，进入
+ * {@link com.github.xiaoymin.knife4j.aggre.utils.PathUtils#processContextPath(String)} 触发
+ * {@link NullPointerException}，导致 {@code getOpenAPI3Response} 整体抛错。
+ */
+class RouteDispatcherSwaggerConfigTest {
+
+    @Test
+    void getOpenAPI3Response_shouldNotThrow_whenServicePathIsNull() {
+        // 复现 issue #421 上报的最简 cloud 配置
+        CloudRoute cloudRoute = new CloudRoute();
+        cloudRoute.setName("openapi3-demo");
+        cloudRoute.setUri("https://openapi3.demo.knife4jnext.com");
+        cloudRoute.setLocation("/v3/api-docs");
+        cloudRoute.setSwaggerVersion("3.0");
+        cloudRoute.setOrder(2);
+        // 故意不设置 servicePath，复刻用户最简配置
+
+        CloudSetting cloudSetting = new CloudSetting();
+        cloudSetting.setEnable(true);
+        cloudSetting.setRoutes(Collections.singletonList(cloudRoute));
+
+        CloudRepository cloudRepository = new CloudRepository(cloudSetting);
+
+        OpenAPIV3Setting openAPIV3Setting = new OpenAPIV3Setting();
+        RouteDispatcher dispatcher = new RouteDispatcher(
+                cloudRepository,
+                new RouteInMemoryCache(),
+                ExecutorEnum.APACHE,
+                GlobalConstants.DEFAULT_OPEN_API_V3_PATH,
+                openAPIV3Setting);
+
+        HttpServletRequest request = stubRequest();
+
+        OpenAPI3Response response = Assertions.assertDoesNotThrow(
+                () -> dispatcher.getOpenAPI3Response(request),
+                "Aggregation starter must not throw NPE when servicePath is unset (#421)");
+
+        Assertions.assertEquals(GlobalConstants.DEFAULT_OPEN_API_V3_CONFIG_PATH, response.getConfigUrl());
+        List<?> urls = response.getUrls();
+        Assertions.assertNotNull(urls);
+        Assertions.assertEquals(1, urls.size());
+
+        OpenAPI2Resource resource = (OpenAPI2Resource) urls.get(0);
+        Assertions.assertEquals("openapi3-demo", resource.getName());
+        Assertions.assertEquals("/v3/api-docs", resource.getUrl());
+        // 未配置 servicePath 时，contextPath 必须归一化为空字符串，避免拼接出多余的 "/"
+        Assertions.assertEquals("", resource.getContextPath());
+    }
+
+    /**
+     * 构造一个最小的 {@link HttpServletRequest} stub：仅返回空 contextPath 与空 Referer，
+     * 用于驱动 {@code RouteDispatcher#getOpenAPI3Response} 中对 contextPath 的解析路径。
+     * 通过 JDK 动态代理避免引入 spring-test / mockito 依赖。
+     */
+    private static HttpServletRequest stubRequest() {
+        InvocationHandler handler = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "getContextPath":
+                    return "";
+                case "getHeader":
+                    return null;
+                case "equals":
+                    return proxy == args[0];
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "toString":
+                    return "StubHttpServletRequest";
+                default:
+                    // 未涉及方法返回 null/0/false；接口方法仅原始类型时由代理框架处理。
+                    if (method.getReturnType().isPrimitive()) {
+                        if (method.getReturnType() == boolean.class) {
+                            return false;
+                        }
+                        return 0;
+                    }
+                    return null;
+            }
+        };
+        return (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                handler);
+    }
+
+}

--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/utils/PathUtilsTest.java
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/utils/PathUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.aggre.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 验证 {@link PathUtils#processContextPath(String)} 的健壮性。
+ *
+ * <p>回归覆盖 issue #421：Cloud 路由未配置 {@code servicePath} 时，
+ * {@link com.github.xiaoymin.knife4j.aggre.core.pojo.SwaggerRoute#getServicePath()} 为 {@code null}，
+ * 此前会触发 {@link NullPointerException}，最终 {@code /v3/api-docs/swagger-config} 返回 500。
+ */
+class PathUtilsTest {
+
+    @Test
+    void processContextPath_shouldReturnEmptyForNull() {
+        // issue #421 复现：null contextPath 不应抛 NPE
+        Assertions.assertEquals("", PathUtils.processContextPath(null));
+    }
+
+    @Test
+    void processContextPath_shouldReturnEmptyForRoot() {
+        Assertions.assertEquals("", PathUtils.processContextPath("/"));
+    }
+
+    @Test
+    void processContextPath_shouldStripTrailingSlash() {
+        Assertions.assertEquals("/api", PathUtils.processContextPath("/api"));
+        Assertions.assertEquals("/api", PathUtils.processContextPath("/api/"));
+        Assertions.assertEquals("/api/v1", PathUtils.processContextPath("/api/v1"));
+        Assertions.assertEquals("/api/v1", PathUtils.processContextPath("/api/v1/"));
+    }
+
+    @Test
+    void processContextPath_shouldPreserveEmptyString() {
+        Assertions.assertEquals("", PathUtils.processContextPath(""));
+    }
+}


### PR DESCRIPTION
## 关联 Issue

- 修复 #421「聚合 starter 最简示例报错」
- 与 #417「为独立聚合 starter 补齐 smoke 验证」相关：本 PR 仅用单元测试 + JDK 动态代理 stub 做窄回归，不在此处引入 smoke 工程，继续走 #417

## 变更内容

- `knife4j-aggregation-jakarta-spring-boot-starter` 中 `PathUtils.processContextPath(String)` 在传入 `null` 时返回空串，避免 `String.endsWith(...)` 抛 `NullPointerException`
- 新增 `PathUtilsTest`，覆盖 `null`、空串、根路径 `/`、带尾斜杠等场景
- 新增 `RouteDispatcherSwaggerConfigTest`，按 issue #421 的最简 cloud 配置（不设 `servicePath`）端到端复现 `getOpenAPI3Response`，断言不抛 NPE、`contextPath` 归一化为空串、`urls` 结构正确

## 根因

用户按文档配置最简 cloud 路由（Boot 3.5.14 + JDK 21）：

```yaml
knife4j:
  enable-aggregation: true
  cloud:
    enable: true
    routes:
      - name: openapi3-demo
        uri: https://openapi3.demo.knife4jnext.com
        location: /v3/api-docs
        swagger-version: "3.0"
        order: 2
```

未设置 `servicePath` 时触发链路：

- `CloudRoute.servicePath = null`
- `SwaggerRoute.servicePath = null`（保持默认）
- `RouteDispatcher.getOpenAPI3Response()` 调用 `PathUtils.processContextPath(copyRouter.getContextPath())`，参数为 `null`
- `processContextPath` 先比对 `DEFAULT_CONTEXT_PATH.equals(null)`（false），随后调用 `null.endsWith("/")` → NPE
- 异常向上抛出，UI 看到 `/v3/api-docs/swagger-config` 返回 500，前端页面为空

`/knife4j/config` 404 是 UI fallback 链上的次生现象：该端点由 `knife4j-openapi3-*-starter` 提供，聚合 starter 不暴露；React UI 在 `swagger-config` 正常时不会走到该 fallback，因此本 PR 不为聚合 starter 引入此端点，保持范围最小。

## 验证

- `./scripts/test-java.sh` 全绿（含 8 个 smoke 模块 evidence OK）：

```
==> Smoke-tests evidence OK (8 modules)
   [OK]      boot2-app: tests=3 failures=0 errors=0
   [OK]      boot2-openapi3-app: tests=3 failures=0 errors=0
   [OK]      boot3-app: tests=1 failures=0 errors=0
   [OK]      boot3-jakarta-app: tests=6 failures=0 errors=0
   [OK]      boot3-gateway-app: tests=1 failures=0 errors=0
   [OK]      boot35-jakarta-app: tests=2 failures=0 errors=0
   [OK]      boot4-jakarta-app: tests=2 failures=0 errors=0
   [OK]      boot4-gateway-app: tests=1 failures=0 errors=0
```

- 反向验证：临时移除 `PathUtils` 的 `null` guard，跑新增的两个测试都失败，错误为 `NullPointerException: Cannot invoke "String.endsWith(String)" because "validateContextPath" is null`，证明测试可证伪 fix 是否生效，不是 `KNOWN_PITFALLS` 中所说的「先 deref 再 null check」型假 bug。
- 横向核验：`knife4j-aggregation-spring-boot-starter`（Boot 2 老模块）没有 `utils/PathUtils`、也没有 `getOpenAPI3Response`，不存在同类 NPE，无需联动修复。

## Worker / Reviewer Handoff

- Worker：coordinator 直接实现（普通低风险窄修复：Java 单点 null guard + 单元测试 + 端到端复现，不改变外部 API 与默认行为）。
- Reviewer：派出独立 reviewer agent，按 `.agent/REVIEW_POLICY.md` 审查 diff。结论 `approve`，关键摘要：
  - 修复方向与根因一致，已用反向验证证伪。
  - 范围合理：Boot 2 老 starter 无同类 NPE；`/knife4j/config` 由 openapi3 starter 提供，聚合 starter 不引入是正确的窄范围决策。
  - 不属于「先 deref 再 null check」型假 bug。
  - 长期补 smoke 工程留给 #417 跟踪。

## 风险

- 改动仅为 `null → ""` 的归一化，行为与传入 `"/"` 路径分支等价；其它显式传字符串的调用方不受影响。
- 测试 stub 使用 JDK 动态代理仅响应 `getContextPath` / `getHeader`，未来若有其他 `RouteDispatcher` 端到端测试，可考虑抽出复用，本 PR 不扩范围。

## 是否需要人工决策

否。属于范围清晰的窄回归修复，无发布、坐标、兼容性承诺等变更。

