### PR TITLE
test(java): 补齐 Boot 2 聚合 smoke 验证

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
             echo ""
             echo "| module | tests | failures | errors |"
             echo "| --- | ---: | ---: | ---: |"
-            for module in boot2-app boot2-openapi3-app boot3-app boot3-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
+            for module in boot2-app boot2-openapi3-app aggregation-boot2-app boot3-app boot3-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
               dir="$root/$module/target/surefire-reports"
               if [ ! -d "$dir" ]; then
                 echo "| $module | (missing) | - | - |"

--- a/docs-site/reference/compatibility.md
+++ b/docs-site/reference/compatibility.md
@@ -53,7 +53,7 @@ title: 兼容矩阵
 | --- | --- | --- | --- | --- | --- |
 | `knife4j-gateway-spring-boot-starter` | ❌ | ✅ | ❌ | Spring Cloud Gateway 聚合 | [boot3-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-gateway-app) |
 | `knife4j-gateway-boot4-spring-boot-starter` | ❌ | ❌ | ✅ | Spring Cloud Gateway 5 聚合 | [boot4-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot4-gateway-app) |
-| `knife4j-aggregation-spring-boot-starter` | ✅ | ❌ | ❌ | 独立聚合（Boot 2.x） | ⚠️ 手动验证 |
+| `knife4j-aggregation-spring-boot-starter` | ✅ | ❌ | ❌ | 独立聚合（Boot 2.x） | [aggregation-boot2-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/aggregation-boot2-app) |
 | `knife4j-aggregation-jakarta-spring-boot-starter` | ❌ | ✅ | ❌ | 独立聚合（Boot 3.x） | ⚠️ 手动验证 |
 
 - Gateway starter 仅用于 Spring Cloud Gateway（WebFlux），**不适用于普通 WebMvc 项目**。

--- a/knife4j/knife4j-smoke-tests/aggregation-boot2-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/aggregation-boot2-app/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>5.0.7</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-aggregation-boot2-app</artifactId>
+    <name>knife4j-smoke-aggregation-boot2-app</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-aggregation-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${knife4j-spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/knife4j/knife4j-smoke-tests/aggregation-boot2-app/src/test/java/com/github/xiaoymin/knife4j/smoke/aggregationboot2/AggregationBoot2DocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/aggregation-boot2-app/src/test/java/com/github/xiaoymin/knife4j/smoke/aggregationboot2/AggregationBoot2DocHttpSmokeTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.aggregationboot2;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.context.WebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class AggregationBoot2DocHttpSmokeTest {
+
+    private static final String GROUP_NAME = "boot2-disk-group";
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void shouldServeDocHtmlAndSwaggerResourcesInDiskAggregationMode() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "spring.main.banner-mode=off",
+                        "knife4j.enable-aggregation=true",
+                        "knife4j.disk.enable=true",
+                        "knife4j.disk.routes[0].name=" + GROUP_NAME,
+                        "knife4j.disk.routes[0].location=classpath:smoke/boot2-aggregation-api.json",
+                        "knife4j.disk.routes[0].swagger-version=2.0",
+                        "knife4j.disk.routes[0].order=1",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(
+                "doc.html should reference Vue 3 webjar JS assets",
+                docHtml.body.contains("webjars/js/"));
+
+        HttpResponse swaggerResources = get(port, "/swagger-resources");
+        Assert.assertEquals(200, swaggerResources.statusCode);
+        Assert.assertTrue(
+                "swagger-resources should return a JSON array",
+                swaggerResources.body.trim().startsWith("["));
+        Assert.assertTrue(
+                "swagger-resources should contain the configured disk aggregation group",
+                swaggerResources.body.contains(GROUP_NAME));
+    }
+
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static class HttpResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+
+    @SpringBootApplication
+    public static class TestApplication {
+    }
+}

--- a/knife4j/knife4j-smoke-tests/aggregation-boot2-app/src/test/resources/smoke/boot2-aggregation-api.json
+++ b/knife4j/knife4j-smoke-tests/aggregation-boot2-app/src/test/resources/smoke/boot2-aggregation-api.json
@@ -1,0 +1,24 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Boot 2 aggregation smoke",
+    "version": "1.0.0"
+  },
+  "host": "localhost",
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/aggregation/hello": {
+      "get": {
+        "summary": "hello",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -23,6 +23,7 @@
     <modules>
         <module>boot2-app</module>
         <module>boot2-openapi3-app</module>
+        <module>aggregation-boot2-app</module>
         <module>boot3-jakarta-app</module>
         <module>boot3-app</module>
         <module>boot3-gateway-app</module>

--- a/scripts/test-java.sh
+++ b/scripts/test-java.sh
@@ -29,6 +29,7 @@ mvn -B -ntp -Dknife4j-skipTests=false verify
 SMOKE_MODULES=(
   "boot2-app"
   "boot2-openapi3-app"
+  "aggregation-boot2-app"
   "boot3-app"
   "boot3-jakarta-app"
   "boot3-gateway-app"


### PR DESCRIPTION
## 关联 Issue

Closes #424

## 变更内容

- 新增 `knife4j-smoke-tests/aggregation-boot2-app`，为 `knife4j-aggregation-spring-boot-starter` 补齐 Boot 2.x 独立聚合 smoke 覆盖。
- smoke 使用 disk 模式配置 `boot2-disk-group`，验证 `/doc.html` 返回 200 且引用 Vue 3 webjar 的 `webjars/js/`，验证 `/swagger-resources` 返回 200 且包含配置分组名。
- 同步登记 `knife4j-smoke-tests/pom.xml`、`scripts/test-java.sh`、`.github/workflows/build.yml`，并把兼容矩阵中的 Boot 2.x 聚合 starter 从手动验证改为新 smoke 链接。

## 协作记录

- worker：实现新增模块和登记点。初次实现环境混入了 #414 WebFlux 未提交内容，coordinator 已将 #424 diff 隔离到独立 worktree，仅保留本 issue 范围内的 7 个文件。
- reviewer：独立审查通过，结论 `approve`；无 findings、无验证缺口、无范围漂移，确认没有 WebFlux 登记、starter runtime 改动或生成物夹带。

## 验证

- `git diff --check`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH mvn -B -ntp -pl knife4j-smoke-tests/aggregation-boot2-app -am -Dknife4j-skipTests=false verify`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH ./scripts/test-java.sh`

完整 Java 验证通过，尾部 smoke evidence 为 `==> Smoke-tests evidence OK (9 modules)`，其中 `aggregation-boot2-app: tests=1 failures=0 errors=0`。

## 风险

- 未修改 starter 运行时代码；本 PR 只增加 smoke 覆盖、验证登记和兼容矩阵链接。
- Boot 2.x 聚合 starter 没有 OpenAPI 3 `/v3/api-docs/swagger-config` 端点，因此本 smoke 按 issue 范围只验证 `/swagger-resources`。
