### PR TITLE
修复 oneOf 字段只显示首个分支

### DIFF
--- a/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
@@ -82,6 +82,34 @@ const doc: Record<string, unknown> = {
           },
         },
       },
+      AllOfOneOfDemo: {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              commonId: { type: 'string' },
+            },
+          },
+        ],
+        oneOf: [{ $ref: '#/components/schemas/User' }, { $ref: '#/components/schemas/Pet' }],
+      },
+      AllOfOneOfFieldContainer: {
+        type: 'object',
+        properties: {
+          payload: {
+            description: 'Polymorphic payload with common fields',
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  commonId: { type: 'string' },
+                },
+              },
+            ],
+            oneOf: [{ $ref: '#/components/schemas/User' }, { $ref: '#/components/schemas/Pet' }],
+          },
+        },
+      },
       FreeFormMap: {
         type: 'object',
         additionalProperties: { type: 'string' },
@@ -445,6 +473,23 @@ describe('buildSchemaFieldTree', () => {
     expect(payloadNode.description).toBe('Polymorphic payload');
     expect(payloadNode.children?.map((n) => n.name)).toEqual(['oneOf[1]', 'oneOf[2]']);
     expect(payloadNode.children?.map((n) => n.refName)).toEqual(['User', 'Pet']);
+  });
+
+  test('keeps allOf fields alongside oneOf branches in field tree', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/AllOfOneOfDemo' }, ctx());
+    expect(nodes.map((n) => n.name)).toEqual(['commonId', 'oneOf[1]', 'oneOf[2]']);
+    expect(nodes[1].refName).toBe('User');
+    expect(nodes[2].refName).toBe('Pet');
+  });
+
+  test('keeps allOf fields alongside oneOf branches for object fields', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/AllOfOneOfFieldContainer' }, ctx());
+    const payloadNode = nodes.find((n) => n.name === 'payload')!;
+    expect(payloadNode.type).toBe('oneOf');
+    expect(payloadNode.description).toBe('Polymorphic payload with common fields');
+    expect(payloadNode.children?.map((n) => n.name)).toEqual(['commonId', 'oneOf[1]', 'oneOf[2]']);
+    expect(payloadNode.children?.[1].refName).toBe('User');
+    expect(payloadNode.children?.[2].refName).toBe('Pet');
   });
 
   // 9. 空输入

--- a/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/schemaExample.test.ts
@@ -73,6 +73,15 @@ const doc: Record<string, unknown> = {
       AnyOfDemo: {
         anyOf: [{ $ref: '#/components/schemas/Pet' }, { type: 'string' }],
       },
+      OneOfFieldContainer: {
+        type: 'object',
+        properties: {
+          payload: {
+            description: 'Polymorphic payload',
+            oneOf: [{ $ref: '#/components/schemas/User' }, { $ref: '#/components/schemas/Pet' }],
+          },
+        },
+      },
       FreeFormMap: {
         type: 'object',
         additionalProperties: { type: 'string' },
@@ -421,11 +430,21 @@ describe('buildSchemaFieldTree', () => {
   });
 
   // 8. oneOf / anyOf
-  test('uses first resolvable branch in oneOf field tree', () => {
+  test('keeps every oneOf branch in field tree', () => {
     const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/OneOfDemo' }, ctx());
-    const names = nodes.map((n) => n.name);
-    expect(names).toContain('id');
-    expect(names).toContain('name');
+    expect(nodes.map((n) => n.name)).toEqual(['oneOf[1]', 'oneOf[2]']);
+    expect(nodes.map((n) => n.refName)).toEqual(['User', 'Pet']);
+    expect(nodes[0].children?.map((n) => n.name)).toContain('id');
+    expect(nodes[1].children?.map((n) => n.name)).toContain('tag');
+  });
+
+  test('keeps every oneOf branch for object fields', () => {
+    const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/OneOfFieldContainer' }, ctx());
+    const payloadNode = nodes.find((n) => n.name === 'payload')!;
+    expect(payloadNode.type).toBe('oneOf');
+    expect(payloadNode.description).toBe('Polymorphic payload');
+    expect(payloadNode.children?.map((n) => n.name)).toEqual(['oneOf[1]', 'oneOf[2]']);
+    expect(payloadNode.children?.map((n) => n.refName)).toEqual(['User', 'Pet']);
   });
 
   // 9. 空输入
@@ -563,11 +582,11 @@ describe('TASK-114: allOf/oneOf/anyOf schema inheritance', () => {
   });
 
   // 3. oneOf 多态场景
-  test('oneOf polymorphism uses first branch properties', () => {
+  test('oneOf polymorphism exposes all branch nodes', () => {
     const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/PolyShape' }, ctx());
-    const names = nodes.map((n) => n.name);
-    // first branch has radius
-    expect(names).toContain('radius');
+    expect(nodes.map((n) => n.name)).toEqual(['oneOf[1]', 'oneOf[2]']);
+    expect(nodes[0].children?.map((n) => n.name)).toEqual(['radius']);
+    expect(nodes[1].children?.map((n) => n.name)).toEqual(['width', 'height']);
   });
 
   test('oneOf example uses first branch', () => {
@@ -576,10 +595,11 @@ describe('TASK-114: allOf/oneOf/anyOf schema inheritance', () => {
   });
 
   // 4. anyOf 多态场景
-  test('anyOf polymorphism uses first branch properties', () => {
+  test('anyOf polymorphism exposes all branch nodes', () => {
     const nodes = buildSchemaFieldTree({ $ref: '#/components/schemas/PolyAny' }, ctx());
-    const names = nodes.map((n) => n.name);
-    expect(names).toContain('x');
+    expect(nodes.map((n) => n.name)).toEqual(['anyOf[1]', 'anyOf[2]']);
+    expect(nodes[0].children?.map((n) => n.name)).toEqual(['x']);
+    expect(nodes[1].type).toBe('string');
   });
 
   test('anyOf example uses first branch', () => {

--- a/knife4j-front/knife4j-core/src/debug/schemaExample.ts
+++ b/knife4j-front/knife4j-core/src/debug/schemaExample.ts
@@ -7,7 +7,7 @@
  * - 优先级：example > default > enum[0] > 按 type/format 推断
  * - 递归处理 $ref / object.properties / array.items
  * - allOf：浅合并子 schema 的 properties / required
- * - oneOf / anyOf：取第一个可解析分支
+ * - oneOf / anyOf：示例值取第一个可解析分支；字段树展示所有分支
  * - 循环引用：按引用链数组截断，重复命中同一 $ref 时返回占位值（example）或 null + truncated 标记（fieldTree）
  * - maxDepth：默认 8，超过后截断
  *
@@ -171,10 +171,16 @@ function mergeAllOf(parts: Record<string, unknown>[], ctx: InternalCtx): Record<
   return merged;
 }
 
+interface ResolveOptions {
+  /** 字段树展示需要保留 oneOf / anyOf 的完整分支，不在解析阶段折叠为第一项 */
+  preserveComposition?: boolean;
+}
+
 /** 解析 schema 的显式分支（$ref / allOf / oneOf / anyOf），返回归一化后的 schema */
 function resolveSchema(
   schema: Record<string, unknown> | undefined,
   ctx: InternalCtx,
+  options: ResolveOptions = {},
 ): { schema: Record<string, unknown> | undefined; ref?: string; truncated: boolean } {
   if (!schema) return { schema: undefined, truncated: false };
 
@@ -187,10 +193,14 @@ function resolveSchema(
     const resolved = resolveRef(ref, ctx.doc);
     if (!resolved) return { schema: undefined, ref, truncated: false };
     // 递归解析（解析后可能仍是 $ref / allOf 等）
-    const deeper = resolveSchema(resolved, {
-      ...ctx,
-      refChain: [...ctx.refChain, ref],
-    });
+    const deeper = resolveSchema(
+      resolved,
+      {
+        ...ctx,
+        refChain: [...ctx.refChain, ref],
+      },
+      options,
+    );
     return { ...deeper, ref };
   }
 
@@ -207,6 +217,10 @@ function resolveSchema(
     return { schema: combined, truncated: false };
   }
 
+  if (options.preserveComposition && (hasComposition(schema, 'oneOf') || hasComposition(schema, 'anyOf'))) {
+    return { schema, truncated: false };
+  }
+
   // 3. oneOf / anyOf：取第一个可解析分支
   const union = (schema.oneOf ?? schema.anyOf) as Record<string, unknown>[] | undefined;
   if (Array.isArray(union) && union.length > 0) {
@@ -218,6 +232,25 @@ function resolveSchema(
   }
 
   return { schema, truncated: false };
+}
+
+type CompositionKind = 'oneOf' | 'anyOf';
+
+function hasComposition(schema: Record<string, unknown>, kind: CompositionKind): boolean {
+  const branches = schema[kind];
+  return Array.isArray(branches) && branches.length > 0;
+}
+
+function getComposition(
+  schema: Record<string, unknown>,
+): { kind: CompositionKind; branches: Record<string, unknown>[] } | undefined {
+  if (hasComposition(schema, 'oneOf')) {
+    return { kind: 'oneOf', branches: schema.oneOf as Record<string, unknown>[] };
+  }
+  if (hasComposition(schema, 'anyOf')) {
+    return { kind: 'anyOf', branches: schema.anyOf as Record<string, unknown>[] };
+  }
+  return undefined;
 }
 
 /** dereference：$ref → 解析后 schema（循环或失败时原样返回） */
@@ -314,9 +347,14 @@ function buildFieldTreeInternal(schema: Record<string, unknown> | undefined, ctx
   if (!schema) return [];
   if (ctx.depth >= ctx.maxDepth) return [];
 
-  const { schema: resolved, ref, truncated } = resolveSchema(schema, ctx);
+  const { schema: resolved, ref, truncated } = resolveSchema(schema, ctx, { preserveComposition: true });
   if (!resolved) return [];
   if (truncated) return [];
+
+  const composition = getComposition(resolved);
+  if (composition) {
+    return buildCompositionBranchNodes(composition.kind, composition.branches, pushRefIfAny(ctx, ref));
+  }
 
   const type = normalizeType(resolved.type);
 
@@ -357,6 +395,17 @@ function buildFieldTreeInternal(schema: Record<string, unknown> | undefined, ctx
       refName: refToName(ref),
     },
   ];
+}
+
+function buildCompositionBranchNodes(
+  kind: CompositionKind,
+  branches: Record<string, unknown>[],
+  ctx: InternalCtx,
+): SchemaFieldNode[] {
+  return branches.map((branch, index) => {
+    const branchNode = buildSingleFieldNode(`${kind}[${index + 1}]`, branch, false, childCtx(ctx));
+    return branchNode;
+  });
 }
 
 function objectToFieldNodes(
@@ -420,7 +469,7 @@ function buildSingleFieldNode(
     };
   }
 
-  const { schema: resolved, ref, truncated } = resolveSchema(rawSchema, ctx);
+  const { schema: resolved, ref, truncated } = resolveSchema(rawSchema, ctx, { preserveComposition: true });
   if (!resolved) {
     return {
       name,
@@ -445,6 +494,25 @@ function buildSingleFieldNode(
       ? refTargetDescription
       : undefined;
   const refTitle = ref ? (typeof resolved.title === 'string' ? resolved.title : undefined) : undefined;
+
+  const composition = getComposition(resolved);
+  if (composition) {
+    const node: SchemaFieldNode = {
+      name,
+      type: composition.kind,
+      required,
+      description,
+      refDescription,
+      refTitle,
+      refName: refToName(ref),
+    };
+    if (ctx.depth + 1 >= ctx.maxDepth) {
+      node.truncated = true;
+      return node;
+    }
+    node.children = buildCompositionBranchNodes(composition.kind, composition.branches, pushRefIfAny(ctx, ref));
+    return node;
+  }
 
   const node: SchemaFieldNode = {
     name,

--- a/knife4j-front/knife4j-core/src/debug/schemaExample.ts
+++ b/knife4j-front/knife4j-core/src/debug/schemaExample.ts
@@ -353,7 +353,7 @@ function buildFieldTreeInternal(schema: Record<string, unknown> | undefined, ctx
 
   const composition = getComposition(resolved);
   if (composition) {
-    return buildCompositionBranchNodes(composition.kind, composition.branches, pushRefIfAny(ctx, ref));
+    return buildTopLevelCompositionNodes(resolved, composition, ctx, ref);
   }
 
   const type = normalizeType(resolved.type);
@@ -406,6 +406,31 @@ function buildCompositionBranchNodes(
     const branchNode = buildSingleFieldNode(`${kind}[${index + 1}]`, branch, false, childCtx(ctx));
     return branchNode;
   });
+}
+
+function buildTopLevelCompositionNodes(
+  resolved: Record<string, unknown>,
+  composition: { kind: CompositionKind; branches: Record<string, unknown>[] },
+  ctx: InternalCtx,
+  ref: string | undefined,
+): SchemaFieldNode[] {
+  return [
+    ...objectToFieldNodes(resolved, ctx, ref),
+    ...buildCompositionBranchNodes(composition.kind, composition.branches, pushRefIfAny(ctx, ref)),
+  ];
+}
+
+function buildNestedCompositionChildren(
+  resolved: Record<string, unknown>,
+  composition: { kind: CompositionKind; branches: Record<string, unknown>[] },
+  ctx: InternalCtx,
+  ref: string | undefined,
+): SchemaFieldNode[] {
+  const nextCtx = pushRefIfAny(ctx, ref);
+  return [
+    ...objectToFieldNodes(resolved, childCtx(nextCtx), ref),
+    ...buildCompositionBranchNodes(composition.kind, composition.branches, nextCtx),
+  ];
 }
 
 function objectToFieldNodes(
@@ -510,7 +535,7 @@ function buildSingleFieldNode(
       node.truncated = true;
       return node;
     }
-    node.children = buildCompositionBranchNodes(composition.kind, composition.branches, pushRefIfAny(ctx, ref));
+    node.children = buildNestedCompositionChildren(resolved, composition, ctx, ref);
     return node;
   }
 

--- a/knife4j-front/knife4j-core/src/debug/types.ts
+++ b/knife4j-front/knife4j-core/src/debug/types.ts
@@ -287,14 +287,15 @@ export interface SchemaFieldNode {
  * 根据 schema 生成 JSON 示例值（纯数据）。
  *
  * 支持：$ref / object / array / enum / example / default / allOf（浅合并） /
- * oneOf / anyOf（取第一个可解析分支） / 循环引用截断 / maxDepth 保护。
+ * oneOf / anyOf（示例值取第一个可解析分支） / 循环引用截断 / maxDepth 保护。
  */
 export type BuildSchemaExampleFn = (schema: Record<string, unknown> | undefined, ctx: SchemaResolveContext) => unknown;
 
 /**
  * 根据 schema 生成字段树（用于文档展示）。
  *
- * 返回值为 SchemaFieldNode 数组：object 展开 properties，array 以伪节点暴露 items。
+ * 返回值为 SchemaFieldNode 数组：object 展开 properties，array 以伪节点暴露 items，
+ * oneOf / anyOf 以组合节点展示全部分支。
  * 循环引用以 `truncated=true` 截断，不会死循环。
  */
 export type BuildSchemaFieldTreeFn = (


### PR DESCRIPTION
## 关联 Issue

- Closes #469

## 变更内容

- 调整 `buildSchemaFieldTree` 的组合 schema 展示逻辑：`oneOf` / `anyOf` 不再在字段树中折叠为第一个可解析分支，而是生成 `oneOf[1]`、`oneOf[2]` 等分支节点。
- 保留每个分支的 `$ref` 类型名与子字段，模型字段页可通过现有表格展开看到所有分支。
- 保持 `buildSchemaExample` 的原有语义不变：示例值仍取第一个可解析分支。
- 增加顶层 `oneOf`、对象字段 `oneOf`、多态 `oneOf` / `anyOf` 的字段树回归测试。

## 协作门禁

- Worker：已启动短命 worker，但该 worker 结束时未返回 handoff 且未产生工作区 diff；为避免任务卡住，由 coordinator 按已确认的窄范围接手实现。该例外已写入 issue 评论。
- Reviewer：独立 reviewer 已审查当前 diff，结论 `approve`；无发现、无验证缺口、无范围漂移。

## 验证

- `./scripts/test-front-core.sh`：通过。
- `git diff --check`：通过。

## 风险与范围外

- 本次不调整 React 表格样式，仅复用现有树形表格展示 `oneOf[1]` / `oneOf[2]` 分支。
- 未修改 Java、Vue3、文档、CI 或 lockfile。
