### PR TITLE
优化 React UI 对异常 api-docs 响应的提示

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { MenuFoldOutlined, MenuUnfoldOutlined, SettingOutlined } from '@ant-design/icons';
-import { Button, ConfigProvider, Dropdown, Layout, MenuProps, Select, Tabs, theme } from 'antd';
+import { Alert, Button, ConfigProvider, Dropdown, Layout, MenuProps, Select, Tabs, theme } from 'antd';
 import { Resizable } from 'react-resizable';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -86,7 +86,7 @@ const AppInner: React.FC = () => {
   const [siderWidth, setSiderWidth] = useState(320);
   const navigate = useNavigate();
   const location = useLocation();
-  const { groups, activeGroup, markdownDocs, setActiveGroupValue, swaggerDoc } = useGroup();
+  const { groups, activeGroup, markdownDocs, setActiveGroupValue, swaggerDoc, groupError } = useGroup();
   const { t, i18n } = useTranslation();
   const { settings, setSetting } = useSettings();
 
@@ -460,6 +460,15 @@ const AppInner: React.FC = () => {
           }}
         >
           <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            {groupError && (
+              <Alert
+                type="error"
+                showIcon
+                message={t('app.groupError.title')}
+                description={<span style={{ whiteSpace: 'pre-wrap' }}>{groupError}</span>}
+                style={{ margin: '2px 2px 8px' }}
+              />
+            )}
             <Dropdown menu={{ items: contextMenuItems }} trigger={['contextMenu']}>
               <div>
                 <Tabs

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SwaggerDoc } from '../types/swagger';
-import { fetchSwaggerUiConfig, parseGroupsFromConfig, parseMenuTags } from './knife4jClient';
+import { fetchSwaggerDocResult, fetchSwaggerUiConfig, parseGroupsFromConfig, parseMenuTags } from './knife4jClient';
 
 function jsonResponse(body: unknown, ok = true): Response {
   return {
     ok,
     json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function textResponse(body: string, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    text: vi.fn().mockResolvedValue(body),
   } as unknown as Response;
 }
 
@@ -39,6 +47,42 @@ describe('knife4jClient', () => {
 
   it('uses the single springdoc url when swagger-config has no urls array', () => {
     expect(parseGroupsFromConfig({ url: '/api/openapi' })).toEqual([{ name: 'default', url: '/api/openapi' }]);
+  });
+
+  it('normalizes OpenAPI docs with missing info', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(textResponse(JSON.stringify({ openapi: '3.0.1', paths: {} })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchSwaggerDocResult('/v3/api-docs')).resolves.toEqual({
+      doc: {
+        openapi: '3.0.1',
+        info: { title: 'API Docs', version: '' },
+        paths: {},
+      },
+      error: null,
+    });
+  });
+
+  it('rejects non OpenAPI JSON responses with a diagnostic message', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(textResponse(JSON.stringify({ error: 'not found' })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchSwaggerDocResult('/v3/api-docs');
+
+    expect(result.doc).toBeNull();
+    expect(result.error).toContain('不是 OpenAPI/Swagger JSON 对象');
+  });
+
+  it('diagnoses Base64 encoded api-docs responses', async () => {
+    const encoded = btoa(JSON.stringify({ openapi: '3.0.1', info: { title: 'demo', version: '1.0.0' }, paths: {} }));
+    const fetchMock = vi.fn().mockResolvedValueOnce(textResponse(JSON.stringify(encoded)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchSwaggerDocResult('/v3/api-docs');
+
+    expect(result.doc).toBeNull();
+    expect(result.error).toContain('Base64');
+    expect(result.error).toContain('HttpMessageConverter');
   });
 
   it('sorts tags and operations by Knife4j x-order extensions', () => {

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -5,6 +5,7 @@
 
 import type {
   SwaggerDoc,
+  SwaggerInfo,
   SwaggerGroup,
   MenuTag,
   MenuOperation,
@@ -14,6 +15,12 @@ import type {
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
 const KNIFE4J_ORDER_EXTENSION = 'x-order';
+const DEFAULT_SWAGGER_INFO: SwaggerInfo = { title: 'API Docs', version: '' };
+
+export interface SwaggerDocFetchResult {
+  doc: SwaggerDoc | null;
+  error: string | null;
+}
 
 /** HTTP method 在 swagger-ui 'method' sorter 下的固定顺序 */
 const METHOD_ORDER: Record<string, number> = {
@@ -111,15 +118,100 @@ export async function fetchGroups(): Promise<SwaggerGroup[]> {
   return [];
 }
 
-/** 拉取指定 group 的 api-docs */
-export async function fetchSwaggerDoc(url: string): Promise<SwaggerDoc | null> {
+/** 拉取指定 group 的 api-docs，并返回可展示的诊断信息 */
+export async function fetchSwaggerDocResult(url: string): Promise<SwaggerDocFetchResult> {
   try {
     const res = await fetch(url);
-    if (!res.ok) return null;
-    return (await res.json()) as SwaggerDoc;
+    if (!res.ok) {
+      return { doc: null, error: `api-docs 请求失败：HTTP ${res.status}` };
+    }
+    const text = await res.text();
+    return normalizeSwaggerDocResponse(text);
   } catch (_) {
-    return null;
+    return { doc: null, error: 'api-docs 加载失败，请检查后端服务。' };
   }
+}
+
+/** 拉取指定 group 的 api-docs */
+export async function fetchSwaggerDoc(url: string): Promise<SwaggerDoc | null> {
+  const result = await fetchSwaggerDocResult(url);
+  return result.doc;
+}
+
+function normalizeSwaggerDocResponse(text: string): SwaggerDocFetchResult {
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(text);
+  } catch (_) {
+    if (isBase64EncodedJson(text)) {
+      return { doc: null, error: base64ApiDocsError() };
+    }
+    return { doc: null, error: 'api-docs 响应不是有效的 JSON，请检查实际返回内容。' };
+  }
+
+  if (typeof payload === 'string') {
+    if (isBase64EncodedJson(payload)) {
+      return { doc: null, error: base64ApiDocsError() };
+    }
+    return { doc: null, error: 'api-docs 响应是字符串，不是 OpenAPI/Swagger JSON 对象。' };
+  }
+
+  if (!isSwaggerDocLike(payload)) {
+    return { doc: null, error: 'api-docs 响应不是 OpenAPI/Swagger JSON 对象，请检查接口文档地址。' };
+  }
+
+  return { doc: normalizeSwaggerDoc(payload), error: null };
+}
+
+function normalizeSwaggerDoc(doc: Record<string, unknown>): SwaggerDoc {
+  return {
+    ...doc,
+    info: normalizeSwaggerInfo(doc.info),
+  } as SwaggerDoc;
+}
+
+function normalizeSwaggerInfo(value: unknown): SwaggerInfo {
+  if (!isRecord(value)) {
+    return { ...DEFAULT_SWAGGER_INFO };
+  }
+
+  const title = typeof value.title === 'string' ? value.title : DEFAULT_SWAGGER_INFO.title;
+  const version =
+    typeof value.version === 'string' || typeof value.version === 'number'
+      ? String(value.version)
+      : DEFAULT_SWAGGER_INFO.version;
+
+  return { ...value, title, version } as SwaggerInfo;
+}
+
+function isSwaggerDocLike(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && (typeof value.openapi === 'string' || typeof value.swagger === 'string');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBase64EncodedJson(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length % 4 === 1) return false;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(trimmed)) return false;
+
+  try {
+    const padded = trimmed.padEnd(trimmed.length + ((4 - (trimmed.length % 4)) % 4), '=');
+    const decoded = atob(padded).trim();
+    return decoded.startsWith('{') && (decoded.includes('"openapi"') || decoded.includes('"swagger"'));
+  } catch (_) {
+    return false;
+  }
+}
+
+function base64ApiDocsError(): string {
+  return [
+    'api-docs 响应是 Base64 字符串，不是 OpenAPI/Swagger JSON 对象。',
+    '请检查 Spring HttpMessageConverter 配置，避免 Jackson JSON converter 接管 byte[] 或 String 响应。',
+  ].join('\n');
 }
 
 /** 将外部传入的字符串归一化为 TagsSorter；无法识别的值一律视为 'preserve'（保持原序） */

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import {
-  fetchSwaggerDoc,
+  fetchSwaggerDocResult,
   fetchSwaggerUiConfig,
   getSchemas,
   normalizeOperationsSorter,
@@ -132,13 +132,13 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
     setLoading(true);
     setGroupError(null);
-    fetchSwaggerDoc(group.url).then((doc) => {
-      if (doc) {
-        setSwaggerDoc(doc);
+    fetchSwaggerDocResult(group.url).then((result) => {
+      if (result.doc) {
+        setSwaggerDoc(result.doc);
       } else {
         // 单个 provider 加载失败：保留其他 group 可用，仅标记当前 group 错误
         setSwaggerDoc(null);
-        setGroupError('加载失败，请检查后端服务');
+        setGroupError(result.error ?? '加载失败，请检查后端服务。');
       }
       setLoading(false);
     });

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -4,6 +4,7 @@ const enUS = {
   'app.header.title': 'OpenAPI Hub',
   'app.tab.home': 'Home',
   'app.footer': 'Apache License 2.0 | Copyright 2019-2026 Knife4j Next Contributors',
+  'app.groupError.title': 'Failed to load API docs',
 
   // Header language switch
   'header.lang.zh': '中',

--- a/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
@@ -4,6 +4,7 @@ const jaJP = {
   'app.header.title': 'OpenAPI ドキュメント集約センター',
   'app.tab.home': 'ホーム',
   'app.footer': 'Apache License 2.0 | Copyright 2019-2026 Knife4j Next Contributors',
+  'app.groupError.title': 'API ドキュメントを読み込めません',
 
   // Header language switch
   'header.lang.zh': '中',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -4,6 +4,7 @@ const zhCN = {
   'app.header.title': 'OpenAPI 接口文档聚合中心',
   'app.tab.home': '主页',
   'app.footer': 'Apache License 2.0 | Copyright 2019-2026 Knife4j Next Contributors',
+  'app.groupError.title': '接口文档加载失败',
 
   // Header language switch
   'header.lang.zh': '中',


### PR DESCRIPTION
## 关联 Issue

无。该 PR 来自维护者现场讨论，目标是把 #442 这类异常 api-docs 响应沉淀为 React UI 的容错提示，不声明修复用户侧 Spring `HttpMessageConverter` 根因。

## 问题原因

React UI 原先在 `fetchSwaggerDoc` 中直接把 api-docs 响应断言为 `SwaggerDoc`。当后端返回缺失 `info` 的 OpenAPI 对象、非 OpenAPI JSON、或被错误编码成 Base64 的字符串时，下游页面容易拿到不完整结构，轻则显示空数据，重则在读取 `info.version` 等字段时崩溃。

## 变更内容

- 新增 `fetchSwaggerDocResult`，在 api-docs 入口统一做响应形状判断并返回可展示诊断信息。
- 对缺失或不完整 `info` 的 OpenAPI/Swagger 文档补充最小 `title/version`，避免首页、导出等路径崩溃。
- 对非文档 JSON、字符串响应、无效 JSON 返回明确错误。
- 对 Base64 编码的 OpenAPI/Swagger 字符串给出 Spring `HttpMessageConverter` 配置提示。
- 在主布局展示当前 group 的 api-docs 加载错误 Alert，不再只表现为空页面。
- 增加 `knife4jClient` 回归测试，覆盖缺失 `info`、非文档 JSON、Base64 响应。

## 协作门禁

- worker：跳过。当前运行时的多 agent 工具策略仅允许在用户明确要求 sub-agent 时启动；本次是维护者现场指定的小型前端容错改动，由 Codex 直接完成。
- reviewer：跳过独立 agent reviewer，等待维护者/PR review。此处不声称已完成独立审查。

## 验证

- `git diff --check`：通过。
- `./scripts/test-front-core.sh`：通过。
  - `knife4j-core`：185 个测试通过。
  - `knife4j-ui-react`：55 个测试通过。
  - format、build、lint 均通过。

补充说明：首次在沙箱内运行 `./scripts/test-front-core.sh` 因 Bun 无法写临时目录失败：`bun is unable to write files to tempdir: AccessDenied`。按本机既有环境规则提权重跑后通过。

## 风险与范围外

- 不自动解码 Base64 并继续渲染，避免掩盖后端配置问题或扩大非标准响应兼容承诺。
- 不修改 Java starter、springdoc 或 message converter 行为。
- 未创建 GitHub issue；如维护者希望保留长期任务记录，可后续补建 issue 或直接在本 PR 讨论。