### PR TITLE
test: 增加 WebFlux starter smoke 覆盖

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
             echo ""
             echo "| module | tests | failures | errors |"
             echo "| --- | ---: | ---: | ---: |"
-            for module in boot2-app boot2-openapi3-app boot3-app boot3-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
+            for module in boot2-app boot2-openapi3-app boot2-webflux-app boot3-app boot3-jakarta-app boot3-webflux-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
               dir="$root/$module/target/surefire-reports"
               if [ ! -d "$dir" ]; then
                 echo "| $module | (missing) | - | - |"

--- a/docs-site/reference/compatibility.md
+++ b/docs-site/reference/compatibility.md
@@ -41,8 +41,8 @@ title: 兼容矩阵
 
 | Starter | Boot 2.7 | Boot 3.x | UI | 验证状态 |
 | --- | --- | --- | --- | --- |
-| `knife4j-openapi3-webflux-spring-boot-starter` | ⚠️ | ❌ | React | 无 smoke test |
-| `knife4j-openapi3-webflux-jakarta-spring-boot-starter` | ❌ | ⚠️ | React | 无 smoke test |
+| `knife4j-openapi3-webflux-spring-boot-starter` | ✅ | ❌ | React | [boot2-webflux-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot2-webflux-app) |
+| `knife4j-openapi3-webflux-jakarta-spring-boot-starter` | ❌ | ✅ | React | [boot3-webflux-jakarta-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app) |
 
 - WebFlux starter 是**纯依赖编排**，不含后端增强能力（`@ApiOperationSupport`、`knife4j.setting.*` 等）。
 - 详见 [WebFlux 接入](../guide/webflux)。
@@ -62,7 +62,7 @@ title: 兼容矩阵
 
 ## Smoke Tests 验证内容
 
-WebMvc smoke-test 子模块验证以下端点返回 200 且内容正确；Gateway smoke-test 额外验证 `/doc.html` 和 `/v3/api-docs/swagger-config`：
+WebMvc smoke-test 子模块验证以下端点返回 200 且内容正确；WebFlux smoke-test 只验证 `/doc.html` 和 `/v3/api-docs`；Gateway smoke-test 额外验证 `/doc.html` 和 `/v3/api-docs/swagger-config`：
 
 | 端点 | openapi2 验证 | openapi3 验证 |
 | --- | --- | --- |
@@ -70,6 +70,8 @@ WebMvc smoke-test 子模块验证以下端点返回 200 且内容正确；Gatewa
 | `GET /v2/api-docs` | ✅ 包含 `"swagger":"2.0"` | — |
 | `GET /v3/api-docs` | — | ✅ 包含 `"openapi"` |
 | `GET /knife4j/config` | — | ✅ 返回 `schemaVersion`、`apiDocsUrl`、`swaggerConfigUrl`，且不出现在 OpenAPI 文档中 |
+
+WebFlux starter 是纯依赖编排，不声明 `/knife4j/config` 等 WebMvc starter 增强入口。
 
 运行全部 smoke test：
 

--- a/knife4j/knife4j-smoke-tests/boot2-webflux-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-webflux-app/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>5.0.7</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-boot2-webflux-app</artifactId>
+    <name>knife4j-smoke-boot2-webflux-app</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-openapi3-webflux-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>${knife4j-spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/knife4j/knife4j-smoke-tests/boot2-webflux-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2webflux/Boot2WebFluxDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot2-webflux-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot2webflux/Boot2WebFluxDocHttpSmokeTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot2webflux;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class Boot2WebFluxDocHttpSmokeTest {
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void shouldServeDocHtmlAndOpenApiJson() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.REACTIVE)
+                .properties(
+                        "server.port=0",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(docHtml.body.contains("webjars/knife4j-ui-react/"));
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+        Assert.assertTrue(apiDocs.body.contains("\"openapi\""));
+        Assert.assertTrue(apiDocs.body.contains("/hello"));
+    }
+
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static class HttpResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+
+    @SpringBootApplication
+    public static class TestApplication {
+    }
+
+    @RestController
+    public static class TestController {
+
+        @GetMapping("/hello")
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>5.0.7</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-boot3-webflux-jakarta-app</artifactId>
+    <name>knife4j-smoke-boot3-webflux-jakarta-app</name>
+
+    <properties>
+        <knife4j-spring3.version>6.2.7</knife4j-spring3.version>
+        <knife4j-spring-boot3.version>3.4.5</knife4j-spring-boot3.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>${knife4j-spring-boot3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3webflux/Boot3WebFluxJakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3webflux/Boot3WebFluxJakartaDocHttpSmokeTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot3webflux;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class Boot3WebFluxJakartaDocHttpSmokeTest {
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void shouldServeDocHtmlAndOpenApiJson() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.REACTIVE)
+                .properties(
+                        "server.port=0",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(docHtml.body.contains("webjars/knife4j-ui-react/"));
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+        Assert.assertTrue(apiDocs.body.contains("\"openapi\""));
+        Assert.assertTrue(apiDocs.body.contains("/hello"));
+    }
+
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static class HttpResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+
+    @SpringBootApplication
+    public static class TestApplication {
+    }
+
+    @RestController
+    public static class TestController {
+
+        @GetMapping("/hello")
+        public String hello() {
+            return "hello";
+        }
+    }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -23,7 +23,9 @@
     <modules>
         <module>boot2-app</module>
         <module>boot2-openapi3-app</module>
+        <module>boot2-webflux-app</module>
         <module>boot3-jakarta-app</module>
+        <module>boot3-webflux-jakarta-app</module>
         <module>boot3-app</module>
         <module>boot3-gateway-app</module>
         <module>boot35-jakarta-app</module>

--- a/scripts/test-java.sh
+++ b/scripts/test-java.sh
@@ -29,8 +29,10 @@ mvn -B -ntp -Dknife4j-skipTests=false verify
 SMOKE_MODULES=(
   "boot2-app"
   "boot2-openapi3-app"
+  "boot2-webflux-app"
   "boot3-app"
   "boot3-jakarta-app"
+  "boot3-webflux-jakarta-app"
   "boot3-gateway-app"
   "boot35-jakarta-app"
   "boot4-jakarta-app"


### PR DESCRIPTION
## 关联 Issue

Closes #414

## 变更内容

- 新增 `boot2-webflux-app`，覆盖 `knife4j-openapi3-webflux-spring-boot-starter` 在 Spring Boot 2.7 WebFlux 下的基础启动与文档入口。
- 新增 `boot3-webflux-jakarta-app`，覆盖 `knife4j-openapi3-webflux-jakarta-spring-boot-starter` 在 Spring Boot 3.4 Jakarta WebFlux 下的基础启动与文档入口。
- 将两个 WebFlux smoke 模块登记到 `knife4j-smoke-tests` reactor、`scripts/test-java.sh` smoke evidence gate 和 CI smoke summary。
- 更新兼容矩阵，把 WebFlux starter 从“无 smoke test”改为对应自动化模块，并继续明确 WebFlux starter 仅做依赖编排，不声明 `/knife4j/config` 等 WebMvc starter 增强入口。

## Worker Handoff

- worker 已实现两个 WebFlux smoke 模块，并完成定向 Maven 测试。
- coordinator 移除了 worker 过程中误带入的 aggregation smoke 越界内容，最终 diff 只保留 #414 范围。

## Reviewer Handoff

- 独立 reviewer 已审查 staged diff。
- 结论：无 findings、无 validation gaps、无 scope drift，recommendation: approve。

## 验证

- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH mvn -B -ntp -Dknife4j-skipTests=false -pl knife4j-smoke-tests/boot2-webflux-app,knife4j-smoke-tests/boot3-webflux-jakarta-app test`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH ./scripts/test-java.sh`
- 本地 smoke evidence：`==> Smoke-tests evidence OK (10 modules)`，其中 `boot2-webflux-app` 与 `boot3-webflux-jakarta-app` 均为 `tests=1 failures=0 errors=0`。
- PR CI：Build run #464 通过，`docs-build`、`front-core-test`、`java-build-test` 均 success，`Smoke-tests evidence summary` step success。

## 风险

- 本地默认 JDK 是 25，按 `.java-version` 使用 JDK 17 完成验证。
- WebFlux smoke 测试只覆盖 `/doc.html` 与 `/v3/api-docs`，不改变 WebFlux starter 的能力承诺。