### PR TITLE
修复网关聚合调试地址默认值

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
@@ -49,6 +49,14 @@ describe('knife4jClient', () => {
     expect(parseGroupsFromConfig({ url: '/api/openapi' })).toEqual([{ name: 'default', url: '/api/openapi' }]);
   });
 
+  it('preserves gateway route contextPath from swagger-config urls', () => {
+    expect(
+      parseGroupsFromConfig({
+        urls: [{ name: '用户中心', url: '/iam/v3/api-docs', contextPath: '/iam' }],
+      }),
+    ).toEqual([{ name: '用户中心', url: '/iam/v3/api-docs', contextPath: '/iam' }]);
+  });
+
   it('normalizes OpenAPI docs with missing info', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(textResponse(JSON.stringify({ openapi: '3.0.1', paths: {} })));
     vi.stubGlobal('fetch', fetchMock);

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -83,7 +83,13 @@ async function fetchSwaggerUiConfigFrom(url: string): Promise<SwaggerUiConfig | 
  */
 export function parseGroupsFromConfig(config: SwaggerUiConfig): SwaggerGroup[] {
   if (config.urls && Array.isArray(config.urls) && config.urls.length > 0) {
-    return config.urls.map((u) => ({ name: u.name, url: u.url }));
+    return config.urls.map((u) => ({
+      name: u.name,
+      url: u.url,
+      ...(u.location ? { location: u.location } : {}),
+      ...(u.swaggerVersion ? { swaggerVersion: u.swaggerVersion } : {}),
+      ...(typeof u.contextPath === 'string' ? { contextPath: u.contextPath } : {}),
+    }));
   }
   if (typeof config.url === 'string' && config.url.length > 0) {
     return [{ name: 'default', url: config.url }];

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -165,6 +165,7 @@ const enUS = {
   'apiDebug.customCookie.title': 'Custom Cookies',
   'apiDebug.customCookie.namePlaceholder': 'Cookie name',
   'apiDebug.noBody': 'This API has no request body',
+  'apiDebug.baseUrl.source.gateway': 'gateway context',
   'apiDebug.baseUrl.source.operation': 'operation server',
   'apiDebug.baseUrl.source.path': 'path server',
   'apiDebug.baseUrl.source.document': 'document server',

--- a/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
@@ -170,6 +170,7 @@ const jaJP = {
   'apiDebug.customCookie.title': 'カスタム Cookie',
   'apiDebug.customCookie.namePlaceholder': 'Cookie 名',
   'apiDebug.noBody': 'この API にリクエストボディはありません',
+  'apiDebug.baseUrl.source.gateway': 'gateway context',
   'apiDebug.baseUrl.source.operation': 'operation server',
   'apiDebug.baseUrl.source.path': 'path server',
   'apiDebug.baseUrl.source.document': 'document server',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -164,6 +164,7 @@ const zhCN = {
   'apiDebug.customCookie.title': '自定义 Cookie',
   'apiDebug.customCookie.namePlaceholder': 'Cookie 名称',
   'apiDebug.noBody': '该接口无请求体',
+  'apiDebug.baseUrl.source.gateway': '网关上下文',
   'apiDebug.baseUrl.source.operation': '接口服务地址',
   'apiDebug.baseUrl.source.path': '路径服务地址',
   'apiDebug.baseUrl.source.document': '文档服务地址',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -47,6 +47,7 @@ import {
 import { OperationModeLayout, useCurrentOperation } from './useCurrentOperation';
 import CodeEditor, { type CodeEditorLanguage } from '../../components/CodeEditor';
 import { useAuth } from '../../context/AuthContext';
+import { useGroup } from '../../context/GroupContext';
 import { useGlobalParam } from '../../context/GlobalParamContext';
 import { useSettings } from '../../context/SettingsContext';
 import ResponsePanel, { type DebugResponsePayload, type SseEvent } from './ResponsePanel';
@@ -1594,6 +1595,7 @@ function buildInitialDebugState(
 const DEBUG_HTTP_METHODS = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']);
 
 function requestServerSourceLabel(source: RequestServerSource, t: ReturnType<typeof useTranslation>['t']): string {
+  if (source === 'gateway') return t('apiDebug.baseUrl.source.gateway');
   if (source === 'operation') return t('apiDebug.baseUrl.source.operation');
   if (source === 'path') return t('apiDebug.baseUrl.source.path');
   return t('apiDebug.baseUrl.source.document');
@@ -1675,7 +1677,9 @@ export default function ApiDebug() {
   const { t } = useTranslation();
   const { group, tag, operaterId } = useParams();
   const { loading: docLoading, swaggerDoc, operation } = useCurrentOperation();
+  const { activeSwaggerGroup } = useGroup();
   const { settings } = useSettings();
+  const groupContextPath = activeSwaggerGroup?.contextPath;
   const operationMethod = operation?.method;
   const operationPath = operation?.path;
   const debugCacheKey = useMemo(() => {
@@ -1689,15 +1693,17 @@ export default function ApiDebug() {
         operation,
         enableHost: settings.enableHost,
         enableHostText: settings.enableHostText,
+        groupContextPath,
         origin: currentOrigin(),
       }),
-    [operation, settings.enableHost, settings.enableHostText, swaggerDoc],
+    [groupContextPath, operation, settings.enableHost, settings.enableHostText, swaggerDoc],
   );
   const requestServerSelectOptions = useMemo(
     () =>
       resolveRequestServerOptions({
         swaggerDoc,
         operation,
+        groupContextPath,
         origin: currentOrigin(),
       }).map((server) => {
         const source = requestServerSourceLabel(server.source, t);
@@ -1707,7 +1713,7 @@ export default function ApiDebug() {
           label: description ? `${server.url} - ${description} (${source})` : `${server.url} (${source})`,
         };
       }),
-    [operation, swaggerDoc, t],
+    [groupContextPath, operation, swaggerDoc, t],
   );
   const [baseUrl, setBaseUrl] = useState(defaultBaseUrl);
   const [method, setMethod] = useState('GET');

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
@@ -59,6 +59,18 @@ describe('request base URL resolution', () => {
     ).toBe('http://127.0.0.1:18000/api');
   });
 
+  it('prefers the current gateway origin plus group contextPath ahead of downstream OpenAPI servers', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://172.19.112.1:20001']),
+        enableHost: false,
+        enableHostText: '',
+        groupContextPath: '/iam',
+        origin: 'http://172.19.112.1:20000',
+      }),
+    ).toBe('http://172.19.112.1:20000/iam');
+  });
+
   it('upgrades same-host OpenAPI server URLs when the UI is served over HTTPS', () => {
     expect(
       resolveRequestBaseUrl({
@@ -102,6 +114,28 @@ describe('request base URL resolution', () => {
         origin: 'http://127.0.0.1:3002',
       }),
     ).toBe('http://gateway.example.test/root');
+  });
+
+  it('keeps the explicit host override ahead of the gateway context path', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://service.example.test']),
+        enableHost: true,
+        enableHostText: 'http://gateway.example.test/',
+        groupContextPath: '/iam',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://gateway.example.test');
+
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://service.example.test']),
+        enableHost: true,
+        enableHostText: 'http://gateway.example.test/iam/',
+        groupContextPath: '/iam',
+        origin: 'http://127.0.0.1:3002',
+      }),
+    ).toBe('http://gateway.example.test/iam');
   });
 
   it('keeps the explicit host override protocol unchanged', () => {
@@ -195,6 +229,28 @@ describe('request base URL resolution', () => {
       ['operation', 'http://operation.example.test/api'],
       ['path', 'http://path.example.test/api'],
       ['document', 'http://root.example.test/api'],
+    ]);
+  });
+
+  it('lists the gateway context option before OpenAPI server options', () => {
+    const swaggerDoc = docWithServerLevels({
+      root: ['http://root.example.test/api'],
+      path: ['http://path.example.test/api'],
+      operation: ['http://operation.example.test/api'],
+    });
+
+    expect(
+      resolveRequestServerOptions({
+        swaggerDoc,
+        operation: petOperation(swaggerDoc),
+        groupContextPath: 'iam',
+        origin: 'http://172.19.112.1:20000',
+      }).map((option) => [option.source, option.url, option.rawUrl]),
+    ).toEqual([
+      ['gateway', 'http://172.19.112.1:20000/iam', '/iam'],
+      ['operation', 'http://operation.example.test/api', 'http://operation.example.test/api'],
+      ['path', 'http://path.example.test/api', 'http://path.example.test/api'],
+      ['document', 'http://root.example.test/api', 'http://root.example.test/api'],
     ]);
   });
 

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
@@ -5,10 +5,11 @@ export interface ResolveRequestBaseUrlOptions {
   operation?: MenuOperation | null;
   enableHost: boolean;
   enableHostText: string;
+  groupContextPath?: string;
   origin: string;
 }
 
-export type RequestServerSource = 'operation' | 'path' | 'document';
+export type RequestServerSource = 'gateway' | 'operation' | 'path' | 'document';
 
 export interface RequestServerOption {
   source: RequestServerSource;
@@ -31,6 +32,38 @@ function trimTrailingSlashes(url: string): string {
 
 function shouldUpgradeSameHostHttpUrl(url: URL, origin: URL): boolean {
   return origin.protocol === 'https:' && url.protocol === 'http:' && url.hostname === origin.hostname;
+}
+
+function normalizeGroupContextPath(contextPath: string | undefined): string {
+  const trimmed = contextPath?.trim() ?? '';
+  if (!trimmed || trimmed === '/') return '';
+  return `/${trimmed.replace(/^\/+/, '').replace(/\/+$/, '')}`;
+}
+
+function appendContextPath(baseUrl: string, contextPath: string | undefined, origin: string): string {
+  const normalizedBaseUrl = normalizeRequestBaseUrl(baseUrl, origin);
+  const normalizedContextPath = normalizeGroupContextPath(contextPath);
+  if (!normalizedContextPath) return normalizedBaseUrl;
+
+  try {
+    const url = new URL(normalizedBaseUrl);
+    const basePath = trimTrailingSlashes(url.pathname);
+    const hasContextPath = basePath === normalizedContextPath || basePath.endsWith(normalizedContextPath);
+    if (!hasContextPath) {
+      url.pathname = basePath && basePath !== '/' ? `${basePath}${normalizedContextPath}` : normalizedContextPath;
+    }
+    return trimTrailingSlashes(url.toString());
+  } catch {
+    return normalizedBaseUrl.endsWith(normalizedContextPath)
+      ? normalizedBaseUrl
+      : `${trimTrailingSlashes(normalizedBaseUrl)}${normalizedContextPath}`;
+  }
+}
+
+function resolveGatewayContextBaseUrl(origin: string, groupContextPath: string | undefined): string | null {
+  const normalizedContextPath = normalizeGroupContextPath(groupContextPath);
+  if (!normalizedContextPath) return null;
+  return appendContextPath(origin, groupContextPath, origin);
 }
 
 export function normalizeRequestBaseUrl(
@@ -84,11 +117,25 @@ function appendServerOptions(
 export function resolveRequestServerOptions({
   swaggerDoc,
   operation,
+  groupContextPath,
   origin,
-}: Pick<ResolveRequestBaseUrlOptions, 'swaggerDoc' | 'operation' | 'origin'>): RequestServerOption[] {
+}: Pick<
+  ResolveRequestBaseUrlOptions,
+  'swaggerDoc' | 'operation' | 'groupContextPath' | 'origin'
+>): RequestServerOption[] {
   const pathItem = operation ? swaggerDoc?.paths[operation.path] : undefined;
   const result: RequestServerOption[] = [];
   const seen = new Set<string>();
+  const gatewayContextBaseUrl = resolveGatewayContextBaseUrl(origin, groupContextPath);
+
+  if (gatewayContextBaseUrl) {
+    seen.add(gatewayContextBaseUrl);
+    result.push({
+      source: 'gateway',
+      url: gatewayContextBaseUrl,
+      rawUrl: normalizeGroupContextPath(groupContextPath),
+    });
+  }
 
   appendServerOptions(result, seen, 'operation', operation?.operation.servers, origin);
   appendServerOptions(result, seen, 'path', pathItem?.servers, origin);
@@ -102,6 +149,7 @@ export function resolveRequestBaseUrl({
   operation,
   enableHost,
   enableHostText,
+  groupContextPath,
   origin,
 }: ResolveRequestBaseUrlOptions): string {
   const hostOverride = enableHost ? enableHostText.trim() : '';
@@ -109,7 +157,7 @@ export function resolveRequestBaseUrl({
     return normalizeRequestBaseUrl(hostOverride, origin);
   }
 
-  const serverUrl = resolveRequestServerOptions({ swaggerDoc, operation, origin })[0]?.url;
+  const serverUrl = resolveRequestServerOptions({ swaggerDoc, operation, groupContextPath, origin })[0]?.url;
   if (serverUrl) {
     return serverUrl;
   }

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -8,6 +8,7 @@ export interface SwaggerGroup {
   url: string; // api-docs 地址
   swaggerVersion?: string;
   location?: string; // swagger-resources 格式
+  contextPath?: string; // gateway / aggregation route context-path
 }
 
 /**
@@ -22,7 +23,13 @@ export interface SwaggerUiConfig {
   /** 单文档 api-docs 地址（springdoc 单文档场景） */
   url?: string;
   /** 分组列表（springdoc 多文档场景） */
-  urls?: Array<{ name: string; url: string }>;
+  urls?: Array<{
+    name: string;
+    url: string;
+    contextPath?: string;
+    swaggerVersion?: string;
+    location?: string;
+  }>;
   /** tag 排序策略（例如 'alpha'） */
   tagsSorter?: string;
   /** operation 排序策略（例如 'alpha' / 'method'） */


### PR DESCRIPTION
## 关联 Issue

Fixes #468

## 问题原因

Spring Cloud Gateway 聚合场景下，后端 `swagger-config.urls[]` 已经返回了每个路由的 `contextPath`，但 React UI 解析分组时没有保留该字段。调试页默认 BaseURL 又优先使用下游 OpenAPI `servers`，所以用户在网关 `20000` 端口打开文档时，调试地址会落到下游服务 `20001`。

## 变更内容

- 在 `SwaggerGroup` / `SwaggerUiConfig.urls[]` 中保留 `contextPath`。
- `parseGroupsFromConfig` 从 `swagger-config.urls[]` 透传 `contextPath`。
- 调试页在当前分组存在 `contextPath` 时，把 `当前页面 origin + contextPath` 作为默认 BaseURL，并作为请求地址下拉的第一项。
- 保持 `setting.enableHost` 显式 Host 覆盖优先，不自动拼接或改写用户手动填写的 Host。
- 增加 `parseGroupsFromConfig` 与 `requestBaseUrl` 回归测试，覆盖 #468 的网关端口与下游端口场景。

## 验证

- `bun --eval` 无依赖冒烟：验证 `/iam` 场景解析为 `http://172.19.112.1:20000/iam`，显式 Host 覆盖保持原样。
- `./scripts/test-front-core.sh`：通过。
- PR CI：`docs-build`、`front-core-test`、`java-build-test` 均通过。

## 协作说明

- worker 子任务曾开始实现，但因工具额度错误中断；coordinator 接管并完成格式修复、验证和提交。
- 独立 reviewer 未能启动，按低风险 React UI 局部修复记录例外：本 PR 使用完整本地前端门禁、PR CI 全绿和 coordinator diff 复核作为替代验证，等待维护者 review。

## 风险

- 本次只修改 React UI 默认调试 BaseURL 解析，不改 Gateway 后端聚合接口。
- 已保留显式 Host 覆盖语义，避免改变用户手动设置的最终 BaseURL。