### PR TITLE
fix: 修复调试页文件上传识别

### DIFF
--- a/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
@@ -180,6 +180,84 @@ describe('buildOperationDebugModel — OAS3', () => {
     expect(model.bodyContents[0].fileFieldsMultiple ?? []).not.toContain('file');
   });
 
+  test('normalizes OAS3 JSON body with binary field to multipart upload model', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/files': {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      file: { type: 'string', format: 'binary', description: 'Upload file' },
+                    },
+                    required: ['file'],
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/files',
+      method: 'post',
+    });
+
+    expect(model.bodyContents).toHaveLength(1);
+    expect(model.bodyContents[0].mediaType).toBe('multipart/form-data');
+    expect(model.bodyContents[0].category).toBe('multipart');
+    expect(model.bodyContents[0].fileFields).toContain('file');
+    expect(model.bodyContents[0].fileFieldsMultiple ?? []).not.toContain('file');
+    expect(model.bodyRequired).toBe(true);
+  });
+
+  test('keeps OAS3 JSON body with base64 field as JSON, not file upload', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/json-file-content': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      content: { type: 'string', format: 'base64' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/json-file-content',
+      method: 'post',
+    });
+
+    expect(model.bodyContents).toHaveLength(1);
+    expect(model.bodyContents[0].mediaType).toBe('application/json');
+    expect(model.bodyContents[0].category).toBe('json');
+    expect(model.bodyContents[0].fileFields).toBeUndefined();
+  });
+
   // WebFlux + springdoc: Flux<FilePart> generates {type:array, items:{type:string,format:binary}}
   // This test verifies extractFileFields() correctly identifies array-of-binary as a file field
   // (upstream xiaoymin/knife4j#733)

--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -214,6 +214,32 @@ function extractMultipleFileFields(schema: Record<string, unknown> | undefined):
   return multiple;
 }
 
+/**
+ * 判断非 multipart requestBody 是否实际描述了文件上传字段。
+ *
+ * springdoc 在 `@PostMapping` 未显式声明 consumes 时，可能把
+ * `@RequestParam MultipartFile file` 暴露为 `application/json` body：
+ * `{ file: { type: "string", format: "binary" } }`。Swagger UI 仍按文件上传
+ * 渲染，调试页也应把这种形状归一为 multipart，而不是显示 JSON 编辑器。
+ *
+ * 这里只接受 `format: "binary"`，不把 JSON 中的 base64/byte 字符串自动改成
+ * 文件上传，以避免误伤真正的 JSON 文本字段。
+ */
+function hasBinaryUploadField(schema: Record<string, unknown> | undefined): boolean {
+  if (!schema || schema.type !== 'object' || !schema.properties) return false;
+  const props = schema.properties as Record<string, Record<string, unknown>>;
+  for (const prop of Object.values(props)) {
+    if (prop.type === 'file') return true;
+    if (prop.type === 'string' && prop.format === 'binary') return true;
+    if (prop.type === 'array' && prop.items && typeof prop.items === 'object') {
+      const items = prop.items as Record<string, unknown>;
+      const typeOk = items.type === undefined || items.type === 'string';
+      if (items.format === 'binary' && typeOk) return true;
+    }
+  }
+  return false;
+}
+
 /** 从 OAS3 requestBody encoding 中提取 contentType=application/json 的字段名 */
 function extractJsonEncodingFields(encoding: Record<string, unknown> | undefined): string[] {
   if (!encoding) return [];
@@ -437,14 +463,23 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
     bodyRequired = Boolean(rb.required);
 
     if (rb.content) {
+      const hasDeclaredMultipart = Object.keys(rb.content).some(
+        (mediaType) => classifyContentType(mediaType) === 'multipart',
+      );
+
       for (const [mediaType, mediaObj] of Object.entries(rb.content)) {
         const schema = mediaObj.schema ? dereference(mediaObj.schema, doc as Record<string, unknown>) : undefined;
-        const isMultipart = classifyContentType(mediaType) === 'multipart';
+        const declaredCategory = classifyContentType(mediaType);
+        const isMultipartFallback =
+          !hasDeclaredMultipart && declaredCategory !== 'multipart' && hasBinaryUploadField(schema);
+        const effectiveMediaType = isMultipartFallback ? 'multipart/form-data' : mediaType;
+        const effectiveCategory: BodyContentType = isMultipartFallback ? 'multipart' : declaredCategory;
+        const isMultipart = effectiveCategory === 'multipart';
         const encoding = mediaObj.encoding;
 
         bodyContents.push({
-          mediaType,
-          category: classifyContentType(mediaType),
+          mediaType: effectiveMediaType,
+          category: effectiveCategory,
           schema,
           exampleValue: schema
             ? JSON.stringify(buildSchemaExample(schema, ctx), null, 2)


### PR DESCRIPTION
## 关联 Issue

Closes #458

## 变更内容

- 在 `knife4j-core` 调试模型中识别 `application/json` requestBody 下的 `format: binary` 文件字段。
- 当文档未声明 `multipart/form-data`、但 schema 实际描述文件上传时，将调试模型归一为 `multipart/form-data`，复用现有上传控件和 FormData 发送逻辑。
- 保留 JSON 中 `format: base64` 字符串的原行为，避免把普通 JSON 字段误判成文件上传。
- 增加 #458 回归测试和 base64 负例测试。

## 根因说明

用户示例中的后端写法是 `@PostMapping("/files")` + `@RequestParam("file") MultipartFile file`，没有显式声明 `consumes = multipart/form-data`。springdoc 在这种形状下可能把文件字段暴露为 `requestBody.content.application/json` 中的 `format: binary` 字段，React 调试页原先因此显示 JSON 编辑器，不会出现“选择文件”控件。

## 验证

- `bun test src/__tests__/debug/operationDebugModel.test.ts` 通过。
- `./scripts/test-front-core.sh` 通过。
- PR CI 通过：`docs-build`、`front-core-test`、`java-build-test`。

说明：普通沙箱运行 `./scripts/test-front-core.sh` 失败于 Bun tempdir 权限，使用提升权限重跑同一命令后通过。

## 协作门禁

- worker：未派出。当前 Codex sub-agent 工具策略要求只有维护者显式要求时才可启动独立 agent，本次按运行时限制记录例外。
- reviewer：未派出独立 reviewer；本次为低风险 `knife4j-core` 解析逻辑切片，已记录例外并以本地门禁、PR CI 和维护者 review 控制风险。

## 风险

- 修复仅在“没有显式 multipart content 且 schema 中存在 `format: binary` 文件字段”时触发，避免影响已有标准 multipart 文档。
- 不把 JSON 里的 `format: base64` 自动改成文件上传，避免误伤真正的 JSON 文本字段。