### PR TITLE
修复 OpenAPI3 starter 传递 commons-lang3 漏洞

### DIFF
--- a/docs-site/reference/version-ref.md
+++ b/docs-site/reference/version-ref.md
@@ -94,6 +94,11 @@ title: 版本对照
 ```bash
 mvn dependency:tree -Dincludes=com.baizhukui
 mvn dependency:tree -Dincludes=org.springdoc
+mvn dependency:tree -Dincludes=org.apache.commons:commons-lang3
 ```
 
 如果 springdoc 版本与上表不一致，说明你的项目中有其他依赖覆盖了版本管理。请检查是否有 BOM 或父 POM 引入了不同版本的 springdoc。
+
+如果安全扫描提示 `CVE-2025-48924`，重点确认 `commons-lang3` 是否低于 `3.18.0`。使用 Spring Boot parent 或
+Spring Boot BOM 的应用可能会把 starter 传递声明的 `commons-lang3` 版本重新管理回 Boot 自带版本；这种情况下需要在应用侧
+`dependencyManagement` 中显式覆盖到 `3.20.0` 或更高版本。

--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
@@ -71,6 +71,17 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${knife4j-springdoc-openapi-jakarta.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${knife4j-commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/knife4j/knife4j-dependencies/pom.xml
+++ b/knife4j/knife4j-dependencies/pom.xml
@@ -72,6 +72,11 @@
                 <artifactId>swagger-core-jakarta</artifactId>
                 <version>${knife4j-swagger-models-v3-jakarta.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${knife4j-commons-lang3.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.baizhukui</groupId>

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
@@ -43,6 +43,17 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${knife4j-springdoc-openapi-jakarta.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${knife4j-commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
@@ -64,6 +64,17 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${knife4j-commons-lang3.version}</version>
         </dependency>
 <!--        <dependency>-->
 <!--            <groupId>io.swagger.core.v3</groupId>-->

--- a/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
@@ -16,6 +16,17 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
             <version>${knife4j-springdoc-openapi-jakarta.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${knife4j-commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>com.baizhukui</groupId>

--- a/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
@@ -16,6 +16,17 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-webflux-ui</artifactId>
             <version>${knife4j-springdoc-openapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${knife4j-commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>com.baizhukui</groupId>

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -73,6 +73,7 @@
         <knife4j-hutool.version>5.8.34</knife4j-hutool.version>
         <knife4j-httpclient.version>4.5.14</knife4j-httpclient.version>
         <knife4j-gson.version>2.11.0</knife4j-gson.version>
+        <knife4j-commons-lang3.version>3.20.0</knife4j-commons-lang3.version>
 
 
         <knife4j-javassist.version>3.30.2-GA</knife4j-javassist.version>
@@ -151,6 +152,11 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${knife4j-gson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${knife4j-commons-lang3.version}</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.javassist/javassist -->


### PR DESCRIPTION
## 关联 Issue

- 处理 #459

## 变更内容

- 在父 POM 和 `knife4j-dependencies` BOM 中统一管理 `org.apache.commons:commons-lang3` 为 `3.20.0`。
- 在 OpenAPI3 Boot 2.x MVC/WebFlux、Boot 3.x Jakarta MVC/WebFlux、Jakarta 聚合 starter 中排除 springdoc 链路带入的旧 `commons-lang3`，并直接声明安全版本。
- 在版本对照文档中补充 `commons-lang3` 依赖树检查命令，并说明 Spring Boot parent/BOM 可能覆盖传递版本；若最终解析低于 `3.18.0`，应用侧需要用 `dependencyManagement` 显式覆盖到 `3.20.0` 或更高。

## 根因与边界

- #459 截图中的 `CVE-2025-48924` 对应 Apache Commons Lang 递归 DoS 风险，影响 `org.apache.commons:commons-lang3` `3.0` 到低于 `3.18.0` 的版本。
- `knife4j-openapi3-jakarta-spring-boot-starter:5.0.10` 的普通消费者会经 `springdoc-openapi-starter-webmvc-ui:2.8.9 -> swagger-core-jakarta:2.2.30` 解析到 `commons-lang3:3.17.0`。
- Boot 2.x OpenAPI3 MVC/WebFlux starter 普通消费者会解析到 `commons-lang3:3.14.0`；Jakarta WebFlux/聚合 starter 会解析到 `3.17.0`。
- 如果下游应用使用 Spring Boot parent/BOM，Maven 会优先应用下游自己的 `dependencyManagement`。本 PR 不能强制压过应用侧 BOM；文档已补充应用侧显式覆盖说明。

## 协作说明

- Worker：本轮由 coordinator 直接实现。例外原因是当前 Codex 多 agent 工具策略不允许按仓库 worker 门禁任意启动实现型子 agent；替代措施是保持改动集中在 POM/文档，并补充消费者依赖树验证。
- Reviewer：独立 reviewer 第一轮发现 Spring Boot parent/BOM 会覆盖传递版本；已补充文档和边界验证。第二轮 reviewer 结论为 `approve`，未发现漏掉的受影响 starter、Maven 语义误解、文档越界表述或范围漂移。

## 验证

- 临时纯消费者 POM：五个受影响 starter 均解析为 `org.apache.commons:commons-lang3:jar:3.20.0:compile`。
- 临时 Boot 3.5.0 parent 消费者：默认解析为 `commons-lang3:3.17.0 (version managed from 3.20.0)`，验证了下游 BOM 覆盖边界；应用侧显式 `dependencyManagement` 后解析为 `3.20.0`。
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home ./scripts/test-java.sh` 通过，尾部为 `==> Smoke-tests evidence OK (12 modules)`。
- `./scripts/test-docs.sh` 通过。
- `git diff --check` 通过。

## 已知风险

- 依赖版本 override 属于 Maven 解析层行为；使用 Spring Boot parent/BOM 的最终应用仍可能需要应用侧显式管理 `commons-lang3`。本 PR 已在文档和 PR 说明中明确该边界。
