### PR TITLE
fix(ui-react): 兼容缺失 info 的 OpenAPI 文档

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SwaggerDoc } from '../types/swagger';
-import { fetchSwaggerUiConfig, parseGroupsFromConfig, parseMenuTags } from './knife4jClient';
+import { fetchSwaggerDoc, fetchSwaggerUiConfig, parseGroupsFromConfig, parseMenuTags } from './knife4jClient';
 
 function jsonResponse(body: unknown, ok = true): Response {
   return {
@@ -39,6 +39,29 @@ describe('knife4jClient', () => {
 
   it('uses the single springdoc url when swagger-config has no urls array', () => {
     expect(parseGroupsFromConfig({ url: '/api/openapi' })).toEqual([{ name: 'default', url: '/api/openapi' }]);
+  });
+
+  it('keeps a malformed OpenAPI document with missing info from crashing the UI', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        openapi: '3.1.0',
+        paths: {},
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchSwaggerDoc('/v3/api-docs')).resolves.toEqual({
+      openapi: '3.1.0',
+      info: { title: 'Unknown', version: '' },
+      paths: {},
+    });
+  });
+
+  it('rejects non OpenAPI payloads from api-docs endpoints', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ error: 'not found' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchSwaggerDoc('/v3/api-docs')).resolves.toBeNull();
   });
 
   it('sorts tags and operations by Knife4j x-order extensions', () => {

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -6,6 +6,7 @@
 import type {
   SwaggerDoc,
   SwaggerGroup,
+  SwaggerInfo,
   MenuTag,
   MenuOperation,
   SwaggerUiConfig,
@@ -14,6 +15,7 @@ import type {
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
 const KNIFE4J_ORDER_EXTENSION = 'x-order';
+type UnknownRecord = Record<string, unknown>;
 
 /** HTTP method 在 swagger-ui 'method' sorter 下的固定顺序 */
 const METHOD_ORDER: Record<string, number> = {
@@ -68,6 +70,40 @@ async function fetchSwaggerUiConfigFrom(url: string): Promise<SwaggerUiConfig | 
   }
 }
 
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeSwaggerInfo(value: unknown): SwaggerInfo {
+  if (!isRecord(value)) {
+    return { title: 'Unknown', version: '' };
+  }
+
+  const info = value as Partial<SwaggerInfo>;
+  const title = typeof info.title === 'string' && info.title.length > 0 ? info.title : 'Unknown';
+  const version =
+    typeof info.version === 'string'
+      ? info.version
+      : typeof info.version === 'number' && Number.isFinite(info.version)
+        ? String(info.version)
+        : '';
+
+  return { ...info, title, version };
+}
+
+function normalizeSwaggerDoc(value: unknown): SwaggerDoc | null {
+  if (!isRecord(value)) return null;
+
+  const hasSpecSignal = typeof value.openapi === 'string' || typeof value.swagger === 'string' || isRecord(value.paths);
+  if (!hasSpecSignal) return null;
+
+  return {
+    ...value,
+    info: normalizeSwaggerInfo(value.info),
+    paths: isRecord(value.paths) ? value.paths : {},
+  } as SwaggerDoc;
+}
+
 /**
  * 从已获取的 SwaggerUiConfig 解析 group 列表。
  * - 有 `urls` → 多文档场景
@@ -116,7 +152,7 @@ export async function fetchSwaggerDoc(url: string): Promise<SwaggerDoc | null> {
   try {
     const res = await fetch(url);
     if (!res.ok) return null;
-    return (await res.json()) as SwaggerDoc;
+    return normalizeSwaggerDoc(await res.json());
   } catch (_) {
     return null;
   }


### PR DESCRIPTION
## 关联 Issue

Fixes #442

## 问题原因

#442 的错误栈显示 React UI 在首页读取 `info.version` 时遇到 `info` 缺失并崩溃。当前 `fetchSwaggerDoc` 直接把 `api-docs` 响应断言成 `SwaggerDoc`，一旦后端返回缺少 `info` 的 OpenAPI 文档，后续 Home、导出等页面都会拿到会崩溃的数据结构。

本次没有拿到报告环境的完整 Spring Boot 4 / springdoc 复现工程，因此修复范围限定为前端数据入口对缺失 `info` 的容错，不扩大到后端兼容性判断。

## 变更内容

- 在 `fetchSwaggerDoc` 入口增加 OpenAPI/Swagger 文档形状归一化。
- 对缺失或不完整的 `info` 补充最小 `title/version`，避免首页访问 `info.version` 崩溃。
- 对明显不是 OpenAPI/Swagger 文档的 JSON 响应返回 `null`，让现有 group 加载失败路径处理。
- 增加 `knife4jClient` 回归测试，覆盖缺失 `info` 和非文档响应两类情况。

## 协作门禁

- worker：跳过。当前 Codex 子 agent 工具策略要求用户显式要求多 agent 才能启动；本次维护者只指定处理 issue，因此由 coordinator 直接完成窄范围实现。
- reviewer：跳过独立 agent reviewer，等待维护者/PR review。该例外已记录，不能声称已完成独立审查。

## 验证

- `git diff --check`：通过。
- `./scripts/test-front-core.sh`：通过。

补充说明：首次在沙箱内运行 `./scripts/test-front-core.sh` 因 Bun 无法写临时目录失败：`bun is unable to write files to tempdir: AccessDenied`。按既有环境规则提权重跑后通过，`knife4j-core` 185 个测试通过，`knife4j-ui-react` 54 个测试通过，ui-react build/lint/format 均通过。

## 风险与范围外

- 未在报告者的真实 Spring Boot 4 环境复现，只针对前端收到缺失 `info` 的文档对象时不再崩溃。
- 若 Spring Boot 4 场景还存在 api-docs 路径、springdoc 版本或后端生成内容问题，需要报告者补充最小复现后另行处理。