### PR TITLE
test(java): 补齐 Boot 3 聚合 smoke 验证

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
             echo ""
             echo "| module | tests | failures | errors |"
             echo "| --- | ---: | ---: | ---: |"
-            for module in boot2-app boot2-openapi3-app boot2-webflux-app aggregation-boot2-app boot3-app boot3-jakarta-app boot3-webflux-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
+            for module in boot2-app boot2-openapi3-app boot2-webflux-app aggregation-boot2-app boot3-aggregation-jakarta-app boot3-app boot3-jakarta-app boot3-webflux-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
               dir="$root/$module/target/surefire-reports"
               if [ ! -d "$dir" ]; then
                 echo "| $module | (missing) | - | - |"

--- a/docs-site/reference/compatibility.md
+++ b/docs-site/reference/compatibility.md
@@ -54,7 +54,7 @@ title: 兼容矩阵
 | `knife4j-gateway-spring-boot-starter` | ❌ | ✅ | ❌ | Spring Cloud Gateway 聚合 | [boot3-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-gateway-app) |
 | `knife4j-gateway-boot4-spring-boot-starter` | ❌ | ❌ | ✅ | Spring Cloud Gateway 5 聚合 | [boot4-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot4-gateway-app) |
 | `knife4j-aggregation-spring-boot-starter` | ✅ | ❌ | ❌ | 独立聚合（Boot 2.x） | [aggregation-boot2-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/aggregation-boot2-app) |
-| `knife4j-aggregation-jakarta-spring-boot-starter` | ❌ | ✅ | ❌ | 独立聚合（Boot 3.x） | ⚠️ 手动验证 |
+| `knife4j-aggregation-jakarta-spring-boot-starter` | ❌ | ✅ | ❌ | 独立聚合（Boot 3.x） | [boot3-aggregation-jakarta-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app) |
 
 - Gateway starter 仅用于 Spring Cloud Gateway（WebFlux），**不适用于普通 WebMvc 项目**。
 - 聚合 starter 用于**非网关**的微服务聚合场景。
@@ -62,7 +62,7 @@ title: 兼容矩阵
 
 ## Smoke Tests 验证内容
 
-WebMvc smoke-test 子模块验证以下端点返回 200 且内容正确；WebFlux smoke-test 只验证 `/doc.html` 和 `/v3/api-docs`；Gateway smoke-test 额外验证 `/doc.html` 和 `/v3/api-docs/swagger-config`：
+WebMvc smoke-test 子模块验证以下端点返回 200 且内容正确；WebFlux smoke-test 只验证 `/doc.html` 和 `/v3/api-docs`；Gateway 与独立聚合 smoke-test 额外验证 `/doc.html` 和 `/v3/api-docs/swagger-config`：
 
 | 端点 | openapi2 验证 | openapi3 验证 |
 | --- | --- | --- |

--- a/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>5.0.7</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-boot3-aggregation-jakarta-app</artifactId>
+    <name>knife4j-smoke-boot3-aggregation-jakarta-app</name>
+
+    <properties>
+        <knife4j-java.version>17</knife4j-java.version>
+        <knife4j-spring3.version>6.2.7</knife4j-spring3.version>
+        <knife4j-spring-boot3.version>3.4.5</knife4j-spring-boot3.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${knife4j-spring-boot3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3aggregation/Boot3AggregationJakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3aggregation/Boot3AggregationJakartaDocHttpSmokeTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot3aggregation;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Boot3AggregationJakartaDocHttpSmokeTest {
+
+    private static final Pattern SWAGGER_INSTANCE_URL = Pattern.compile("\"url\":\"([^\"]*/swagger-instance\\?group=[^\"]+)\"");
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void shouldServeDocHtmlAndDiskSwaggerConfigOnBoot3Aggregation() throws IOException {
+        context = new SpringApplicationBuilder(TestAggregationApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "spring.main.banner-mode=off",
+                        "knife4j.enable-aggregation=true",
+                        "knife4j.disk.enable=true",
+                        "knife4j.disk.routes[0].name=聚合用户服务",
+                        "knife4j.disk.routes[0].location=classpath:swagger/user-service-openapi.json",
+                        "knife4j.disk.routes[0].swagger-version=3.0",
+                        "knife4j.disk.routes[0].service-path=/user-service",
+                        "knife4j.disk.routes[0].order=1",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse docHtml = get(port, "/doc.html");
+        Assert.assertEquals(200, docHtml.statusCode);
+        Assert.assertTrue(docHtml.body.contains("webjars/knife4j-ui-react/"));
+
+        HttpResponse swaggerConfig = get(port, "/v3/api-docs/swagger-config");
+        Assert.assertEquals(200, swaggerConfig.statusCode);
+        String swaggerConfigBody = swaggerConfig.body.replace("\\u003d", "=");
+        Assert.assertTrue(swaggerConfigBody.contains("\"configUrl\""));
+        Assert.assertTrue(swaggerConfigBody.contains("/v3/api-docs/swagger-config"));
+        Assert.assertTrue(swaggerConfigBody.contains("\"urls\""));
+        Assert.assertTrue(swaggerConfigBody.contains("聚合用户服务"));
+        Assert.assertTrue(swaggerConfigBody.contains("/user-service/swagger-instance?group="));
+        Assert.assertTrue(swaggerConfigBody.contains("\"contextPath\":\"/user-service\""));
+
+        String swaggerInstanceUrl = extractSwaggerInstanceUrl(swaggerConfigBody);
+        HttpResponse swaggerInstance = get(port, swaggerInstanceUrl);
+        Assert.assertEquals(200, swaggerInstance.statusCode);
+        Assert.assertTrue(swaggerInstance.body.contains("\"openapi\": \"3.0.3\""));
+        Assert.assertTrue(swaggerInstance.body.contains("Aggregated User Service"));
+        Assert.assertTrue(swaggerInstance.body.contains("/users"));
+    }
+
+    private String extractSwaggerInstanceUrl(String swaggerConfigBody) {
+        Matcher matcher = SWAGGER_INSTANCE_URL.matcher(swaggerConfigBody);
+        Assert.assertTrue("swagger-config should expose a disk swagger-instance URL:\n" + swaggerConfigBody,
+                matcher.find());
+        return matcher.group(1);
+    }
+
+    private HttpResponse get(int port, String path) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static class HttpResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+
+    @SpringBootApplication
+    public static class TestAggregationApplication {
+    }
+}

--- a/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/src/test/resources/swagger/user-service-openapi.json
+++ b/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/src/test/resources/swagger/user-service-openapi.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Aggregated User Service",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "List users",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -25,6 +25,7 @@
         <module>boot2-openapi3-app</module>
         <module>boot2-webflux-app</module>
         <module>aggregation-boot2-app</module>
+        <module>boot3-aggregation-jakarta-app</module>
         <module>boot3-jakarta-app</module>
         <module>boot3-webflux-jakarta-app</module>
         <module>boot3-app</module>

--- a/scripts/test-java.sh
+++ b/scripts/test-java.sh
@@ -31,6 +31,7 @@ SMOKE_MODULES=(
   "boot2-openapi3-app"
   "boot2-webflux-app"
   "aggregation-boot2-app"
+  "boot3-aggregation-jakarta-app"
   "boot3-app"
   "boot3-jakarta-app"
   "boot3-webflux-jakarta-app"


### PR DESCRIPTION
## 关联 Issue

- #417

## 变更内容

- 新增 `boot3-aggregation-jakarta-app` smoke 模块，使用 Spring Boot 3.4.5、Servlet 和 `knife4j-aggregation-jakarta-spring-boot-starter`。
- smoke 启用 `knife4j.enable-aggregation=true` 与 disk 聚合配置，验证 `/doc.html`、`/v3/api-docs/swagger-config`，并通过 `/swagger-instance?group=...` 读取本地 OpenAPI 3 fixture。
- 同步 `knife4j-smoke-tests/pom.xml`、`scripts/test-java.sh`、CI smoke evidence summary 与兼容矩阵。
- `aggregation-boot2-app` 已由 #424 / #425 合入，本 PR 仅补 Boot 3.x Jakarta 独立聚合入口。

## 协作记录

- worker：完成 Boot 3.x Jakarta 独立聚合 smoke 模块与登记点。
- reviewer：最终复核 staged diff，结论 `approve`；无 findings、无验证缺口、无范围漂移。

## 验证

- `git diff --cached --check`：通过。
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/.bun/bin:/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin ./scripts/test-java.sh`：通过，尾部证据为 `==> Smoke-tests evidence OK (12 modules)`，其中 `boot3-aggregation-jakarta-app: tests=1 failures=0 errors=0`。
- `./scripts/test-docs.sh`：通过。

## 风险

- 未修改 starter runtime 行为，仅增加 smoke 覆盖和验证状态登记。
