### PR TITLE
修复 OAS3 请求示例显式值展示

### DIFF
--- a/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
@@ -92,6 +92,52 @@ describe('buildOperationDebugModel — OAS3', () => {
     expect(parsed).toHaveProperty('age');
   });
 
+  test('uses OAS3 media type examples.value string before schema example', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/pictures': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      pictureUrl: { type: 'string' },
+                      title: { type: 'string' },
+                    },
+                  },
+                  examples: {
+                    emptyPictureUrl: {
+                      value: '{"pictureUrl":"","title":"cover"}',
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/pictures',
+      method: 'post',
+    });
+
+    expect(model.bodyContents).toHaveLength(1);
+    const exampleValue = model.bodyContents[0].exampleValue;
+    expect(exampleValue).toBeDefined();
+    const parsed = JSON.parse(exampleValue!);
+    expect(parsed.pictureUrl).toBe('');
+    expect(parsed.title).toBe('cover');
+    expect(exampleValue).not.toContain('"pictureUrl":"string"');
+  });
+
   test('parses OAS3 with $ref requestBody', () => {
     const docWithRef = {
       openapi: '3.0.1',

--- a/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
+++ b/knife4j-front/knife4j-core/src/__tests__/debug/operationDebugModel.test.ts
@@ -138,6 +138,45 @@ describe('buildOperationDebugModel — OAS3', () => {
     expect(exampleValue).not.toContain('"pictureUrl":"string"');
   });
 
+  test('serializes OAS3 JSON scalar string example as a valid JSON payload', () => {
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/names': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { type: 'string' },
+                  example: 'abc',
+                },
+                'text/plain': {
+                  schema: { type: 'string' },
+                  example: 'abc',
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    };
+
+    const model = buildOperationDebugModel({
+      doc: doc as any,
+      path: '/names',
+      method: 'post',
+    });
+
+    expect(model.bodyContents).toHaveLength(2);
+    const jsonBody = model.bodyContents.find((body) => body.mediaType === 'application/json');
+    const textBody = model.bodyContents.find((body) => body.mediaType === 'text/plain');
+    expect(jsonBody?.exampleValue).toBe('"abc"');
+    expect(JSON.parse(jsonBody!.exampleValue!)).toBe('abc');
+    expect(textBody?.exampleValue).toBe('abc');
+  });
+
   test('parses OAS3 with $ref requestBody', () => {
     const docWithRef = {
       openapi: '3.0.1',

--- a/knife4j-front/knife4j-core/src/debug/index.ts
+++ b/knife4j-front/knife4j-core/src/debug/index.ts
@@ -52,3 +52,6 @@ export type { BuildRequestOptions } from './requestBuilder';
 
 // schemaExample
 export { buildSchemaExample, buildSchemaFieldTree } from './schemaExample';
+
+// mediaTypeExample
+export { buildMediaTypeExampleValue } from './mediaTypeExample';

--- a/knife4j-front/knife4j-core/src/debug/mediaTypeExample.ts
+++ b/knife4j-front/knife4j-core/src/debug/mediaTypeExample.ts
@@ -7,13 +7,37 @@ interface MediaTypeExampleSource {
   examples?: Record<string, unknown>;
 }
 
+interface MediaTypeExampleOptions {
+  mediaType?: string;
+}
+
 function hasOwn(obj: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
 
-function formatExampleValue(value: unknown): string | undefined {
+function isJsonMediaType(mediaType: string | undefined): boolean {
+  if (!mediaType) return false;
+  const normalized = mediaType.split(';', 1)[0].trim().toLowerCase();
+  return normalized === 'application/json' || normalized.endsWith('+json');
+}
+
+function isJsonDocumentString(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatExampleValue(value: unknown, options: MediaTypeExampleOptions = {}): string | undefined {
   if (value === undefined) return undefined;
-  if (typeof value === 'string') return value;
+  if (typeof value === 'string') {
+    if (isJsonMediaType(options.mediaType) && !isJsonDocumentString(value)) {
+      return JSON.stringify(value);
+    }
+    return value;
+  }
   return JSON.stringify(value, null, 2);
 }
 
@@ -28,11 +52,15 @@ function resolveExampleObject(example: unknown, doc: Record<string, unknown>): R
   return exampleObj;
 }
 
-function firstExamplesValue(examples: Record<string, unknown>, doc: Record<string, unknown>): string | undefined {
+function firstExamplesValue(
+  examples: Record<string, unknown>,
+  doc: Record<string, unknown>,
+  options: MediaTypeExampleOptions,
+): string | undefined {
   for (const example of Object.values(examples)) {
     const exampleObj = resolveExampleObject(example, doc);
     if (exampleObj && hasOwn(exampleObj, 'value')) {
-      return formatExampleValue(exampleObj.value);
+      return formatExampleValue(exampleObj.value, options);
     }
   }
   return undefined;
@@ -42,16 +70,17 @@ export function buildMediaTypeExampleValue(
   mediaObj: MediaTypeExampleSource | undefined,
   schema: Record<string, unknown> | undefined,
   ctx: SchemaResolveContext,
+  options: MediaTypeExampleOptions = {},
 ): string | undefined {
   if (mediaObj) {
     const mediaRecord = mediaObj as Record<string, unknown>;
     if (hasOwn(mediaRecord, 'example')) {
-      const exampleValue = formatExampleValue(mediaObj.example);
+      const exampleValue = formatExampleValue(mediaObj.example, options);
       if (exampleValue !== undefined) return exampleValue;
     }
 
     if (mediaObj.examples) {
-      const exampleValue = firstExamplesValue(mediaObj.examples, ctx.doc);
+      const exampleValue = firstExamplesValue(mediaObj.examples, ctx.doc, options);
       if (exampleValue !== undefined) return exampleValue;
     }
   }

--- a/knife4j-front/knife4j-core/src/debug/mediaTypeExample.ts
+++ b/knife4j-front/knife4j-core/src/debug/mediaTypeExample.ts
@@ -1,0 +1,61 @@
+import type { SchemaResolveContext } from './types';
+import { resolveRef } from './resolveRef';
+import { buildSchemaExample } from './schemaExample';
+
+interface MediaTypeExampleSource {
+  example?: unknown;
+  examples?: Record<string, unknown>;
+}
+
+function hasOwn(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function formatExampleValue(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value, null, 2);
+}
+
+function resolveExampleObject(example: unknown, doc: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!example || typeof example !== 'object') return undefined;
+
+  const exampleObj = example as Record<string, unknown>;
+  if (typeof exampleObj.$ref === 'string') {
+    return resolveRef(exampleObj.$ref, doc) ?? exampleObj;
+  }
+
+  return exampleObj;
+}
+
+function firstExamplesValue(examples: Record<string, unknown>, doc: Record<string, unknown>): string | undefined {
+  for (const example of Object.values(examples)) {
+    const exampleObj = resolveExampleObject(example, doc);
+    if (exampleObj && hasOwn(exampleObj, 'value')) {
+      return formatExampleValue(exampleObj.value);
+    }
+  }
+  return undefined;
+}
+
+export function buildMediaTypeExampleValue(
+  mediaObj: MediaTypeExampleSource | undefined,
+  schema: Record<string, unknown> | undefined,
+  ctx: SchemaResolveContext,
+): string | undefined {
+  if (mediaObj) {
+    const mediaRecord = mediaObj as Record<string, unknown>;
+    if (hasOwn(mediaRecord, 'example')) {
+      const exampleValue = formatExampleValue(mediaObj.example);
+      if (exampleValue !== undefined) return exampleValue;
+    }
+
+    if (mediaObj.examples) {
+      const exampleValue = firstExamplesValue(mediaObj.examples, ctx.doc);
+      if (exampleValue !== undefined) return exampleValue;
+    }
+  }
+
+  if (!schema) return undefined;
+  return JSON.stringify(buildSchemaExample(schema, ctx), null, 2);
+}

--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -19,6 +19,7 @@ import type {
 } from './types';
 import { resolveRef, dereference } from './resolveRef';
 import { buildSchemaExample } from './schemaExample';
+import { buildMediaTypeExampleValue } from './mediaTypeExample';
 
 // ─── 内部类型 ─────────────────────────────────────────
 
@@ -481,11 +482,7 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
           mediaType: effectiveMediaType,
           category: effectiveCategory,
           schema,
-          exampleValue: schema
-            ? JSON.stringify(buildSchemaExample(schema, ctx), null, 2)
-            : mediaObj.example
-              ? JSON.stringify(mediaObj.example, null, 2)
-              : undefined,
+          exampleValue: buildMediaTypeExampleValue(mediaObj, schema, ctx),
           fileFields: isMultipart ? extractFileFields(schema) : undefined,
           // 区分「单文件」与「多文件」语义（issue #251）：
           // fileFields 记录所有文件字段（兼容老消费方），fileFieldsMultiple 仅记录

--- a/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
+++ b/knife4j-front/knife4j-core/src/debug/operationDebugModel.ts
@@ -482,7 +482,7 @@ export function buildOperationDebugModel(options: BuildDebugModelOptions): Opera
           mediaType: effectiveMediaType,
           category: effectiveCategory,
           schema,
-          exampleValue: buildMediaTypeExampleValue(mediaObj, schema, ctx),
+          exampleValue: buildMediaTypeExampleValue(mediaObj, schema, ctx, { mediaType }),
           fileFields: isMultipart ? extractFileFields(schema) : undefined,
           // 区分「单文件」与「多文件」语义（issue #251）：
           // fileFields 记录所有文件字段（兼容老消费方），fileFieldsMultiple 仅记录

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -1,13 +1,19 @@
 import { Alert, Badge, Button, Space, Spin, Table, Tabs, Tag, Typography, message } from 'antd';
 import { CopyOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
-import { buildSchemaFieldTree, resolveRefMeta, type SchemaFieldNode } from 'knife4j-core';
+import {
+  buildMediaTypeExampleValue,
+  buildSchemaExample,
+  buildSchemaFieldTree,
+  generateApiMarkdown,
+  resolveRefMeta,
+  type SchemaFieldNode,
+} from 'knife4j-core';
 import { useTranslation } from 'react-i18next';
-import type { ParameterObject, ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
+import type { ParameterObject, RequestBodyObject, ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
 import { OperationModeLayout, useCurrentOperation } from './useCurrentOperation';
 import Markdown from '../../components/Markdown';
 import { copyToClipboard } from '../../utils/clipboard';
-import { buildSchemaExample, generateApiMarkdown } from 'knife4j-core';
 import SchemaFieldTable, { SchemaTypeLink } from '../../components/schema/SchemaFieldTable';
 import { schemaNameFromRef } from '../../components/schema/schemaUtils';
 import CodeBlock from './CodeBlock';
@@ -33,6 +39,8 @@ interface ResponseRow {
   schema?: SchemaObject;
 }
 
+type RequestMediaObject = NonNullable<RequestBodyObject['content']>[string];
+
 function resolveRef(ref: string, doc: Pick<SwaggerDoc, 'components' | 'definitions'>): SchemaObject | undefined {
   const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
   if (!match) return undefined;
@@ -52,15 +60,19 @@ function parameterType(parameter: ParameterObject): string {
   return schemaName(parameter.schema) || [parameter.type, parameter.format].filter(Boolean).join(' / ') || '-';
 }
 
+function firstRequestMedia(requestBody: RequestBodyObject | undefined): RequestMediaObject | undefined {
+  if (!requestBody?.content) return undefined;
+  return requestBody.content['application/json'] ?? Object.values(requestBody.content)[0];
+}
+
 function firstRequestSchema(
-  requestBody: { content?: Record<string, { schema?: SchemaObject }> } | undefined,
+  requestBody: RequestBodyObject | undefined,
   parameters: ParameterObject[] | undefined,
 ): SchemaObject | undefined {
   const bodyParameter = parameters?.find((parameter) => parameter.in === 'body')?.schema;
-  if (!requestBody?.content) return bodyParameter;
-  return (
-    requestBody.content['application/json']?.schema ?? Object.values(requestBody.content)[0]?.schema ?? bodyParameter
-  );
+  const mediaObj = firstRequestMedia(requestBody);
+  if (!mediaObj) return bodyParameter;
+  return mediaObj.schema ?? bodyParameter;
 }
 
 function responseSchema(response: ResponseObject): SchemaObject | undefined {
@@ -162,6 +174,26 @@ function buildJsonExample(schema: SchemaObject | undefined, doc: SwaggerDoc): st
   } catch {
     return null;
   }
+}
+
+function buildRequestBodyExample(
+  requestBody: RequestBodyObject | undefined,
+  bodySchema: SchemaObject | undefined,
+  doc: SwaggerDoc,
+): string | null {
+  const mediaObj = firstRequestMedia(requestBody);
+  if (!mediaObj) return buildJsonExample(bodySchema, doc);
+
+  try {
+    const example = buildMediaTypeExampleValue(mediaObj, undefined, {
+      doc: doc as unknown as Record<string, unknown>,
+    });
+    if (example !== undefined) return example;
+  } catch {
+    return null;
+  }
+
+  return buildJsonExample(mediaObj.schema ?? bodySchema, doc);
 }
 
 /** Extract per-status-code response schemas for example generation. */
@@ -322,7 +354,7 @@ export default function ApiDoc() {
     );
   })();
 
-  const requestExample = buildJsonExample(bodySchema, swaggerDoc);
+  const requestExample = buildRequestBodyExample(op.requestBody, bodySchema, swaggerDoc);
   const respExamples = responseExamples(op.responses, swaggerDoc);
   const authors = operationAuthors(op);
 
@@ -422,7 +454,7 @@ export default function ApiDoc() {
       <Title level={5} style={{ marginTop: 24 }}>
         {t('apiDoc.requestBody')}
       </Title>
-      {bodySchema ? (
+      {bodySchema || requestExample !== null ? (
         <Tabs
           size="small"
           items={[
@@ -431,7 +463,7 @@ export default function ApiDoc() {
               label: t('apiDoc.tab.schema'),
               children: <SchemaFieldTable fields={bodyFields} emptyText={t('apiDoc.body.notExpandable')} />,
             },
-            ...(requestExample
+            ...(requestExample !== null
               ? [
                   {
                     key: 'example',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -40,6 +40,10 @@ interface ResponseRow {
 }
 
 type RequestMediaObject = NonNullable<RequestBodyObject['content']>[string];
+interface RequestMediaEntry {
+  mediaType: string;
+  mediaObj: RequestMediaObject;
+}
 
 function resolveRef(ref: string, doc: Pick<SwaggerDoc, 'components' | 'definitions'>): SchemaObject | undefined {
   const match = ref.match(/^#\/components\/schemas\/(.+)$/) ?? ref.match(/^#\/definitions\/(.+)$/);
@@ -60,9 +64,15 @@ function parameterType(parameter: ParameterObject): string {
   return schemaName(parameter.schema) || [parameter.type, parameter.format].filter(Boolean).join(' / ') || '-';
 }
 
-function firstRequestMedia(requestBody: RequestBodyObject | undefined): RequestMediaObject | undefined {
+function firstRequestMedia(requestBody: RequestBodyObject | undefined): RequestMediaEntry | undefined {
   if (!requestBody?.content) return undefined;
-  return requestBody.content['application/json'] ?? Object.values(requestBody.content)[0];
+  const jsonMedia = requestBody.content['application/json'];
+  if (jsonMedia) return { mediaType: 'application/json', mediaObj: jsonMedia };
+
+  const firstEntry = Object.entries(requestBody.content)[0];
+  if (!firstEntry) return undefined;
+  const [mediaType, mediaObj] = firstEntry;
+  return { mediaType, mediaObj };
 }
 
 function firstRequestSchema(
@@ -70,9 +80,9 @@ function firstRequestSchema(
   parameters: ParameterObject[] | undefined,
 ): SchemaObject | undefined {
   const bodyParameter = parameters?.find((parameter) => parameter.in === 'body')?.schema;
-  const mediaObj = firstRequestMedia(requestBody);
-  if (!mediaObj) return bodyParameter;
-  return mediaObj.schema ?? bodyParameter;
+  const mediaEntry = firstRequestMedia(requestBody);
+  if (!mediaEntry) return bodyParameter;
+  return mediaEntry.mediaObj.schema ?? bodyParameter;
 }
 
 function responseSchema(response: ResponseObject): SchemaObject | undefined {
@@ -181,19 +191,24 @@ function buildRequestBodyExample(
   bodySchema: SchemaObject | undefined,
   doc: SwaggerDoc,
 ): string | null {
-  const mediaObj = firstRequestMedia(requestBody);
-  if (!mediaObj) return buildJsonExample(bodySchema, doc);
+  const mediaEntry = firstRequestMedia(requestBody);
+  if (!mediaEntry) return buildJsonExample(bodySchema, doc);
 
   try {
-    const example = buildMediaTypeExampleValue(mediaObj, undefined, {
-      doc: doc as unknown as Record<string, unknown>,
-    });
+    const example = buildMediaTypeExampleValue(
+      mediaEntry.mediaObj,
+      undefined,
+      {
+        doc: doc as unknown as Record<string, unknown>,
+      },
+      { mediaType: mediaEntry.mediaType },
+    );
     if (example !== undefined) return example;
   } catch {
     return null;
   }
 
-  return buildJsonExample(mediaObj.schema ?? bodySchema, doc);
+  return buildJsonExample(mediaEntry.mediaObj.schema ?? bodySchema, doc);
 }
 
 /** Extract per-status-code response schemas for example generation. */

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -97,6 +97,14 @@ export interface SchemaObject {
   enum?: unknown[];
 }
 
+export interface ExampleObject {
+  summary?: string;
+  description?: string;
+  value?: unknown;
+  externalValue?: string;
+  $ref?: string;
+}
+
 export interface ParameterObject {
   name: string;
   in: 'query' | 'header' | 'path' | 'cookie' | 'body' | 'formData';
@@ -110,7 +118,14 @@ export interface ParameterObject {
 export interface RequestBodyObject {
   description?: string;
   required?: boolean;
-  content?: Record<string, { schema?: SchemaObject }>;
+  content?: Record<
+    string,
+    {
+      schema?: SchemaObject;
+      example?: unknown;
+      examples?: Record<string, ExampleObject>;
+    }
+  >;
 }
 
 export interface ResponseObject {
@@ -206,6 +221,7 @@ export interface SwaggerDoc {
   schemes?: string[];
   components?: {
     schemas?: Record<string, SchemaObject>;
+    examples?: Record<string, ExampleObject>;
     securitySchemes?: Record<string, SecuritySchemeObject>;
   };
   definitions?: Record<string, SchemaObject>; // OAS2


### PR DESCRIPTION
## 关联 Issue

- Closes #479

## 问题原因

OAS3 `requestBody.content` 同时包含 `schema` 和显式 `example` / `examples` 时，React 侧请求示例仍优先使用 schema 生成占位数据，导致用户提供的空字符串示例被替换为 `"string"`。

## 变更内容

- 新增 `buildMediaTypeExampleValue`，优先读取 media type 的 `example` / `examples[*].value`，支持 `#/components/examples` 引用。
- `operationDebugModel` 的 OAS3 `bodyContents.exampleValue` 改为先使用显式示例，缺失时才回退 schema 生成。
- `ApiDoc` 请求示例页同步使用显式 media example，避免文档页继续展示 schema 占位值。
- 补充回归测试，覆盖 `examples.value` 为 JSON 字符串且字段值为空字符串的场景。

## Worker / Reviewer

- Worker：完成 core helper、调试模型、文档页接入和回归测试。
- Reviewer：第一次指出新增 helper 未纳入 tracked diff；已修正后复核 staged diff，结论为 `approve`。

## 验证

- `./scripts/test-front-core.sh`：通过。
- `cd knife4j-front/knife4j-core && bun run test -- src/__tests__/debug/operationDebugModel.test.ts --runTestsByPath`：通过。
- `git diff --cached --check`：通过。

## 风险

- 未新增 `ApiDoc` 组件级渲染测试；当前由 core 回归测试、React 类型检查和生产构建间接覆盖。