### PR TITLE
修复 Kotlin is 前缀字段文档命名

### DIFF
--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jAutoConfiguration.java
@@ -21,6 +21,7 @@ import com.github.xiaoymin.knife4j.core.conf.GlobalConstants;
 import com.github.xiaoymin.knife4j.extend.filter.basic.AbstractSecurityFilter;
 import com.github.xiaoymin.knife4j.extend.filter.basic.JakartaServletSecurityBasicAuthFilter;
 import com.github.xiaoymin.knife4j.spring.extension.Knife4jJakartaOperationCustomizer;
+import com.github.xiaoymin.knife4j.spring.extension.Knife4jKotlinIsPrefixOpenApiCustomizer;
 import com.github.xiaoymin.knife4j.spring.extension.Knife4jOpenApiCustomizer;
 import com.github.xiaoymin.knife4j.spring.filter.JakartaProductionSecurityFilter;
 import com.github.xiaoymin.knife4j.spring.util.EnvironmentUtils;
@@ -29,6 +30,7 @@ import jakarta.servlet.DispatcherType;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -42,6 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -128,6 +131,13 @@ public class Knife4jAutoConfiguration {
     @ConditionalOnMissingBean
     public Knife4jJakartaOperationCustomizer knife4jJakartaOperationCustomizer() {
         return new Knife4jJakartaOperationCustomizer();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Knife4jKotlinIsPrefixOpenApiCustomizer knife4jKotlinIsPrefixOpenApiCustomizer(
+                                                                                         ObjectProvider<RequestMappingInfoHandlerMapping> handlerMappings) {
+        return new Knife4jKotlinIsPrefixOpenApiCustomizer(handlerMappings);
     }
 
     /**

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jKotlinIsPrefixOpenApiCustomizer.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jKotlinIsPrefixOpenApiCustomizer.java
@@ -31,6 +31,7 @@ import java.beans.Introspector;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -54,6 +55,14 @@ import java.util.concurrent.CompletableFuture;
 public class Knife4jKotlinIsPrefixOpenApiCustomizer implements GlobalOpenApiCustomizer {
 
     private static final String KOTLIN_METADATA_ANNOTATION = "kotlin.Metadata";
+
+    private static final String JACKSON2_JSON_GETTER_ANNOTATION = "com.fasterxml.jackson.annotation.JsonGetter";
+
+    private static final String JACKSON2_JSON_PROPERTY_ANNOTATION = "com.fasterxml.jackson.annotation.JsonProperty";
+
+    private static final String JACKSON3_JSON_GETTER_ANNOTATION = "tools.jackson.annotation.JsonGetter";
+
+    private static final String JACKSON3_JSON_PROPERTY_ANNOTATION = "tools.jackson.annotation.JsonProperty";
 
     private final ObjectProvider<RequestMappingInfoHandlerMapping> handlerMappings;
 
@@ -162,7 +171,7 @@ public class Knife4jKotlinIsPrefixOpenApiCustomizer implements GlobalOpenApiCust
         Class<?> currentClass = rawClass;
         while (currentClass != null && currentClass != Object.class) {
             for (Field field : currentClass.getDeclaredFields()) {
-                if (isKotlinIsPrefixBooleanField(field)) {
+                if (isKotlinIsPrefixBooleanField(field) && !hasExplicitJsonPropertyName(rawClass, field)) {
                     String fieldName = field.getName();
                     String javaBeansName = Introspector.decapitalize(fieldName.substring(2));
                     if (!fieldName.equals(javaBeansName)) {
@@ -230,6 +239,49 @@ public class Knife4jKotlinIsPrefixOpenApiCustomizer implements GlobalOpenApiCust
         }
         Class<?> fieldType = field.getType();
         return fieldType == boolean.class || fieldType == Boolean.class;
+    }
+
+    private boolean hasExplicitJsonPropertyName(Class<?> rawClass, Field field) {
+        if (hasExplicitJsonPropertyName(field.getAnnotations())) {
+            return true;
+        }
+        String fieldName = field.getName();
+        String capitalizedFieldName = Character.toUpperCase(fieldName.charAt(0)) + fieldName.substring(1);
+        for (Method method : rawClass.getDeclaredMethods()) {
+            if (Modifier.isStatic(method.getModifiers()) || method.getParameterCount() != 0) {
+                continue;
+            }
+            String methodName = method.getName();
+            if ((methodName.equals(fieldName) || methodName.equals("get" + capitalizedFieldName))
+                    && hasExplicitJsonPropertyName(method.getAnnotations())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasExplicitJsonPropertyName(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            String annotationName = annotation.annotationType().getName();
+            if ((JACKSON2_JSON_PROPERTY_ANNOTATION.equals(annotationName)
+                    || JACKSON2_JSON_GETTER_ANNOTATION.equals(annotationName)
+                    || JACKSON3_JSON_PROPERTY_ANNOTATION.equals(annotationName)
+                    || JACKSON3_JSON_GETTER_ANNOTATION.equals(annotationName))
+                    && hasNonBlankValue(annotation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasNonBlankValue(Annotation annotation) {
+        try {
+            Method valueMethod = annotation.annotationType().getMethod("value");
+            Object value = valueMethod.invoke(annotation);
+            return value instanceof String && !((String) value).trim().isEmpty();
+        } catch (ReflectiveOperationException e) {
+            return false;
+        }
     }
 
     private boolean isKotlinClass(Class<?> rawClass) {

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jKotlinIsPrefixOpenApiCustomizer.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jKotlinIsPrefixOpenApiCustomizer.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.extension;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+
+import java.beans.Introspector;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Keeps Kotlin boolean properties such as {@code val isEnabled: Boolean} aligned with the
+ * field name that Jackson 3 exposes at runtime.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class Knife4jKotlinIsPrefixOpenApiCustomizer implements GlobalOpenApiCustomizer {
+
+    private static final String KOTLIN_METADATA_ANNOTATION = "kotlin.Metadata";
+
+    private final ObjectProvider<RequestMappingInfoHandlerMapping> handlerMappings;
+
+    public Knife4jKotlinIsPrefixOpenApiCustomizer(ObjectProvider<RequestMappingInfoHandlerMapping> handlerMappings) {
+        this.handlerMappings = handlerMappings;
+    }
+
+    @Override
+    public void customise(OpenAPI openApi) {
+        if (openApi == null || openApi.getComponents() == null || openApi.getComponents().getSchemas() == null) {
+            return;
+        }
+        Map<String, Schema> schemas = openApi.getComponents().getSchemas();
+        Map<String, Map<String, String>> renamesBySchema = collectKotlinIsPrefixRenames();
+        if (renamesBySchema.isEmpty()) {
+            return;
+        }
+        renamesBySchema.forEach((schemaName, propertyRenames) -> {
+            Schema schema = schemas.get(schemaName);
+            if (schema != null) {
+                renameSchemaProperties(schema, propertyRenames);
+            }
+        });
+    }
+
+    private Map<String, Map<String, String>> collectKotlinIsPrefixRenames() {
+        Map<String, Map<String, String>> renamesBySchema = new LinkedHashMap<>();
+        handlerMappings.orderedStream()
+                .flatMap(handlerMapping -> handlerMapping.getHandlerMethods().values().stream())
+                .forEach(handlerMethod -> collectHandlerMethodRenames(handlerMethod, renamesBySchema));
+        return renamesBySchema;
+    }
+
+    private void collectHandlerMethodRenames(HandlerMethod handlerMethod,
+                                             Map<String, Map<String, String>> renamesBySchema) {
+        Set<Type> visited = new HashSet<>();
+        for (MethodParameter parameter : handlerMethod.getMethodParameters()) {
+            if (parameter.hasParameterAnnotation(RequestBody.class)) {
+                collectTypeRenames(parameter.getGenericParameterType(), renamesBySchema, visited);
+            }
+        }
+        collectTypeRenames(handlerMethod.getReturnType().getGenericParameterType(), renamesBySchema, visited);
+    }
+
+    private void collectTypeRenames(Type type, Map<String, Map<String, String>> renamesBySchema, Set<Type> visited) {
+        if (type == null || !visited.add(type)) {
+            return;
+        }
+        if (type instanceof Class) {
+            Class<?> rawClass = (Class<?>) type;
+            if (rawClass.isArray()) {
+                collectTypeRenames(rawClass.getComponentType(), renamesBySchema, visited);
+                return;
+            }
+            collectClassRenames(rawClass, renamesBySchema);
+            return;
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type rawType = parameterizedType.getRawType();
+            if (rawType instanceof Class) {
+                Class<?> rawClass = (Class<?>) rawType;
+                if (!isContainerOrWrapper(rawClass)) {
+                    collectClassRenames(rawClass, renamesBySchema);
+                }
+            }
+            for (Type argument : parameterizedType.getActualTypeArguments()) {
+                collectTypeRenames(argument, renamesBySchema, visited);
+            }
+            return;
+        }
+        if (type instanceof GenericArrayType) {
+            collectTypeRenames(((GenericArrayType) type).getGenericComponentType(), renamesBySchema, visited);
+            return;
+        }
+        if (type instanceof WildcardType) {
+            WildcardType wildcardType = (WildcardType) type;
+            for (Type upperBound : wildcardType.getUpperBounds()) {
+                collectTypeRenames(upperBound, renamesBySchema, visited);
+            }
+            return;
+        }
+        if (type instanceof TypeVariable) {
+            TypeVariable<?> typeVariable = (TypeVariable<?>) type;
+            for (Type bound : typeVariable.getBounds()) {
+                collectTypeRenames(bound, renamesBySchema, visited);
+            }
+        }
+    }
+
+    private void collectClassRenames(Class<?> rawClass, Map<String, Map<String, String>> renamesBySchema) {
+        if (!isKotlinClass(rawClass)) {
+            return;
+        }
+        Map<String, String> propertyRenames = collectPropertyRenames(rawClass);
+        if (propertyRenames.isEmpty()) {
+            return;
+        }
+        renamesBySchema
+                .computeIfAbsent(schemaName(rawClass), ignored -> new LinkedHashMap<>())
+                .putAll(propertyRenames);
+    }
+
+    private Map<String, String> collectPropertyRenames(Class<?> rawClass) {
+        Map<String, String> propertyRenames = new LinkedHashMap<>();
+        Class<?> currentClass = rawClass;
+        while (currentClass != null && currentClass != Object.class) {
+            for (Field field : currentClass.getDeclaredFields()) {
+                if (isKotlinIsPrefixBooleanField(field)) {
+                    String fieldName = field.getName();
+                    String javaBeansName = Introspector.decapitalize(fieldName.substring(2));
+                    if (!fieldName.equals(javaBeansName)) {
+                        propertyRenames.put(javaBeansName, fieldName);
+                    }
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+        return propertyRenames;
+    }
+
+    private void renameSchemaProperties(Schema schema, Map<String, String> propertyRenames) {
+        Map<String, Schema> properties = schema.getProperties();
+        if (properties == null || properties.isEmpty()) {
+            return;
+        }
+        Map<String, Schema> renamedProperties = new LinkedHashMap<>();
+        boolean changed = false;
+        for (Map.Entry<String, Schema> entry : properties.entrySet()) {
+            String renamed = propertyRenames.get(entry.getKey());
+            if (renamed != null && !properties.containsKey(renamed)) {
+                renamedProperties.put(renamed, entry.getValue());
+                changed = true;
+            } else {
+                renamedProperties.put(entry.getKey(), entry.getValue());
+            }
+        }
+        if (!changed) {
+            return;
+        }
+        schema.setProperties(renamedProperties);
+        renameRequiredProperties(schema, propertyRenames);
+    }
+
+    private void renameRequiredProperties(Schema schema, Map<String, String> propertyRenames) {
+        List<String> required = schema.getRequired();
+        if (required == null || required.isEmpty()) {
+            return;
+        }
+        List<String> renamedRequired = new ArrayList<>(required.size());
+        boolean changed = false;
+        for (String item : required) {
+            String renamed = propertyRenames.get(item);
+            if (renamed == null) {
+                renamedRequired.add(item);
+            } else {
+                renamedRequired.add(renamed);
+                changed = true;
+            }
+        }
+        if (changed) {
+            schema.setRequired(renamedRequired);
+        }
+    }
+
+    private boolean isKotlinIsPrefixBooleanField(Field field) {
+        int modifiers = field.getModifiers();
+        if (Modifier.isStatic(modifiers)) {
+            return false;
+        }
+        String name = field.getName();
+        if (name.length() <= 2 || !name.startsWith("is") || !Character.isUpperCase(name.charAt(2))) {
+            return false;
+        }
+        Class<?> fieldType = field.getType();
+        return fieldType == boolean.class || fieldType == Boolean.class;
+    }
+
+    private boolean isKotlinClass(Class<?> rawClass) {
+        for (Annotation annotation : rawClass.getAnnotations()) {
+            if (KOTLIN_METADATA_ANNOTATION.equals(annotation.annotationType().getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String schemaName(Class<?> rawClass) {
+        io.swagger.v3.oas.annotations.media.Schema schema =
+                rawClass.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+        if (schema != null && schema.name() != null && !schema.name().trim().isEmpty()) {
+            return schema.name().trim();
+        }
+        return rawClass.getSimpleName();
+    }
+
+    private boolean isContainerOrWrapper(Class<?> rawClass) {
+        return Collection.class.isAssignableFrom(rawClass)
+                || Map.class.isAssignableFrom(rawClass)
+                || Optional.class.isAssignableFrom(rawClass)
+                || HttpEntity.class.isAssignableFrom(rawClass)
+                || CompletableFuture.class.isAssignableFrom(rawClass)
+                || "reactor.core.publisher.Mono".equals(rawClass.getName())
+                || "reactor.core.publisher.Flux".equals(rawClass.getName());
+    }
+}

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <knife4j-java.version>17</knife4j-java.version>
+        <knife4j-kotlin.version>2.4.0</knife4j-kotlin.version>
     </properties>
 
     <dependencyManagement>
@@ -42,10 +43,47 @@
             <version>${knife4j-spring-boot4.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${knife4j-kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${knife4j-kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${knife4j-kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <jvmTarget>${knife4j-java.version}</jvmTarget>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot4/Boot4JakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot4/Boot4JakartaDocHttpSmokeTest.java
@@ -22,6 +22,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,6 +50,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class Boot4JakartaDocHttpSmokeTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private ConfigurableApplicationContext context;
 
@@ -102,6 +106,83 @@ public class Boot4JakartaDocHttpSmokeTest {
     }
 
     @Test
+    public void shouldExposeIsPrefixedFieldNameConsistentlyWithJacksonJson() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        JsonNode runtimeJson = OBJECT_MAPPER.valueToTree(new IsPrefixFieldPayload(Boolean.TRUE));
+        Assert.assertTrue("Jackson runtime JSON should keep the DTO field name 'isEnabled':\n" + runtimeJson,
+                runtimeJson.has("isEnabled"));
+        Assert.assertFalse("Jackson runtime JSON should not expose JavaBeans-stripped 'enabled':\n" + runtimeJson,
+                runtimeJson.has("enabled"));
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+
+        JsonNode apiDocsJson = OBJECT_MAPPER.readTree(apiDocs.body);
+        JsonNode operation = apiDocsJson.path("paths").path("/api/is-prefix-field/echo").path("post");
+        Assert.assertFalse("api-docs should contain POST /api/is-prefix-field/echo operation:\n" + apiDocs.body,
+                operation.isMissingNode());
+
+        JsonNode requestProperties = schemaProperties(apiDocsJson,
+                operation.path("requestBody").path("content").path("application/json").path("schema"));
+        Assert.assertTrue("OpenAPI request schema should keep 'isEnabled'. Actual request properties:\n"
+                + requestProperties, requestProperties.has("isEnabled"));
+        Assert.assertFalse("OpenAPI request schema should not expose JavaBeans-stripped 'enabled'. "
+                + "Actual request properties:\n" + requestProperties, requestProperties.has("enabled"));
+
+        JsonNode responseProperties = schemaProperties(apiDocsJson,
+                operation.path("responses").path("200").path("content").path("application/json").path("schema"));
+        Assert.assertTrue("OpenAPI response schema should keep 'isEnabled'. Actual response properties:\n"
+                + responseProperties, responseProperties.has("isEnabled"));
+        Assert.assertFalse("OpenAPI response schema should not expose JavaBeans-stripped 'enabled'. "
+                + "Actual response properties:\n" + responseProperties, responseProperties.has("enabled"));
+    }
+
+    @Test
+    public void shouldExposeKotlinIsPrefixedFieldNameInOpenApiSchema() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+
+        JsonNode apiDocsJson = OBJECT_MAPPER.readTree(apiDocs.body);
+        JsonNode operation = apiDocsJson.path("paths").path("/api/kotlin-is-prefix-field/echo").path("post");
+        Assert.assertFalse("api-docs should contain POST /api/kotlin-is-prefix-field/echo operation:\n"
+                + apiDocs.body, operation.isMissingNode());
+
+        JsonNode requestProperties = schemaProperties(apiDocsJson,
+                operation.path("requestBody").path("content").path("application/json").path("schema"));
+        Assert.assertTrue("OpenAPI request schema should keep Kotlin 'isEnabled'. Actual request properties:\n"
+                + requestProperties, requestProperties.has("isEnabled"));
+        Assert.assertFalse("OpenAPI request schema should not expose JavaBeans-stripped 'enabled'. "
+                + "Actual request properties:\n" + requestProperties, requestProperties.has("enabled"));
+
+        JsonNode responseProperties = schemaProperties(apiDocsJson,
+                operation.path("responses").path("200").path("content").path("application/json").path("schema"));
+        Assert.assertTrue("OpenAPI response schema should keep Kotlin 'isEnabled'. Actual response properties:\n"
+                + responseProperties, responseProperties.has("isEnabled"));
+        Assert.assertFalse("OpenAPI response schema should not expose JavaBeans-stripped 'enabled'. "
+                + "Actual response properties:\n" + responseProperties, responseProperties.has("enabled"));
+
+    }
+
+    @Test
     public void shouldServeCustomApiDocsPathThroughKnife4jRuntimeConfig() throws IOException {
         context = new SpringApplicationBuilder(TestApplication.class)
                 .web(WebApplicationType.SERVLET)
@@ -134,6 +215,15 @@ public class Boot4JakartaDocHttpSmokeTest {
         HttpResponse customConfig = get(port, "/api/openapi/swagger-config");
         Assert.assertEquals(200, customConfig.statusCode);
         Assert.assertTrue(customConfig.body.contains("/api/openapi"));
+    }
+
+    private JsonNode schemaProperties(JsonNode apiDocsJson, JsonNode schema) {
+        JsonNode ref = schema.path("$ref");
+        if (ref.isTextual() && ref.asText().startsWith("#/components/schemas/")) {
+            String schemaName = ref.asText().substring("#/components/schemas/".length());
+            return apiDocsJson.path("components").path("schemas").path(schemaName).path("properties");
+        }
+        return schema.path("properties");
     }
 
     private HttpResponse get(int port, String path) throws IOException {
@@ -182,6 +272,32 @@ public class Boot4JakartaDocHttpSmokeTest {
         @GetMapping("/hello")
         public String hello() {
             return "hello";
+        }
+    }
+
+    @Tag(name = "is 前缀字段接口", description = "Boot4 is 前缀字段示例接口")
+    @RestController
+    @RequestMapping("/api/is-prefix-field")
+    public static class IsPrefixFieldController {
+
+        @Operation(summary = "回显 isEnabled 字段")
+        @PostMapping(path = "/echo", consumes = "application/json", produces = "application/json")
+        public IsPrefixFieldPayload echo(@RequestBody IsPrefixFieldPayload request) {
+            return request;
+        }
+    }
+
+    @Schema(description = "is 前缀字段复现 DTO")
+    public static class IsPrefixFieldPayload {
+
+        @Schema(description = "是否启用", example = "true")
+        public Boolean isEnabled;
+
+        public IsPrefixFieldPayload() {
+        }
+
+        public IsPrefixFieldPayload(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
         }
     }
 

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot4/Boot4JakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot4/Boot4JakartaDocHttpSmokeTest.java
@@ -183,6 +183,44 @@ public class Boot4JakartaDocHttpSmokeTest {
     }
 
     @Test
+    public void shouldHonorExplicitJsonPropertyNameForKotlinIsPrefixedField() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+
+        JsonNode apiDocsJson = OBJECT_MAPPER.readTree(apiDocs.body);
+        JsonNode operation = apiDocsJson
+                .path("paths")
+                .path("/api/kotlin-is-prefix-field/explicit-json-name/echo")
+                .path("post");
+        Assert.assertFalse("api-docs should contain explicit JSON name operation:\n" + apiDocs.body,
+                operation.isMissingNode());
+
+        JsonNode requestProperties = schemaProperties(apiDocsJson,
+                operation.path("requestBody").path("content").path("application/json").path("schema"));
+        Assert.assertTrue("OpenAPI request schema should honor explicit Kotlin JSON name 'enabled'. "
+                + "Actual request properties:\n" + requestProperties, requestProperties.has("enabled"));
+        Assert.assertFalse("OpenAPI request schema should not rename explicit JSON name back to 'isEnabled'. "
+                + "Actual request properties:\n" + requestProperties, requestProperties.has("isEnabled"));
+
+        JsonNode responseProperties = schemaProperties(apiDocsJson,
+                operation.path("responses").path("200").path("content").path("application/json").path("schema"));
+        Assert.assertTrue("OpenAPI response schema should honor explicit Kotlin JSON name 'enabled'. "
+                + "Actual response properties:\n" + responseProperties, responseProperties.has("enabled"));
+        Assert.assertFalse("OpenAPI response schema should not rename explicit JSON name back to 'isEnabled'. "
+                + "Actual response properties:\n" + responseProperties, responseProperties.has("isEnabled"));
+    }
+
+    @Test
     public void shouldServeCustomApiDocsPathThroughKnife4jRuntimeConfig() throws IOException {
         context = new SpringApplicationBuilder(TestApplication.class)
                 .web(WebApplicationType.SERVLET)

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/kotlin/com/github/xiaoymin/knife4j/smoke/boot4/KotlinIsPrefixFieldController.kt
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/kotlin/com/github/xiaoymin/knife4j/smoke/boot4/KotlinIsPrefixFieldController.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.xiaoymin.knife4j.smoke.boot4
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Kotlin is 前缀字段接口", description = "Boot4 Kotlin is 前缀字段示例接口")
+@RestController
+@RequestMapping("/api/kotlin-is-prefix-field")
+class KotlinIsPrefixFieldController {
+
+    @Operation(summary = "回显 Kotlin isEnabled 字段")
+    @PostMapping(path = ["/echo"], consumes = ["application/json"], produces = ["application/json"])
+    fun echo(@RequestBody request: KotlinIsPrefixFieldPayload): KotlinIsPrefixFieldPayload = request
+}
+
+@Schema(description = "Kotlin is 前缀字段复现 DTO")
+data class KotlinIsPrefixFieldPayload(
+    val isEnabled: Boolean
+)

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/kotlin/com/github/xiaoymin/knife4j/smoke/boot4/KotlinIsPrefixFieldController.kt
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/kotlin/com/github/xiaoymin/knife4j/smoke/boot4/KotlinIsPrefixFieldController.kt
@@ -16,6 +16,7 @@
 
 package com.github.xiaoymin.knife4j.smoke.boot4
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -32,9 +33,21 @@ class KotlinIsPrefixFieldController {
     @Operation(summary = "回显 Kotlin isEnabled 字段")
     @PostMapping(path = ["/echo"], consumes = ["application/json"], produces = ["application/json"])
     fun echo(@RequestBody request: KotlinIsPrefixFieldPayload): KotlinIsPrefixFieldPayload = request
+
+    @Operation(summary = "回显显式命名的 Kotlin enabled 字段")
+    @PostMapping(path = ["/explicit-json-name/echo"], consumes = ["application/json"], produces = ["application/json"])
+    fun explicitJsonNameEcho(
+        @RequestBody request: KotlinExplicitJsonNamePayload
+    ): KotlinExplicitJsonNamePayload = request
 }
 
 @Schema(description = "Kotlin is 前缀字段复现 DTO")
 data class KotlinIsPrefixFieldPayload(
+    val isEnabled: Boolean
+)
+
+@Schema(description = "Kotlin 显式 JSON 字段名 DTO")
+data class KotlinExplicitJsonNamePayload(
+    @get:JsonProperty("enabled")
     val isEnabled: Boolean
 )


### PR DESCRIPTION
## 背景

Closes #444。

Boot4 + Kotlin DTO 场景下，`val isEnabled: Boolean` 的运行时 JSON 字段为 `isEnabled`，但 OpenAPI schema 会被默认 JavaBeans 命名规则写成 `enabled`，导致 Knife4j 文档展示与实际接口不一致。

GPT review 指出显式 JSON 字段命名场景需要保留用户声明，例如 `@JsonProperty("enabled")` 不应再被自动改回 `isEnabled`。本 PR 已一并覆盖该边界。

## 改动

- 新增 `Knife4jKotlinIsPrefixOpenApiCustomizer`，在 OpenAPI 构建后只针对 handler 中使用到的 Kotlin DTO 修正 `isXxx` boolean 字段名。
- 不向生产 starter 引入 Kotlin 或 Jackson Kotlin 运行时依赖。
- 对显式 `JsonProperty` / `JsonGetter` 非空命名的字段跳过自动改名，兼容 Jackson 2 与 Jackson 3 注解类名。
- 在 Boot4 smoke 模块增加 Kotlin 复现 controller，并断言 request/response schema 都保留 `isEnabled`。
- 增加显式 `@JsonProperty("enabled")` 的 Kotlin DTO 对照用例，确认用户声明的 `enabled` 会被保留。
- 保留 Java public-field DTO 对照用例，确认普通 Java 场景不被误改。

## 验证

- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH mvn -B -ntp -pl knife4j-smoke-tests/boot4-jakarta-app -am -Dknife4j-skipTests=false -Dtest=Boot4JakartaDocHttpSmokeTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - `Tests run: 5, Failures: 0, Errors: 0`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH ./scripts/test-java.sh`
  - `BUILD SUCCESS`
  - `Smoke-tests evidence OK (12 modules)`
- `gh pr checks 447 --repo songxychn/knife4j-next --watch`
  - `docs-build`、`front-core-test`、`java-build-test` 均通过。

## 协作门禁

- worker：已完成 Kotlin `isEnabled` 复现探索，修复前 smoke 失败证据为 schema properties 输出 `enabled`。
- reviewer：独立审查通过，后续 GPT review 指出的显式 JSON 命名边界已采纳并补充 smoke 覆盖。