### PR TITLE
支持展示 OpenAPI 3.2 文档信息

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -48,6 +48,8 @@ const enUS = {
   'home.meta.servers': 'Servers',
   'home.meta.contact': 'Contact',
   'home.meta.license': 'License',
+  'home.meta.licenseIdentifier': 'License Identifier',
+  'home.meta.extensions': 'Extensions',
   'home.meta.terms': 'Terms of Service',
   'home.meta.security': 'Security Schemes',
 

--- a/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
@@ -48,6 +48,8 @@ const jaJP = {
   'home.meta.servers': 'サーバー',
   'home.meta.contact': '連絡先',
   'home.meta.license': 'ライセンス',
+  'home.meta.licenseIdentifier': 'ライセンス識別子',
+  'home.meta.extensions': '拡張属性',
   'home.meta.terms': '利用規約',
   'home.meta.security': 'セキュリティスキーム',
 

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -48,6 +48,8 @@ const zhCN = {
   'home.meta.servers': '服务地址',
   'home.meta.contact': '联系方式',
   'home.meta.license': '许可协议',
+  'home.meta.licenseIdentifier': '许可证标识',
+  'home.meta.extensions': '扩展属性',
   'home.meta.terms': '服务条款',
   'home.meta.security': '安全方案',
 

--- a/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
@@ -36,6 +36,45 @@ const METHOD_COLORS: Record<HttpMethod, string> = {
   options: '#0d5aa7',
 };
 
+interface DisplayExtension {
+  key: string;
+  value: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toDisplayExtensionValue(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return null;
+}
+
+function collectSpecificationExtensions(source: Record<string, unknown> | undefined): DisplayExtension[] {
+  if (!source) return [];
+  const result: DisplayExtension[] = [];
+  const seen = new Set<string>();
+  const add = (key: string, value: unknown) => {
+    if (!key.startsWith('x-') || seen.has(key)) return;
+    const displayValue = toDisplayExtensionValue(value);
+    if (!displayValue) return;
+    seen.add(key);
+    result.push({ key, value: displayValue });
+  };
+
+  Object.entries(source).forEach(([key, value]) => add(key, value));
+  if (isRecord(source.extensions)) {
+    Object.entries(source.extensions).forEach(([key, value]) => add(key, value));
+  }
+  return result;
+}
+
 export default function Home() {
   const { t } = useTranslation();
   const { activeSwaggerGroup, swaggerDoc, menuTags, loading } = useGroup();
@@ -155,9 +194,23 @@ export default function Home() {
   const heroBg = `linear-gradient(135deg, ${token.colorPrimary} 0%, ${
     token.colorInfoHover ?? '#1677ff'
   } 45%, #40c9a2 100%)`;
+  const heroSubtitle = info.summary || info.description;
+  const infoExtensions = collectSpecificationExtensions(info);
+  const contactExtensions = collectSpecificationExtensions(info.contact);
+  const licenseExtensions = collectSpecificationExtensions(info.license);
 
-  const hasContactInfo = !!(info.contact?.name || info.contact?.email || info.contact?.url);
-  const hasLicense = !!(info.license?.name || info.license?.url);
+  const hasContactInfo = !!(
+    info.contact?.name ||
+    info.contact?.email ||
+    info.contact?.url ||
+    contactExtensions.length > 0
+  );
+  const hasLicense = !!(
+    info.license?.name ||
+    info.license?.url ||
+    info.license?.identifier ||
+    licenseExtensions.length > 0
+  );
   const hasTerms = !!info.termsOfService;
   const sourceRows = [
     { key: 'groupName', label: 'home.meta.groupName', value: activeSwaggerGroup?.name, icon: <TagsOutlined /> },
@@ -172,7 +225,8 @@ export default function Home() {
     { key: 'basePath', label: 'home.meta.basePath', value: swaggerDoc.basePath, icon: <LinkOutlined /> },
   ].flatMap((row) => (typeof row.value === 'string' && row.value.length > 0 ? [{ ...row, value: row.value }] : []));
   const hasSourceInfo = sourceRows.length > 0;
-  const hasAnyMeta = hasSourceInfo || hasContactInfo || hasLicense || hasTerms || servers.length > 0;
+  const hasAnyMeta =
+    hasSourceInfo || hasContactInfo || hasLicense || hasTerms || servers.length > 0 || infoExtensions.length > 0;
 
   const summaryCards = [
     {
@@ -284,6 +338,19 @@ export default function Home() {
     </div>
   );
 
+  const renderExtensionList = (extensions: DisplayExtension[]) => (
+    <Space direction="vertical" size={2} style={{ width: '100%' }}>
+      {extensions.map((extension) => (
+        <span key={extension.key} style={{ display: 'block', overflowWrap: 'anywhere' }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            {extension.key}:{' '}
+          </Text>
+          <Text style={{ fontSize: 12 }}>{extension.value}</Text>
+        </span>
+      ))}
+    </Space>
+  );
+
   return (
     <div style={{ padding: 20 }}>
       {/* Hero */}
@@ -338,7 +405,7 @@ export default function Home() {
         >
           {info.title ?? 'Unknown'}
         </Title>
-        {info.description && (
+        {heroSubtitle && (
           <Paragraph
             style={{
               color: 'rgba(255,255,255,0.9)',
@@ -348,7 +415,7 @@ export default function Home() {
               fontSize: 14,
             }}
           >
-            <Markdown source={info.description} />
+            <Markdown source={heroSubtitle} />
           </Paragraph>
         )}
       </div>
@@ -513,15 +580,35 @@ export default function Home() {
                       <Space direction="vertical" size={2} style={{ width: '100%' }}>
                         {servers.map((s, idx) => (
                           <Tooltip key={`${s.url}-${idx}`} title={s.description}>
-                            <span
-                              style={{
-                                display: 'block',
-                                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-                                fontSize: 12,
-                                overflowWrap: 'anywhere',
-                              }}
-                            >
-                              {s.url}
+                            <span style={{ display: 'block' }}>
+                              {s.name && (
+                                <Text strong style={{ display: 'block', fontSize: 12, overflowWrap: 'anywhere' }}>
+                                  {s.name}
+                                </Text>
+                              )}
+                              <span
+                                style={{
+                                  display: 'block',
+                                  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                                  fontSize: 12,
+                                  overflowWrap: 'anywhere',
+                                }}
+                              >
+                                {s.url}
+                              </span>
+                              {s.description && (
+                                <Text
+                                  type="secondary"
+                                  style={{
+                                    display: 'block',
+                                    fontSize: 12,
+                                    lineHeight: '18px',
+                                    overflowWrap: 'anywhere',
+                                  }}
+                                >
+                                  {s.description}
+                                </Text>
+                              )}
                             </span>
                           </Tooltip>
                         ))}
@@ -552,6 +639,7 @@ export default function Home() {
                             </Link>
                           </span>
                         )}
+                        {contactExtensions.length > 0 && renderExtensionList(contactExtensions)}
                       </Space>,
                     )}
                   </>
@@ -563,13 +651,32 @@ export default function Home() {
                       'license',
                       'home.meta.license',
                       <FileProtectOutlined />,
-                      info.license?.url ? (
-                        <Link href={info.license.url} target="_blank" rel="noreferrer">
-                          {info.license.name ?? info.license.url}
-                        </Link>
-                      ) : (
-                        <Text>{info.license?.name}</Text>
-                      ),
+                      <Space direction="vertical" size={2} style={{ width: '100%' }}>
+                        {info.license?.url ? (
+                          <Link href={info.license.url} target="_blank" rel="noreferrer">
+                            {info.license.name ?? info.license.url}
+                          </Link>
+                        ) : (
+                          info.license?.name && <Text>{info.license.name}</Text>
+                        )}
+                        {info.license?.identifier && (
+                          <Text type="secondary">
+                            {t('home.meta.licenseIdentifier')}: {info.license.identifier}
+                          </Text>
+                        )}
+                        {licenseExtensions.length > 0 && renderExtensionList(licenseExtensions)}
+                      </Space>,
+                    )}
+                  </>
+                )}
+
+                {infoExtensions.length > 0 && (
+                  <>
+                    {renderMetaRow(
+                      'extensions',
+                      'home.meta.extensions',
+                      <InfoCircleOutlined />,
+                      renderExtensionList(infoExtensions),
                     )}
                   </>
                 )}

--- a/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
@@ -194,7 +194,11 @@ export default function Home() {
   const heroBg = `linear-gradient(135deg, ${token.colorPrimary} 0%, ${
     token.colorInfoHover ?? '#1677ff'
   } 45%, #40c9a2 100%)`;
-  const heroSubtitle = info.summary || info.description;
+  const heroSummary = typeof info.summary === 'string' && info.summary.trim().length > 0 ? info.summary : undefined;
+  const heroDescription =
+    typeof info.description === 'string' && info.description.trim().length > 0 && info.description !== heroSummary
+      ? info.description
+      : undefined;
   const infoExtensions = collectSpecificationExtensions(info);
   const contactExtensions = collectSpecificationExtensions(info.contact);
   const licenseExtensions = collectSpecificationExtensions(info.license);
@@ -405,7 +409,7 @@ export default function Home() {
         >
           {info.title ?? 'Unknown'}
         </Title>
-        {heroSubtitle && (
+        {heroSummary && (
           <Paragraph
             style={{
               color: 'rgba(255,255,255,0.9)',
@@ -415,7 +419,20 @@ export default function Home() {
               fontSize: 14,
             }}
           >
-            <Markdown source={heroSubtitle} />
+            <Markdown source={heroSummary} />
+          </Paragraph>
+        )}
+        {heroDescription && (
+          <Paragraph
+            style={{
+              color: 'rgba(255,255,255,0.82)',
+              marginTop: heroSummary ? 6 : 10,
+              marginBottom: 0,
+              maxWidth: 900,
+              fontSize: 14,
+            }}
+          >
+            <Markdown source={heroDescription} />
           </Paragraph>
         )}
       </div>

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -50,24 +50,31 @@ export interface SwaggerContact {
   name?: string;
   url?: string;
   email?: string;
+  [key: string]: unknown;
 }
 
 export interface SwaggerLicense {
   name?: string;
   url?: string;
+  identifier?: string;
+  extensions?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 export interface SwaggerInfo {
   title: string;
   version: string;
+  summary?: string;
   description?: string;
   termsOfService?: string;
   contact?: SwaggerContact;
   license?: SwaggerLicense;
+  [key: string]: unknown;
 }
 
 export interface SwaggerServer {
   url: string;
+  name?: string;
   description?: string;
 }
 


### PR DESCRIPTION
## 关联 Issue

Closes #451

## 变更内容

- 为 React UI 的 OpenAPI 类型补充 `info.summary`、`license.identifier`、server `name` 以及 `info` / `contact` / `license` 的扩展字段承载。
- 首页标题区优先展示 `info.summary`，缺失时保留原有 `info.description` 回退。
- 文档信息卡片补充展示 server 的名称和描述、许可证标识，以及 `info` / `contact` / `license` 中标量 `x-*` 扩展字段。
- 更新中英日三语首页文案。

## 协作门禁

- worker：已完成 React 首页最小实现 handoff。
- reviewer：首轮提出扩展字段展示与 server 文本换行问题；返工后复审 `approve`，无剩余发现。

## 验证

- `bun run format`（`knife4j-front/knife4j-ui-react`）：通过。
- `git diff --check`：通过。
- `./scripts/test-front-core.sh`：通过。sandbox 内首次因 Bun tempdir `AccessDenied` 失败，提升权限重跑通过；包含 `knife4j-core` format/test/lint/build 与 `knife4j-ui-react` format/test/build/lint。Vite 仅有既有 chunk size warning。
- 本地预览：使用临时 mock 后端提供 issue 示例 payload，确认首页显示 `OpenAPI 3.2.0`、`info.summary`、server name/description、contact/license/info 的 `x-wp-content-type` 与 `license.identifier`。

## 风险说明

- 不修改 Java 生成逻辑，不改变 OAS2 支持承诺。
- `x-*` 扩展只展示字符串、数字和布尔值；对象和数组保持不展示，避免首页展示大块内部结构。