### PR TITLE
test(java): 补充接口作者 smoke 覆盖

### DIFF
--- a/knife4j/knife4j-smoke-tests/boot3-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3JakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot3-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot3/Boot3JakartaDocHttpSmokeTest.java
@@ -17,6 +17,9 @@
 
 package com.github.xiaoymin.knife4j.smoke.boot3;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.xiaoymin.knife4j.annotations.ApiOperationSupport;
 import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -42,6 +45,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 public class Boot3JakartaDocHttpSmokeTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private ConfigurableApplicationContext context;
 
@@ -72,6 +77,36 @@ public class Boot3JakartaDocHttpSmokeTest {
         Assert.assertEquals(200, apiDocs.statusCode);
         Assert.assertTrue(apiDocs.body.contains("\"openapi\""));
         Assert.assertTrue(apiDocs.body.contains("/hello"));
+    }
+
+    @Test
+    public void shouldExposeOperationAuthorsFromApiOperationSupport() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+
+        JsonNode helloOperation = OBJECT_MAPPER.readTree(apiDocs.body)
+                .path("paths")
+                .path("/hello")
+                .path("get");
+        Assert.assertFalse("api-docs should contain GET /hello operation", helloOperation.isMissingNode());
+
+        String author = helloOperation.path("x-author").asText();
+        Assert.assertTrue("x-author should contain wxp for @ApiOperationSupport.authors (#438):\n"
+                + apiDocs.body, author.contains("wxp"));
+        Assert.assertTrue("x-author should contain wfg for @ApiOperationSupport.authors (#438):\n"
+                + apiDocs.body, author.contains("wfg"));
+        Assert.assertEquals("x-order should keep @ApiOperationSupport.order for the same operation (#438)",
+                1, helloOperation.path("x-order").asInt());
     }
 
     @Test
@@ -327,6 +362,7 @@ public class Boot3JakartaDocHttpSmokeTest {
     @RestController
     public static class TestController {
 
+        @ApiOperationSupport(authors = {"wxp", "wfg"}, order = 1)
         @GetMapping("/hello")
         public String hello() {
             return "hello";


### PR DESCRIPTION
## 关联 Issue

Closes #438

## 变更内容

- 在 Boot 3 Jakarta smoke 的 `/hello` 接口上加入 `@ApiOperationSupport(authors = {"wxp", "wfg"}, order = 1)`，对应 #438 的用户示例。
- 新增 `/v3/api-docs` JSON 断言，确认 `GET /hello` operation 写出 `x-author`，且包含 `wxp`、`wfg`，同时保留 `x-order = 1`。

## 说明

- 当前 `master` 的 React operation `x-author` 展示已由 PR #436 合入；#438 中提到的 `5.0.8` 版本尚不包含该前端展示能力。
- 本 PR 不修改 Java 注解扫描或运行时 customizer，只补后端 spec 回归证据。
- 不处理 OAS2 / Vue3 兼容线，也不新增 tag-level 作者聚合。

## 协作门禁

- worker handoff：跳过独立 worker。原因：维护者现场指定任务，改动为单文件 smoke 覆盖；当前 Codex 工具策略没有显式授权启动 sub-agent。替代验证为定向 Maven 测试和完整 Java gate。
- reviewer handoff：跳过独立 reviewer，等待维护者 PR review。未将 coordinator 自查描述为独立审查。
- 已知风险：`x-author` 当前仍是逗号拼接字符串，本 PR 仅断言包含两个作者，不改变作者顺序或扩展字段格式。

## 验证

- `env JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH mvn -B -ntp -pl knife4j-smoke-tests/boot3-jakarta-app -am -Dknife4j-skipTests=false test` 通过；`Boot3JakartaDocHttpSmokeTest` 7 tests / 0 failures / 0 errors。
- `env JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH ./scripts/test-java.sh` 通过；尾部输出 `==> Smoke-tests evidence OK (12 modules)`。
- `git diff --check` 通过。
