### PR TITLE
修复 React 语言切换后的接口文档重新加载

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/api/acceptLanguage.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/acceptLanguage.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAcceptLanguageHeader } from './acceptLanguage';
+
+describe('acceptLanguage', () => {
+  it('keeps the browser default when no language is explicitly selected', () => {
+    expect(buildAcceptLanguageHeader(undefined, ['zh-CN', 'en-US'])).toBeUndefined();
+  });
+
+  it('puts the selected language before the browser language order', () => {
+    expect(buildAcceptLanguageHeader('en-US', ['zh-CN', 'en-US', 'ja-JP'])).toBe('en-US,zh-CN;q=0.9,ja-JP;q=0.8');
+  });
+
+  it('deduplicates language tags case-insensitively and ignores invalid tags', () => {
+    expect(buildAcceptLanguageHeader('en-US', ['EN-us', 'zh-CN', 'zh-CN\r\nX-Debug: true', ''])).toBe(
+      'en-US,zh-CN;q=0.9',
+    );
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/api/acceptLanguage.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/acceptLanguage.ts
@@ -1,0 +1,59 @@
+const LANGUAGE_TAG_PATTERN = /^[A-Za-z0-9*]+(?:-[A-Za-z0-9*]+)*$/;
+
+function normalizeLanguageTag(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || !LANGUAGE_TAG_PATTERN.test(trimmed)) return null;
+  return trimmed;
+}
+
+function getBrowserLanguages(): string[] {
+  if (typeof navigator === 'undefined') return [];
+  if (Array.isArray(navigator.languages) && navigator.languages.length > 0) {
+    return [...navigator.languages];
+  }
+  return navigator.language ? [navigator.language] : [];
+}
+
+function qualityValue(index: number): string {
+  return Math.max(1 - index * 0.1, 0.1).toFixed(1);
+}
+
+export function buildAcceptLanguageHeader(
+  preferredLanguage: string | undefined,
+  browserLanguages: readonly string[] = getBrowserLanguages(),
+): string | undefined {
+  const preferred = preferredLanguage ? normalizeLanguageTag(preferredLanguage) : null;
+  if (!preferred) return undefined;
+
+  const seen = new Set<string>();
+  const languages: string[] = [];
+  const addLanguage = (language: string | null) => {
+    if (!language) return;
+    const key = language.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    languages.push(language);
+  };
+
+  addLanguage(preferred);
+  browserLanguages.forEach((language) => addLanguage(normalizeLanguageTag(language)));
+
+  return languages
+    .map((language, index) => (index === 0 ? language : `${language};q=${qualityValue(index)}`))
+    .join(',');
+}
+
+export function createLanguageAwareRequestInit(preferredLanguage?: string): RequestInit | undefined {
+  const acceptLanguage = buildAcceptLanguageHeader(preferredLanguage);
+  if (!acceptLanguage) return undefined;
+  return {
+    headers: {
+      'Accept-Language': acceptLanguage,
+    },
+  };
+}
+
+export function fetchWithAcceptLanguage(input: RequestInfo | URL, preferredLanguage?: string): Promise<Response> {
+  const init = createLanguageAwareRequestInit(preferredLanguage);
+  return init ? fetch(input, init) : fetch(input);
+}

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
@@ -63,6 +63,30 @@ describe('knife4jClient', () => {
     });
   });
 
+  it('sends the selected UI language when fetching api-docs', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      textResponse(
+        JSON.stringify({
+          openapi: '3.0.1',
+          info: { title: 'demo', version: '1.0.0' },
+          paths: {},
+        }),
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchSwaggerDocResult('/v3/api-docs', { preferredLanguage: 'en-US' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v3/api-docs',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Accept-Language': expect.stringMatching(/^en-US(?:,|$)/),
+        }),
+      }),
+    );
+  });
+
   it('rejects non OpenAPI JSON responses with a diagnostic message', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(textResponse(JSON.stringify({ error: 'not found' })));
     vi.stubGlobal('fetch', fetchMock);

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -12,6 +12,7 @@ import type {
   SwaggerUiConfig,
   Knife4jRuntimeConfig,
 } from '../types/swagger';
+import { fetchWithAcceptLanguage } from './acceptLanguage';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
 const KNIFE4J_ORDER_EXTENSION = 'x-order';
@@ -20,6 +21,10 @@ const DEFAULT_SWAGGER_INFO: SwaggerInfo = { title: 'API Docs', version: '' };
 export interface SwaggerDocFetchResult {
   doc: SwaggerDoc | null;
   error: string | null;
+}
+
+export interface LanguageAwareRequestOptions {
+  preferredLanguage?: string;
 }
 
 /** HTTP method 在 swagger-ui 'method' sorter 下的固定顺序 */
@@ -45,29 +50,32 @@ export type OperationsSorter = 'alpha' | 'method' | 'preserve';
  * 当用户自定义 `springdoc.api-docs.path` 时，默认 swagger-config 会移动到新路径；
  * 此时读取 Knife4j runtime config `/knife4j/config` 来发现实际 swagger-config URL。
  */
-export async function fetchSwaggerUiConfig(): Promise<SwaggerUiConfig | null> {
-  const defaultConfig = await fetchSwaggerUiConfigFrom('v3/api-docs/swagger-config');
+export async function fetchSwaggerUiConfig(options: LanguageAwareRequestOptions = {}): Promise<SwaggerUiConfig | null> {
+  const defaultConfig = await fetchSwaggerUiConfigFrom('v3/api-docs/swagger-config', options);
   if (defaultConfig) {
     return defaultConfig;
   }
 
   try {
-    const res = await fetch('knife4j/config');
+    const res = await fetchWithAcceptLanguage('knife4j/config', options.preferredLanguage);
     if (!res.ok) return null;
     const discovery = (await res.json()) as Knife4jRuntimeConfig;
     const swaggerConfigUrl = discovery.openapi?.swaggerConfigUrl;
     if (typeof swaggerConfigUrl !== 'string' || swaggerConfigUrl.length === 0) {
       return null;
     }
-    return fetchSwaggerUiConfigFrom(swaggerConfigUrl);
+    return fetchSwaggerUiConfigFrom(swaggerConfigUrl, options);
   } catch (_) {
     return null;
   }
 }
 
-async function fetchSwaggerUiConfigFrom(url: string): Promise<SwaggerUiConfig | null> {
+async function fetchSwaggerUiConfigFrom(
+  url: string,
+  options: LanguageAwareRequestOptions,
+): Promise<SwaggerUiConfig | null> {
   try {
-    const res = await fetch(url);
+    const res = await fetchWithAcceptLanguage(url, options.preferredLanguage);
     if (!res.ok) return null;
     return (await res.json()) as SwaggerUiConfig;
   } catch (_) {
@@ -92,16 +100,16 @@ export function parseGroupsFromConfig(config: SwaggerUiConfig): SwaggerGroup[] {
 }
 
 /** 拉取 group 列表（兼容 springfox / springdoc） */
-export async function fetchGroups(): Promise<SwaggerGroup[]> {
+export async function fetchGroups(options: LanguageAwareRequestOptions = {}): Promise<SwaggerGroup[]> {
   // 优先尝试 springdoc: v3/api-docs/swagger-config
-  const config = await fetchSwaggerUiConfig();
+  const config = await fetchSwaggerUiConfig(options);
   if (config) {
     return parseGroupsFromConfig(config);
   }
 
   // fallback: springfox swagger-resources
   try {
-    const res = await fetch('swagger-resources');
+    const res = await fetchWithAcceptLanguage('swagger-resources', options.preferredLanguage);
     if (res.ok) {
       const data: Array<{ name: string; location: string; swaggerVersion?: string }> = await res.json();
       return data.map((g) => ({
@@ -119,9 +127,12 @@ export async function fetchGroups(): Promise<SwaggerGroup[]> {
 }
 
 /** 拉取指定 group 的 api-docs，并返回可展示的诊断信息 */
-export async function fetchSwaggerDocResult(url: string): Promise<SwaggerDocFetchResult> {
+export async function fetchSwaggerDocResult(
+  url: string,
+  options: LanguageAwareRequestOptions = {},
+): Promise<SwaggerDocFetchResult> {
   try {
-    const res = await fetch(url);
+    const res = await fetchWithAcceptLanguage(url, options.preferredLanguage);
     if (!res.ok) {
       return { doc: null, error: `api-docs 请求失败：HTTP ${res.status}` };
     }
@@ -133,8 +144,11 @@ export async function fetchSwaggerDocResult(url: string): Promise<SwaggerDocFetc
 }
 
 /** 拉取指定 group 的 api-docs */
-export async function fetchSwaggerDoc(url: string): Promise<SwaggerDoc | null> {
-  const result = await fetchSwaggerDocResult(url);
+export async function fetchSwaggerDoc(
+  url: string,
+  options: LanguageAwareRequestOptions = {},
+): Promise<SwaggerDoc | null> {
+  const result = await fetchSwaggerDocResult(url, options);
   return result.doc;
 }
 

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -11,6 +11,7 @@ import {
   type OperationsSorter,
   type TagsSorter,
 } from '../api/knife4jClient';
+import { fetchWithAcceptLanguage } from '../api/acceptLanguage';
 import type { MenuTag, SchemaObject, SwaggerDoc, SwaggerGroup, SwaggerUiConfig } from '../types/swagger';
 import { extractKnife4jSettings, extractMarkdownFiles } from '../utils/knife4jSettings';
 import { groupNameFromPathname, selectInitialGroupName } from '../utils/groupRoute';
@@ -70,6 +71,8 @@ const GroupContext = createContext<GroupContextValue | null>(null);
 export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
   const initialPathnameRef = useRef(location.pathname);
+  const { settings, setServerSettings } = useSettings();
+  const initialLanguageRef = useRef(settings.language);
   const [rawGroups, setRawGroups] = useState<SwaggerGroup[]>([]);
   const [swaggerUiConfig, setSwaggerUiConfig] = useState<SwaggerUiConfig | null>(null);
   const [activeGroupValue, setActiveGroupValue] = useState<string>('');
@@ -78,13 +81,12 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [usingMock, setUsingMock] = useState(false);
   const [groupError, setGroupError] = useState<string | null>(null);
 
-  const { settings, setServerSettings } = useSettings();
-
   // 初始化：优先拉取 swagger-config（拿到 tagsSorter / operationsSorter），失败回退到 swagger-resources
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const config = await fetchSwaggerUiConfig();
+      const preferredLanguage = initialLanguageRef.current;
+      const config = await fetchSwaggerUiConfig({ preferredLanguage });
       if (cancelled) return;
 
       if (config) {
@@ -99,7 +101,7 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
       // swagger-config 不可用 → 回退 springfox swagger-resources
       try {
-        const res = await fetch('swagger-resources');
+        const res = await fetchWithAcceptLanguage('swagger-resources', preferredLanguage);
         if (res.ok) {
           const data: Array<{ name: string; location: string; swaggerVersion?: string }> = await res.json();
           const groups: SwaggerGroup[] = data.map((g) => ({
@@ -143,9 +145,12 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const group = rawGroups.find((g) => g.name === activeGroupValue);
     if (!group) return;
 
+    const preferredLanguage = settings.language;
+    let cancelled = false;
     setLoading(true);
     setGroupError(null);
-    fetchSwaggerDocResult(group.url).then((result) => {
+    fetchSwaggerDocResult(group.url, { preferredLanguage }).then((result) => {
+      if (cancelled) return;
       if (result.doc) {
         setSwaggerDoc(result.doc);
       } else {
@@ -155,7 +160,10 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       }
       setLoading(false);
     });
-  }, [activeGroupValue, rawGroups, usingMock]);
+    return () => {
+      cancelled = true;
+    };
+  }, [activeGroupValue, rawGroups, settings.language, usingMock]);
 
   useEffect(() => {
     setServerSettings(extractKnife4jSettings(swaggerDoc));

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -71,8 +71,8 @@ const GroupContext = createContext<GroupContextValue | null>(null);
 export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const location = useLocation();
   const initialPathnameRef = useRef(location.pathname);
-  const { settings, setServerSettings } = useSettings();
-  const initialLanguageRef = useRef(settings.language);
+  const { settings, userSettings, setServerSettings } = useSettings();
+  const initialLanguageRef = useRef(userSettings.language);
   const [rawGroups, setRawGroups] = useState<SwaggerGroup[]>([]);
   const [swaggerUiConfig, setSwaggerUiConfig] = useState<SwaggerUiConfig | null>(null);
   const [activeGroupValue, setActiveGroupValue] = useState<string>('');
@@ -145,7 +145,7 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const group = rawGroups.find((g) => g.name === activeGroupValue);
     if (!group) return;
 
-    const preferredLanguage = settings.language;
+    const preferredLanguage = userSettings.language;
     let cancelled = false;
     setLoading(true);
     setGroupError(null);
@@ -163,7 +163,7 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     return () => {
       cancelled = true;
     };
-  }, [activeGroupValue, rawGroups, settings.language, usingMock]);
+  }, [activeGroupValue, rawGroups, userSettings.language, usingMock]);
 
   useEffect(() => {
     setServerSettings(extractKnife4jSettings(swaggerDoc));

--- a/knife4j-front/knife4j-ui-react/src/context/SettingsContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/SettingsContext.tsx
@@ -61,6 +61,7 @@ function shallowEqualSettings(a: SettingsOverrides, b: SettingsOverrides): boole
 
 interface SettingsContextValue {
   settings: AppSettings;
+  userSettings: Partial<AppSettings>;
   setSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void;
   resetSettings: () => void;
   setServerSettings: (settings: SettingsOverrides) => void;
@@ -95,8 +96,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   }, []);
 
   const value = useMemo(
-    () => ({ settings, setSetting, resetSettings, setServerSettings }),
-    [settings, setSetting, resetSettings, setServerSettings],
+    () => ({ settings, userSettings: userOverrides, setSetting, resetSettings, setServerSettings }),
+    [settings, userOverrides, setSetting, resetSettings, setServerSettings],
   );
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;


### PR DESCRIPTION
## 关联 Issue

Closes #470

## 变更内容

- 为 React UI 的接口文档请求增加 `Accept-Language` 构造逻辑。
- 当用户在右上角选择语言后，当前 group 的 `api-docs` 会随 `settings.language` 变化重新请求。
- 在显式选择语言时，将用户选择放在浏览器语言序列之前；未显式选择时保持浏览器默认请求行为。
- 补充 `Accept-Language` 构造和 `api-docs` 请求头测试。

## 验证

- `TMPDIR=/private/tmp ./scripts/test-front-core.sh`：通过。

## Worker / Reviewer

- 跳过 worker：当前 Codex 子 agent 工具策略要求只有维护者明确要求多 agent 时才可启动；本次由 coordinator 直接处理。
- 跳过 reviewer：同上，未声称已独立审查；替代验证为 diff 自审、`git diff --cached --check` 与完整前端门禁。

## 已知风险

- 本 PR 只处理 React/OAS3 UI 请求行为；后端是否按 `Accept-Language` 返回本地化文档由应用自身或后续 Java 任务决定。
