### PR TITLE
展示 operation x-author 作者信息

### DIFF
--- a/docs-site/reference/annotations.md
+++ b/docs-site/reference/annotations.md
@@ -142,7 +142,7 @@ title: 注解速查表
 public class UserController { ... }
 ```
 
-> **React UI 注意**：`order` 会通过 `x-order` 写入 OpenAPI spec，React 前端已按该字段排序；`author`/`authors` 展示暂未实现。
+> **React UI 注意**：`order` 会通过 `x-order` 写入 OpenAPI spec，React 前端已按该字段排序；`author`/`authors` 会由后端合并为 operation `x-author`，React 在接口详情页展示该 operation 作者信息，不额外推断 Tag 级作者。
 
 ### 3.2 `@ApiOperationSupport` — 接口增强
 
@@ -180,7 +180,7 @@ public UserVO create(@RequestBody UserCreateRequest req) { ... }
 @ApiOperationSupport(includeParameters = {"name", "email"})
 ```
 
-> **React UI 注意**：`order` 会通过 `x-order` 写入 OpenAPI spec，React 前端已按该字段排序；`author`/`authors` 展示暂未实现。`ignoreParameters`/`includeParameters` 依赖后端 OpenAPI customizer 修改 schema，React 前端可以消费其结果。
+> **React UI 注意**：`order` 会通过 `x-order` 写入 OpenAPI spec，React 前端已按该字段排序；`author`/`authors` 会由后端合并为 operation `x-author`，React 在接口详情页展示该 operation 作者信息。`ignoreParameters`/`includeParameters` 依赖后端 OpenAPI customizer 修改 schema，React 前端可以消费其结果。
 
 ### 3.3 `@DynamicParameter` / `@DynamicParameters` / `@DynamicResponseParameters` — 动态模型
 
@@ -354,9 +354,9 @@ Knife4j 专有注解的后端增强逻辑通过 `Knife4jOpenApiCustomizer` / `Kn
 | 增强功能 | 后端是否生效 | Vue 3 UI（OAS2） | React UI（OAS3） | 说明 |
 | --- | --- | --- | --- | --- |
 | `@ApiSupport.order` Tag 排序 | ✅ 写入 spec | ✅ | ✅ | React 按 `x-order` 排序，缺失时保持原排序策略 |
-| `@ApiSupport.author/authors` | ✅ 写入 spec | ✅ | ❌ | React 暂不展示开发者信息 |
+| `@ApiSupport.author/authors` | ✅ 写入 spec | ✅ | ✅ | 类级作者由后端回退写入 operation `x-author`，React 展示 operation 作者信息，不做 Tag 级聚合 |
 | `@ApiOperationSupport.order` 操作排序 | ✅ 写入 spec | ✅ | ✅ | React 按 `x-order` 排序，缺失时保持原排序策略 |
-| `@ApiOperationSupport.author/authors` | ✅ 写入 spec | ✅ | ❌ | React 暂不展示开发者信息 |
+| `@ApiOperationSupport.author/authors` | ✅ 写入 spec | ✅ | ✅ | 后端合并为 operation `x-author`，React 在接口详情页展示非空字符串值 |
 | `ignoreParameters` / `includeParameters` | ✅ 修改 schema | ✅ | ⚠️ | 后端已修改 schema，React 能读到结果 |
 | `@DynamicParameter` 系列 | ⚠️ 仅 openapi2 | ✅ | ❌ | 4.0 起放弃维护 |
 | `@Ignore` | ✅ 过滤接口 | ✅ | ⚠️ | 后端过滤后 React 不展示被忽略接口 |

--- a/docs-site/roadmap/index.md
+++ b/docs-site/roadmap/index.md
@@ -46,6 +46,7 @@ title: 路线图
 | React 前端 | 设置面板默认值与后端 starter 对齐，能读取 OpenAPI 文档中的 `enableHost` 等服务端注入项 | ✅ |
 | React 前端 | 调试器 raw body 多格式 Beautify（JSON / XML / HTML / JavaScript）与完整 MIME 展示 | ✅ |
 | React 前端 | `enableSwaggerModels=false` 时 Schema 页以 403 提示填充，路由守卫防止被禁用路径被访问 | ✅ |
+| React 前端 | ApiDoc 展示 operation `x-author` 作者信息 | ✅ |
 | knife4j-core | debug 解析层抽取（resolveRef / OperationDebugModel / requestBuilder） | ✅ |
 | knife4j-core | buildSchemaExample & buildSchemaFieldTree | ✅ |
 | 基础设施 | Bun workspace 统一 knife4j-front 包管理 | ✅ |
@@ -86,9 +87,9 @@ title: 路线图
 | 功能 | Vue3 | React | 缺口说明 |
 | --- | --- | --- | --- |
 | `@ApiSupport.order` Tag 排序 | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
-| `@ApiSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
+| `@ApiSupport.author/authors` 展示 | ✅ | ✅ | 类级作者由后端回退写入 operation `x-author`，React 在接口详情页展示，不做 Tag 级聚合 |
 | `@ApiOperationSupport.order` 操作排序 | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
-| `@ApiOperationSupport.author/authors` 展示 | ✅ | ⬜ | 后端已写入 spec，UI 不展示 |
+| `@ApiOperationSupport.author/authors` 展示 | ✅ | ✅ | 后端合并为 operation `x-author`，React 展示非空作者字符串 |
 | 自定义 Markdown 文档 | ✅ | ✅ | React 读取 `x-openapi.x-markdownFiles` 并在侧边栏渲染 |
 | 全局搜索（跨分组） | ✅ | 🔲 | React 仅搜索当前分组 |
 | TypeScript 代码生成 | ✅ | ✅ | React 操作页提供基础 JS / TypeScript 请求函数片段 |

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -76,6 +76,7 @@ const enUS = {
   'apiDoc.notFound.title': 'API doc not found',
   'apiDoc.notFound.desc': 'No OpenAPI operation matched the current route. Please reopen from the left API list.',
   'apiDoc.deprecated': 'Deprecated',
+  'apiDoc.author': 'Author:',
   'apiDoc.requestParams': 'Request Parameters',
   'apiDoc.col.paramName': 'Name',
   'apiDoc.col.location': 'In',

--- a/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
@@ -77,6 +77,7 @@ const jaJP = {
   'apiDoc.notFound.desc':
     '現在のルートに一致する OpenAPI operation はありません。左側の API 一覧から開き直してください。',
   'apiDoc.deprecated': '非推奨',
+  'apiDoc.author': '作成者：',
   'apiDoc.requestParams': 'リクエストパラメータ',
   'apiDoc.col.paramName': '名前',
   'apiDoc.col.location': '位置',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -75,6 +75,7 @@ const zhCN = {
   'apiDoc.notFound.title': '未找到接口文档',
   'apiDoc.notFound.desc': '当前路由没有匹配到 OpenAPI operation，请重新从左侧接口列表打开。',
   'apiDoc.deprecated': '已废弃',
+  'apiDoc.author': '作者：',
   'apiDoc.requestParams': '请求参数',
   'apiDoc.col.paramName': '参数名',
   'apiDoc.col.location': '位置',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -11,6 +11,7 @@ import { buildSchemaExample, generateApiMarkdown } from 'knife4j-core';
 import SchemaFieldTable, { SchemaTypeLink } from '../../components/schema/SchemaFieldTable';
 import { schemaNameFromRef } from '../../components/schema/schemaUtils';
 import CodeBlock from './CodeBlock';
+import { operationAuthors } from './operationAuthor';
 
 const { Title, Text } = Typography;
 
@@ -323,6 +324,7 @@ export default function ApiDoc() {
 
   const requestExample = buildJsonExample(bodySchema, swaggerDoc);
   const respExamples = responseExamples(op.responses, swaggerDoc);
+  const authors = operationAuthors(op);
 
   return (
     <OperationModeLayout activeKey="doc">
@@ -351,6 +353,7 @@ export default function ApiDoc() {
         style={{
           display: 'flex',
           alignItems: 'center',
+          flexWrap: 'wrap',
           gap: 12,
           marginBottom: 8,
         }}
@@ -358,10 +361,32 @@ export default function ApiDoc() {
         <Tag color={METHOD_COLOR[method] ?? 'default'} style={{ fontSize: 14, padding: '2px 10px' }}>
           {method}
         </Tag>
-        <Text code style={{ fontSize: 15 }}>
+        <Text code style={{ fontSize: 15, wordBreak: 'break-all' }}>
           {operation.path}
         </Text>
         {op.deprecated && <Tag color="red">{t('apiDoc.deprecated')}</Tag>}
+        {authors.length > 0 && (
+          <Space size={4} wrap style={{ minWidth: 0 }}>
+            <Text type="secondary" style={{ fontSize: 13 }}>
+              {t('apiDoc.author')}
+            </Text>
+            {authors.map((author, index) => (
+              <Tag
+                key={`${author}-${index}`}
+                color="geekblue"
+                style={{
+                  marginInlineEnd: 0,
+                  maxWidth: 280,
+                  overflowWrap: 'anywhere',
+                  whiteSpace: 'normal',
+                }}
+                title={author}
+              >
+                {author}
+              </Tag>
+            ))}
+          </Space>
+        )}
       </div>
       {op.description && <Markdown source={op.description} />}
 

--- a/knife4j-front/knife4j-ui-react/src/pages/api/operationAuthor.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/operationAuthor.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeOperationAuthors, operationAuthors } from './operationAuthor';
+
+describe('operation author formatting', () => {
+  it('splits comma-joined x-author values and trims empty entries', () => {
+    expect(normalizeOperationAuthors(' Alice, Bob ,, Carol ')).toEqual(['Alice', 'Bob', 'Carol']);
+  });
+
+  it('keeps a single non-empty author value', () => {
+    expect(operationAuthors({ 'x-author': '张三' })).toEqual(['张三']);
+  });
+
+  it('ignores blank or unsupported x-author values', () => {
+    expect(normalizeOperationAuthors('   ')).toEqual([]);
+    expect(normalizeOperationAuthors(['Alice'])).toEqual([]);
+    expect(normalizeOperationAuthors({ name: 'Alice' })).toEqual([]);
+    expect(operationAuthors(undefined)).toEqual([]);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/operationAuthor.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/operationAuthor.ts
@@ -1,0 +1,13 @@
+import type { OperationObject } from '../../types/swagger';
+
+export function normalizeOperationAuthors(value: unknown): string[] {
+  if (typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map((author) => author.trim())
+    .filter(Boolean);
+}
+
+export function operationAuthors(operation: Pick<OperationObject, 'x-author'> | undefined): string[] {
+  return normalizeOperationAuthors(operation?.['x-author']);
+}

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -156,6 +156,8 @@ export interface OperationObject {
   servers?: SwaggerServer[];
   /** Knife4j extension emitted from @ApiOperationSupport.order. */
   'x-order'?: number | string;
+  /** Knife4j extension emitted from @ApiOperationSupport.author/authors. */
+  'x-author'?: string;
 }
 
 export interface PathItemObject {


### PR DESCRIPTION
## 关联 Issue

Closes #434

## 变更内容

- `OperationObject` 增加 `x-author` 扩展字段声明。
- `ApiDoc` 在 operation 元信息区展示非空字符串型 `x-author`，按逗号拆成作者 Tag；缺失、空白或非法类型不展示占位。
- 新增 `operationAuthor` 纯函数和定向测试，覆盖拆分、trim、空白和非法类型。
- 同步 `docs-site/reference/annotations.md` 与 `docs-site/roadmap/index.md`，说明 React 展示的是 operation `x-author`，类级作者由后端回退写入 operation，不做 Tag 级聚合。

## 协作门禁

- worker handoff：已完成限定范围实现；改动文件均在 #434 允许范围内。
- reviewer handoff：approve，无发现。
- 残余风险：未做浏览器截图/视觉验证；长作者文本布局通过代码样式审查、前端测试、构建和 lint 覆盖。

## 验证

- `./scripts/test-front-core.sh` 通过。沙箱 tempdir 首次失败后提升权限重跑；`knife4j-core` 15 suites / 185 tests 通过，`knife4j-ui-react` 10 files / 46 tests 通过，build/lint 通过；仅保留 Vite chunk size warning。
- `./scripts/test-docs.sh` 通过。
- `git show --check HEAD` 通过。

## 范围外

- 不修改 Java 注解扫描或 `x-author` 写入逻辑。
- 不新增 `x-authors` 数组 extension。
- 不实现 tag-level 作者聚合视图。
- 不处理 OAS2 / Vue3 兼容线。