### PR TITLE
fix: 优化深层响应字段表格布局

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
@@ -1,12 +1,19 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Badge, Popover, Space, Table, Tag, Tooltip, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { buildSchemaFieldTree, type SchemaFieldNode } from 'knife4j-core';
 import { Link as RouterLink } from 'react-router-dom';
+import { Resizable, type ResizeCallbackData } from 'react-resizable';
 import { useTranslation } from 'react-i18next';
 import { useGroup } from '../../context/GroupContext';
 import type { SchemaObject, SwaggerDoc } from '../../types/swagger';
-import { schemaFieldTableLayout } from './schemaFieldTableLayout';
+import {
+  SCHEMA_FIELD_COLUMN_MIN_WIDTHS,
+  schemaFieldTableLayout,
+  schemaFieldTableScrollX,
+  type SchemaFieldTableColumnKey,
+  type SchemaFieldTableColumnWidths,
+} from './schemaFieldTableLayout';
 import { schemaNodeRefName, schemaNodeTypeLabel } from './schemaUtils';
 
 const { Text } = Typography;
@@ -33,6 +40,12 @@ interface SchemaTypeLinkProps {
 interface SchemaFieldTableProps {
   fields: SchemaFieldNode[];
   emptyText?: string;
+}
+
+interface ResizableTitleProps extends React.ThHTMLAttributes<HTMLTableCellElement> {
+  width?: number;
+  minWidth?: number;
+  onResize?: (event: React.SyntheticEvent<Element>, data: ResizeCallbackData) => void;
 }
 
 function toRows(fields: SchemaFieldNode[], parentKey = ''): SchemaFieldRow[] {
@@ -146,16 +159,74 @@ function ConstraintTooltip({ node, children }: { node: SchemaFieldNode; children
   );
 }
 
+function ResizableTitle({ width, minWidth, onResize, children, ...restProps }: ResizableTitleProps) {
+  if (!width || !onResize) {
+    return <th {...restProps}>{children}</th>;
+  }
+
+  return (
+    <Resizable
+      width={width}
+      height={0}
+      resizeHandles={['e']}
+      minConstraints={[minWidth ?? 80, 0]}
+      draggableOpts={{ enableUserSelectHack: false }}
+      handle={
+        <span
+          className="knife4j-schema-resize-handle"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="调整列宽"
+          onClick={(event) => event.stopPropagation()}
+        />
+      }
+      onResize={onResize}
+    >
+      <th {...restProps} style={{ ...restProps.style, width }}>
+        {children}
+      </th>
+    </Resizable>
+  );
+}
+
 export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTableProps) {
   const { t } = useTranslation();
-  const rows = toRows(fields);
-  const tableLayout = schemaFieldTableLayout(fields);
+  const rows = useMemo(() => toRows(fields), [fields]);
+  const tableLayout = useMemo(() => schemaFieldTableLayout(fields), [fields]);
+  const defaultColumnWidths = tableLayout.columnWidths;
+  const [columnWidths, setColumnWidths] = useState<SchemaFieldTableColumnWidths>(defaultColumnWidths);
+
+  useEffect(() => {
+    setColumnWidths(defaultColumnWidths);
+  }, [defaultColumnWidths]);
+
+  const handleResize = useCallback(
+    (columnKey: SchemaFieldTableColumnKey) =>
+      (_event: React.SyntheticEvent<Element>, { size }: ResizeCallbackData) => {
+        setColumnWidths((current) => ({
+          ...current,
+          [columnKey]: Math.max(SCHEMA_FIELD_COLUMN_MIN_WIDTHS[columnKey], Math.round(size.width)),
+        }));
+      },
+    [],
+  );
+
+  const resizableHeader = useCallback(
+    (columnKey: SchemaFieldTableColumnKey) =>
+      ({
+        width: columnWidths[columnKey],
+        minWidth: SCHEMA_FIELD_COLUMN_MIN_WIDTHS[columnKey],
+        onResize: handleResize(columnKey),
+      }) as unknown as React.HTMLAttributes<HTMLTableCellElement>,
+    [columnWidths, handleResize],
+  );
 
   const columns: ColumnsType<SchemaFieldRow> = [
     {
       title: t('schema.col.fieldName'),
       dataIndex: 'name',
-      width: tableLayout.fieldNameWidth,
+      width: columnWidths.fieldName,
+      onHeaderCell: () => resizableHeader('fieldName'),
       render: (value) => (
         <Text
           code
@@ -172,13 +243,15 @@ export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTable
     },
     {
       title: t('schema.col.type'),
-      width: 160,
+      width: columnWidths.type,
+      onHeaderCell: () => resizableHeader('type'),
       render: (_, record) => <SchemaTypeLink node={record} />,
     },
     {
       title: t('schema.col.required'),
       dataIndex: 'required',
-      width: 90,
+      width: columnWidths.required,
+      onHeaderCell: () => resizableHeader('required'),
       render: (value) =>
         value ? (
           <Badge status="error" text={t('schema.required.yes')} />
@@ -189,6 +262,8 @@ export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTable
     {
       title: t('schema.col.description'),
       dataIndex: 'description',
+      width: columnWidths.description,
+      onHeaderCell: () => resizableHeader('description'),
       render: (value, record) => (
         <Space size={6} wrap>
           {value ? <span>{value}</span> : <Text type="secondary">-</Text>}
@@ -210,6 +285,11 @@ export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTable
   return (
     <Table<SchemaFieldRow>
       columns={columns}
+      components={{
+        header: {
+          cell: ResizableTitle,
+        },
+      }}
       dataSource={rows}
       pagination={false}
       size="small"
@@ -218,7 +298,7 @@ export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTable
         childrenColumnName: 'children',
         defaultExpandAllRows: true,
       }}
-      scroll={{ x: tableLayout.scrollX }}
+      scroll={{ x: schemaFieldTableScrollX(columnWidths) }}
       locale={{ emptyText: emptyText ?? t('schema.noFields') }}
     />
   );

--- a/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
@@ -6,6 +6,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useGroup } from '../../context/GroupContext';
 import type { SchemaObject, SwaggerDoc } from '../../types/swagger';
+import { schemaFieldTableLayout } from './schemaFieldTableLayout';
 import { schemaNodeRefName, schemaNodeTypeLabel } from './schemaUtils';
 
 const { Text } = Typography;
@@ -148,13 +149,26 @@ function ConstraintTooltip({ node, children }: { node: SchemaFieldNode; children
 export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTableProps) {
   const { t } = useTranslation();
   const rows = toRows(fields);
+  const tableLayout = schemaFieldTableLayout(fields);
 
   const columns: ColumnsType<SchemaFieldRow> = [
     {
       title: t('schema.col.fieldName'),
       dataIndex: 'name',
-      width: 210,
-      render: (value) => <Text code>{value || 'items'}</Text>,
+      width: tableLayout.fieldNameWidth,
+      render: (value) => (
+        <Text
+          code
+          title={value || 'items'}
+          style={{
+            whiteSpace: 'normal',
+            overflowWrap: 'anywhere',
+            lineHeight: '20px',
+          }}
+        >
+          {value || 'items'}
+        </Text>
+      ),
     },
     {
       title: t('schema.col.type'),
@@ -204,6 +218,7 @@ export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTable
         childrenColumnName: 'children',
         defaultExpandAllRows: true,
       }}
+      scroll={{ x: tableLayout.scrollX }}
       locale={{ emptyText: emptyText ?? t('schema.noFields') }}
     />
   );

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { SchemaFieldNode } from 'knife4j-core';
-import { maxSchemaFieldDepth, schemaFieldTableLayout } from './schemaFieldTableLayout';
+import { maxSchemaFieldDepth, schemaFieldTableLayout, schemaFieldTableScrollX } from './schemaFieldTableLayout';
 
 function field(name: string, children?: SchemaFieldNode[]): SchemaFieldNode {
   return {
@@ -14,6 +14,12 @@ function field(name: string, children?: SchemaFieldNode[]): SchemaFieldNode {
 describe('schemaFieldTableLayout', () => {
   it('keeps the base field-name width for shallow schemas', () => {
     expect(schemaFieldTableLayout([field('id')])).toEqual({
+      columnWidths: {
+        description: 360,
+        fieldName: 240,
+        required: 90,
+        type: 160,
+      },
       fieldNameWidth: 240,
       scrollX: 850,
     });
@@ -29,6 +35,12 @@ describe('schemaFieldTableLayout', () => {
 
     expect(maxSchemaFieldDepth(fields)).toBe(5);
     expect(schemaFieldTableLayout(fields)).toEqual({
+      columnWidths: {
+        description: 360,
+        fieldName: 360,
+        required: 90,
+        type: 160,
+      },
       fieldNameWidth: 360,
       scrollX: 970,
     });
@@ -41,8 +53,25 @@ describe('schemaFieldTableLayout', () => {
     }
 
     expect(schemaFieldTableLayout([current])).toEqual({
+      columnWidths: {
+        description: 360,
+        fieldName: 520,
+        required: 90,
+        type: 160,
+      },
       fieldNameWidth: 520,
       scrollX: 1130,
     });
+  });
+
+  it('uses the current column widths for horizontal scrolling', () => {
+    expect(
+      schemaFieldTableScrollX({
+        description: 720,
+        fieldName: 520,
+        required: 90,
+        type: 160,
+      }),
+    ).toBe(1490);
   });
 });

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { SchemaFieldNode } from 'knife4j-core';
+import { maxSchemaFieldDepth, schemaFieldTableLayout } from './schemaFieldTableLayout';
+
+function field(name: string, children?: SchemaFieldNode[]): SchemaFieldNode {
+  return {
+    name,
+    type: 'object',
+    required: false,
+    children,
+  };
+}
+
+describe('schemaFieldTableLayout', () => {
+  it('keeps the base field-name width for shallow schemas', () => {
+    expect(schemaFieldTableLayout([field('id')])).toEqual({
+      fieldNameWidth: 240,
+      scrollX: 850,
+    });
+  });
+
+  it('increases the field-name width for deep nested schemas', () => {
+    const leaf = field('leaf');
+    const level4 = field('level4', [leaf]);
+    const level3 = field('level3', [level4]);
+    const level2 = field('level2', [level3]);
+    const level1 = field('level1', [level2]);
+    const fields = [field('root', [level1])];
+
+    expect(maxSchemaFieldDepth(fields)).toBe(5);
+    expect(schemaFieldTableLayout(fields)).toEqual({
+      fieldNameWidth: 360,
+      scrollX: 970,
+    });
+  });
+
+  it('caps the field-name width for very deep schemas', () => {
+    let current = field('leaf');
+    for (let i = 0; i < 20; i += 1) {
+      current = field(`level${i}`, [current]);
+    }
+
+    expect(schemaFieldTableLayout([current])).toEqual({
+      fieldNameWidth: 520,
+      scrollX: 1130,
+    });
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.ts
@@ -8,8 +8,20 @@ const REQUIRED_COLUMN_WIDTH = 90;
 const DESCRIPTION_MIN_WIDTH = 360;
 const TABLE_MIN_SCROLL_WIDTH = 840;
 
+export type SchemaFieldTableColumnKey = 'fieldName' | 'type' | 'required' | 'description';
+
+export type SchemaFieldTableColumnWidths = Record<SchemaFieldTableColumnKey, number>;
+
+export const SCHEMA_FIELD_COLUMN_MIN_WIDTHS: SchemaFieldTableColumnWidths = {
+  fieldName: 160,
+  type: 120,
+  required: 80,
+  description: 240,
+};
+
 export interface SchemaFieldTableLayout {
   fieldNameWidth: number;
+  columnWidths: SchemaFieldTableColumnWidths;
   scrollX: number;
 }
 
@@ -20,18 +32,25 @@ export function maxSchemaFieldDepth(fields: Pick<SchemaFieldNode, 'children'>[],
   }, depth);
 }
 
+export function schemaFieldTableScrollX(widths: SchemaFieldTableColumnWidths): number {
+  return Math.max(TABLE_MIN_SCROLL_WIDTH, widths.fieldName + widths.type + widths.required + widths.description);
+}
+
 export function schemaFieldTableLayout(fields: SchemaFieldNode[]): SchemaFieldTableLayout {
   const fieldNameWidth = Math.min(
     FIELD_NAME_MAX_WIDTH,
     FIELD_NAME_BASE_WIDTH + maxSchemaFieldDepth(fields) * FIELD_NAME_DEPTH_STEP,
   );
-  const scrollX = Math.max(
-    TABLE_MIN_SCROLL_WIDTH,
-    fieldNameWidth + TYPE_COLUMN_WIDTH + REQUIRED_COLUMN_WIDTH + DESCRIPTION_MIN_WIDTH,
-  );
+  const columnWidths = {
+    fieldName: fieldNameWidth,
+    type: TYPE_COLUMN_WIDTH,
+    required: REQUIRED_COLUMN_WIDTH,
+    description: DESCRIPTION_MIN_WIDTH,
+  };
 
   return {
     fieldNameWidth,
-    scrollX,
+    columnWidths,
+    scrollX: schemaFieldTableScrollX(columnWidths),
   };
 }

--- a/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.ts
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/schemaFieldTableLayout.ts
@@ -1,0 +1,37 @@
+import type { SchemaFieldNode } from 'knife4j-core';
+
+const FIELD_NAME_BASE_WIDTH = 240;
+const FIELD_NAME_DEPTH_STEP = 24;
+const FIELD_NAME_MAX_WIDTH = 520;
+const TYPE_COLUMN_WIDTH = 160;
+const REQUIRED_COLUMN_WIDTH = 90;
+const DESCRIPTION_MIN_WIDTH = 360;
+const TABLE_MIN_SCROLL_WIDTH = 840;
+
+export interface SchemaFieldTableLayout {
+  fieldNameWidth: number;
+  scrollX: number;
+}
+
+export function maxSchemaFieldDepth(fields: Pick<SchemaFieldNode, 'children'>[], depth = 0): number {
+  return fields.reduce((maxDepth, field) => {
+    const childDepth = field.children ? maxSchemaFieldDepth(field.children, depth + 1) : depth;
+    return Math.max(maxDepth, childDepth);
+  }, depth);
+}
+
+export function schemaFieldTableLayout(fields: SchemaFieldNode[]): SchemaFieldTableLayout {
+  const fieldNameWidth = Math.min(
+    FIELD_NAME_MAX_WIDTH,
+    FIELD_NAME_BASE_WIDTH + maxSchemaFieldDepth(fields) * FIELD_NAME_DEPTH_STEP,
+  );
+  const scrollX = Math.max(
+    TABLE_MIN_SCROLL_WIDTH,
+    fieldNameWidth + TYPE_COLUMN_WIDTH + REQUIRED_COLUMN_WIDTH + DESCRIPTION_MIN_WIDTH,
+  );
+
+  return {
+    fieldNameWidth,
+    scrollX,
+  };
+}

--- a/knife4j-front/knife4j-ui-react/src/index.css
+++ b/knife4j-front/knife4j-ui-react/src/index.css
@@ -57,6 +57,36 @@ body {
   z-index: 1;
 }
 
+.ant-table-thead > tr > th.react-resizable {
+  position: relative;
+}
+
+.knife4j-schema-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  bottom: 0;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 2;
+}
+
+.knife4j-schema-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 8px;
+  right: 3px;
+  bottom: 8px;
+  width: 1px;
+  background: transparent;
+  transition: background 0.16s ease;
+}
+
+.ant-table-thead > tr > th.react-resizable:hover .knife4j-schema-resize-handle::after,
+.knife4j-schema-resize-handle:hover::after {
+  background: #1677ff;
+}
+
 .knife4j-operation-tabs.ant-tabs {
   min-height: calc(100vh - 176px);
   margin: 0;


### PR DESCRIPTION
## 关联 Issue

Closes #465

## 变更内容

- 将 `SchemaFieldTable` 的字段名列从固定 210px 改为按 schema 树深度动态加宽。
- 为 schema 字段表格设置横向滚动下限，窄容器下可以横向查看完整字段名和说明。
- 字段名 code 标签允许正常换行，避免深层对象字段名只露出尾部。
- 支持在表头拖拽调整 `字段名`、`类型`、`必填`、`说明` 四列宽度，拖拽后同步更新横向滚动宽度。
- 新增布局计算单测，覆盖浅层、深层、极深层宽度上限，以及拖宽列后 scroll 宽度变化。

## 复现与验证

使用临时 OpenAPI 3 fixture 复现一个 7 层左右的深层响应对象，并在本地分别启动：

- 修复前基线：`origin/master` worktree，`http://127.0.0.1:5177/`
- 修复后分支：`agent/465-response-table-layout`，`http://127.0.0.1:5178/`
- 同一路由：`#/default/AnyLogic项目控制器/deepResponse/doc`

对比字段 `extremelyLongDeepNestedMeasurementUnitIdentifierForIssue465`：

- 修复前：字段名列宽 `210px`，表格无横向滚动，字段文本渲染宽度 `188px`，高度 `86px`。
- 自动加宽后：字段名列宽 `408px`，表格开启横向滚动，字段文本渲染宽度 `389px`，高度 `42px`。
- 拖拽列宽后：将字段名列向右拖拽约 `220px`，字段名列宽变为 `628px`，表格 `scrollWidth` 从 `1021px` 变为 `1241px`，目标字段文本高度降到 `20px`，可以单行显示。

这证明旧版能稳定复现深层字段列宽不足的问题，当前分支可以先自动改善可读性，也允许维护者继续手动拖宽列来容纳更长字段。

## 协作与审查

- worker：曾启动短命 worker，但当前运行时额度限制导致 worker 未完成 handoff；因此本 PR 记录为 coordinator 按运行时例外直接实现。
- reviewer：第一版 diff 已由短命 reviewer 审查通过；拖拽列宽增量 diff 复用 reviewer `Rawls` 审查，结论 `approve`，无需要返工的问题。

## 自动化验证

- `bun run format`：通过，无额外改动。
- `./scripts/test-front-core.sh`：第一次在沙箱内因 Bun tempdir 权限失败；提权重跑同一脚本通过。
  - `knife4j-core`：15 个测试套件、187 个测试通过，format、lint、build 通过。
  - `knife4j-ui-react`：14 个测试文件、68 个测试通过，format、lint、build 通过。
- 浏览器验证：已完成修复前、修复后、拖拽后的本地页面复现与截图。
- PR CI：`front-core-test`、`docs-build`、`java-build-test` 全部通过。

## 已知风险

- 本次拖拽宽度只保存在当前组件状态中，不做 localStorage 持久化；刷新页面后回到自动计算的默认列宽。
- 现有自动化测试覆盖布局计算，真实拖拽交互通过本地浏览器验证覆盖。