### PR TITLE
fix: 数据模型默认折叠展示

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -8,6 +8,7 @@ import { normalizeGenericTitle } from '../components/schema/schemaUtils';
 import { useGroup } from '../context/GroupContext';
 import { useSettings } from '../context/SettingsContext';
 import type { SchemaObject, SwaggerDoc } from '../types/swagger';
+import { resolveSchemaActiveKeys } from './schemaActiveKeys';
 
 const { Title, Text } = Typography;
 
@@ -80,17 +81,20 @@ export default function Schema() {
   }, [models, searchText]);
 
   const [activeKeys, setActiveKeys] = useState<string[]>([]);
+  const selectedModelVisible = useMemo(
+    () => Boolean(selectedSchemaName && filteredModels.some((model) => model.name === selectedSchemaName)),
+    [filteredModels, selectedSchemaName],
+  );
 
   useEffect(() => {
+    setActiveKeys(resolveSchemaActiveKeys(selectedSchemaName));
     if (selectedSchemaName) {
-      setActiveKeys([selectedSchemaName]);
+      if (!selectedModelVisible) return;
       window.setTimeout(() => {
         document.getElementById(modelDomId(selectedSchemaName))?.scrollIntoView({ block: 'start' });
       }, 0);
-      return;
     }
-    setActiveKeys(filteredModels.map((model) => model.name));
-  }, [filteredModels, selectedSchemaName]);
+  }, [activeGroup.value, selectedModelVisible, selectedSchemaName]);
 
   // Disabled state: show access-denied instead of schema content
   if (settings.enableSwaggerModels === false) {

--- a/knife4j-front/knife4j-ui-react/src/pages/schemaActiveKeys.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/schemaActiveKeys.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSchemaActiveKeys } from './schemaActiveKeys';
+
+describe('resolveSchemaActiveKeys', () => {
+  it('keeps the schema list collapsed by default', () => {
+    expect(resolveSchemaActiveKeys()).toEqual([]);
+  });
+
+  it('opens the model selected by the route', () => {
+    expect(resolveSchemaActiveKeys('UserDTO')).toEqual(['UserDTO']);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/schemaActiveKeys.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/schemaActiveKeys.ts
@@ -1,0 +1,3 @@
+export function resolveSchemaActiveKeys(selectedSchemaName?: string): string[] {
+  return selectedSchemaName ? [selectedSchemaName] : [];
+}


### PR DESCRIPTION
## 关联 Issue
- Closes #477

## 变更内容
- 调整 React OAS3 数据模型页的折叠面板状态：无 `schemaName` 路由参数时默认全部折叠，不再自动展开所有模型。
- 保留 `/schema/:schemaName` 深链接行为：从侧边栏或直接链接进入具体模型时，仍自动展开并滚动到该模型。
- 新增 `resolveSchemaActiveKeys` 单元测试，锁定默认折叠和路由选中展开两个行为。

## 验证
- `./scripts/test-front-core.sh` 通过。
- PR CI 通过：`docs-build`、`front-core-test`、`java-build-test`。

## Worker / Reviewer
- Worker 例外：本次改动为单一 React 页面默认展开策略的小范围修正，由 coordinator 直接完成；未触碰 Java、Vue3/OAS2、文档站或发布逻辑。
- Reviewer handoff：独立 reviewer 已审查 `agent/477-collapse-swagger-model` 相对 `origin/master` 的 diff，结论 `approve`，无发现、无验证缺口、无范围漂移。

## 风险与范围
- 行为变化限于 `knife4j-front/knife4j-ui-react` 的数据模型页默认展开状态。
- 未改动 OpenAPI 2 兼容维护线、Java starter、后端配置和文档站。