### PR TITLE
fix: 让调试数据默认使用示例值

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -68,6 +68,20 @@ import {
   type DebugCacheState,
 } from './debugCache';
 import { readDebugSessionState, removeDebugSessionState, writeDebugSessionState } from './debugSessionState';
+import {
+  EMPTY_BODY_CONTENT_DEFAULTS,
+  buildBodyContentDefaults,
+  buildInitialParamValues,
+  extractSchemaFields,
+  initialBodyValueForContent,
+  initialFormFieldsForContent,
+  mergeCachedFormFields,
+  paramKey,
+  stringifyDebugValue,
+  type BodyContentDefaults,
+  type ParamValueMap,
+  type SchemaFieldRow,
+} from './debugDefaultValues';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
@@ -81,14 +95,6 @@ const METHOD_COLORS: Record<string, string> = {
   HEAD: 'cyan',
   OPTIONS: 'default',
 };
-
-// ─── Helper: form value shape ─────────────────────────
-// Key by `${in}:${name}` to avoid cross-location name collisions
-type ParamValueMap = Record<string, string>;
-
-function paramKey(param: DebugParam): string {
-  return `${param.in}:${param.name}`;
-}
 
 // ─── Response body classification ─────────────────────
 
@@ -193,154 +199,6 @@ function extractFilenameFromUrl(url: string): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-// ─── Initial value derivation ─────────────────────────
-
-/**
- * 按优先级取参数的初始值：example > default > 类型空值
- * 返回始终是字符串（<Input> / JSON 字符串 / enum 选中值）。
- */
-function initialValueFor(param: DebugParam): string {
-  if (param.example !== undefined && param.example !== null) {
-    return stringify(param.example, param.type);
-  }
-  if (param.default !== undefined && param.default !== null) {
-    return stringify(param.default, param.type);
-  }
-  // 按类型生成空值
-  switch (param.type) {
-    case 'array':
-    case 'object':
-      return ''; // TextArea 占位；空字符串让 requestBuilder 走默认分支
-    case 'boolean':
-      return '';
-    case 'integer':
-    case 'number':
-      return '';
-    default:
-      return '';
-  }
-}
-
-function stringify(value: unknown, type: string): string {
-  if (value === undefined || value === null) return '';
-  if (type === 'array' || type === 'object') {
-    try {
-      return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
-    } catch {
-      return String(value);
-    }
-  }
-  if (typeof value === 'object') {
-    try {
-      return JSON.stringify(value);
-    } catch {
-      return String(value);
-    }
-  }
-  return String(value);
-}
-
-// ─── Schema property → field row for urlencoded / multipart ──────
-
-interface SchemaFieldRow {
-  name: string;
-  type: string;
-  format?: string;
-  required: boolean;
-  description?: string;
-  default?: unknown;
-  example?: unknown;
-  enum?: unknown[];
-  isFile: boolean;
-  /**
-   * File field backed by an array schema (`type:"array"` + `items.format:"binary"|"base64"`)
-   * — the UI renders `<Upload multiple />` and the send handler appends every file
-   * as a separate part. When `false`, the field is a single-file upload and **must**
-   * only send one part even if the user somehow staged more (issue #251).
-   */
-  isMultipleFile: boolean;
-  /** encoding.contentType=application/json — render as JSON TextArea */
-  isJson: boolean;
-}
-
-/**
- * 从 BodyContent 的 schema.properties 提取字段行，过滤 readOnly 字段（请求不应包含只读字段）
- */
-function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
-  const schema = bodyContent.schema;
-  if (!schema || schema.type !== 'object' || !schema.properties) return [];
-
-  const props = schema.properties as Record<string, Record<string, unknown>>;
-  const requiredSet = new Set<string>(Array.isArray(schema.required) ? (schema.required as string[]) : []);
-  const fileFields = new Set(bodyContent.fileFields ?? []);
-  // issue #251: multi-file field names are a subset of fileFields, derived from
-  // `type:"array"` + `items.format:"binary"|"base64"`. This set is what lets us
-  // distinguish MultipartFile / FilePart (single) from MultipartFile[] / Flux<FilePart>.
-  const multipleFileFields = new Set(bodyContent.fileFieldsMultiple ?? []);
-  const jsonFields = new Set(bodyContent.jsonFields ?? []);
-
-  return Object.entries(props)
-    .filter(([, prop]) => !prop.readOnly)
-    .map(([name, prop]) => {
-      const t = (prop.type as string) ?? 'string';
-      const isFile =
-        fileFields.has(name) ||
-        t === 'file' ||
-        (t === 'string' && prop.format === 'binary') ||
-        (t === 'string' && prop.format === 'base64');
-
-      // A field is considered multi-file if either (a) knife4j-core marked it in
-      // fileFieldsMultiple, or (b) it has the explicit array-of-binary/base64 shape.
-      // (b) is a defence-in-depth: older documents produced before fileFieldsMultiple
-      // existed still render correctly.
-      //
-      // Important: springdoc 2.x (OAS 3.1) drops `type:"string"` from items, emitting
-      // `{ items: { format: "binary", description: ... } }` for @ArraySchema(schema=
-      // @Schema(type="string", format="binary")). So the fallback must NOT require
-      // items.type === 'string'; only the format matters. Matches knife4j-core's
-      // isBinaryItems() (issue #251 live repro against knife4j-demo).
-      let isMultipleFile = false;
-      if (isFile) {
-        if (multipleFileFields.has(name)) {
-          isMultipleFile = true;
-        } else if (t === 'array' && prop.items && typeof prop.items === 'object') {
-          const items = prop.items as Record<string, unknown>;
-          const hasBinaryFormat = items.format === 'binary' || items.format === 'base64';
-          const typeOk = items.type === undefined || items.type === 'string';
-          if (hasBinaryFormat && typeOk) {
-            isMultipleFile = true;
-          }
-        }
-      }
-
-      return {
-        name,
-        type: isFile ? 'file' : t,
-        format: typeof prop.format === 'string' ? prop.format : undefined,
-        required: requiredSet.has(name),
-        description: typeof prop.description === 'string' ? prop.description : undefined,
-        default: prop.default,
-        example: prop.example,
-        enum: Array.isArray(prop.enum) ? prop.enum : undefined,
-        isFile,
-        isMultipleFile,
-        isJson: !isFile && jsonFields.has(name),
-      };
-    });
-}
-
-/** 根据 SchemaFieldRow 的类型推断初始值 */
-function initialFieldValue(field: SchemaFieldRow): string {
-  if (field.isFile) return '';
-  if (field.isJson) return field.example !== undefined ? JSON.stringify(field.example, null, 2) : '{}';
-  if (field.example !== undefined && field.example !== null) return String(field.example);
-  if (field.default !== undefined && field.default !== null) return String(field.default);
-  if (field.enum && field.enum.length > 0) return String(field.enum[0]);
-  if (field.type === 'boolean') return 'true';
-  if (field.type === 'integer' || field.type === 'number') return '0';
-  return '';
 }
 
 // ─── Raw mode types ───────────────────────────────────
@@ -915,6 +773,7 @@ function ParamNameCell({ param }: { param: DebugParam }) {
 
 interface BodyTabProps {
   debugModel: OperationDebugModel;
+  bodyDefaults: BodyContentDefaults;
   body: string;
   setBody: (v: string) => void;
   selectedContentType: string;
@@ -928,6 +787,7 @@ interface BodyTabProps {
 
 function BodyTab({
   debugModel,
+  bodyDefaults,
   body,
   setBody,
   selectedContentType,
@@ -954,21 +814,15 @@ function BodyTab({
     setSelectedContentType(mediaType);
     const target = bodyContents.find((b) => b.mediaType === mediaType);
     if (target) {
-      // 初始化 formFields
-      const fields = extractSchemaFields(target);
-      const initial: Record<string, string> = {};
-      for (const f of fields) {
-        initial[f.name] = initialFieldValue(f);
-      }
-      setFormFields(initial);
+      setFormFields(initialFormFieldsForContent(target, bodyDefaults));
       // 重置 fileFields
       fileFieldsRef.current = {};
 
       // 更新 body 文本
       if (target.category === 'json') {
-        setBody(target.exampleValue ?? '');
+        setBody(initialBodyValueForContent(target, bodyDefaults));
       } else if (target.category === 'raw') {
-        setBody(target.exampleValue ?? '');
+        setBody(initialBodyValueForContent(target, bodyDefaults));
       }
       setRawMode(inferRawMode(target));
     }
@@ -1119,7 +973,7 @@ function UrlencodedForm({ bodyContent, formFields, setFormFields }: UrlencodedFo
             <Text type="secondary" style={{ fontSize: 11 }}>
               {t('apiDebug.desc.default')}
               <Text code style={{ fontSize: 11 }}>
-                {String(record.default)}
+                {stringifyDebugValue(record.default, record.type)}
               </Text>
             </Text>
           )}
@@ -1127,7 +981,7 @@ function UrlencodedForm({ bodyContent, formFields, setFormFields }: UrlencodedFo
             <Text type="secondary" style={{ fontSize: 11 }}>
               {t('apiDebug.desc.example')}
               <Text code style={{ fontSize: 11 }}>
-                {String(record.example)}
+                {stringifyDebugValue(record.example, record.type)}
               </Text>
             </Text>
           )}
@@ -1547,19 +1401,12 @@ function inferRawMode(bodyContent: BodyContent | undefined): RawMode {
   return 'text';
 }
 
-function initialFormFieldsFor(bodyContent: BodyContent | undefined): Record<string, string> {
-  if (!bodyContent || (bodyContent.category !== 'urlencoded' && bodyContent.category !== 'multipart')) return {};
-  const initial: Record<string, string> = {};
-  for (const field of extractSchemaFields(bodyContent)) {
-    initial[field.name] = initialFieldValue(field);
-  }
-  return initial;
-}
-
 function buildInitialDebugState(
   debugModel: OperationDebugModel,
   operation: NonNullable<ReturnType<typeof useCurrentOperation>['operation']>,
+  swaggerDoc: NonNullable<ReturnType<typeof useCurrentOperation>['swaggerDoc']>,
   baseUrl: string,
+  bodyDefaults: BodyContentDefaults,
 ): InitialDebugState {
   const allParams = [
     ...debugModel.pathParams,
@@ -1567,10 +1414,9 @@ function buildInitialDebugState(
     ...debugModel.headerParams,
     ...debugModel.cookieParams,
   ];
-  const paramValues: ParamValueMap = {};
+  const paramValues = buildInitialParamValues(debugModel, swaggerDoc, operation);
   const paramEnabled: Record<string, boolean> = {};
   for (const param of allParams) {
-    paramValues[paramKey(param)] = initialValueFor(param);
     paramEnabled[paramKey(param)] = true;
   }
 
@@ -1582,8 +1428,8 @@ function buildInitialDebugState(
     paramValues,
     paramEnabled,
     selectedContentType: firstBody?.mediaType ?? '',
-    body: firstBody?.exampleValue ?? '',
-    formFields: initialFormFieldsFor(firstBody),
+    body: initialBodyValueForContent(firstBody, bodyDefaults),
+    formFields: initialFormFieldsForContent(firstBody, bodyDefaults),
     rawMode: inferRawMode(firstBody),
     customQueryParams: [],
     customHeaders: [],
@@ -1625,21 +1471,11 @@ function mergeCachedBooleanRecord(
   return next;
 }
 
-function mergeCachedFormFields(bodyContent: BodyContent | undefined, cached: Record<string, string>) {
-  const next = initialFormFieldsFor(bodyContent);
-  const allowedFields = new Set(Object.keys(next));
-  for (const [key, value] of Object.entries(cached)) {
-    if (allowedFields.has(key)) {
-      next[key] = value;
-    }
-  }
-  return next;
-}
-
 function restoreInitialDebugStateFromCache(
   initial: InitialDebugState,
   cached: DebugCacheState | null,
   debugModel: OperationDebugModel,
+  bodyDefaults: BodyContentDefaults,
 ): InitialDebugState {
   if (!cached) return initial;
 
@@ -1658,10 +1494,10 @@ function restoreInitialDebugStateFromCache(
     paramValues: mergeCachedStringRecord(initial.paramValues, cached.paramValues),
     paramEnabled: mergeCachedBooleanRecord(initial.paramEnabled, cached.paramEnabled),
     selectedContentType: selectedBody?.mediaType ?? '',
-    body: restoreCachedBody ? cached.body : (selectedBody?.exampleValue ?? initial.body),
+    body: restoreCachedBody ? cached.body : initialBodyValueForContent(selectedBody, bodyDefaults),
     formFields: restoreCachedBody
-      ? mergeCachedFormFields(selectedBody, cached.formFields)
-      : initialFormFieldsFor(selectedBody),
+      ? mergeCachedFormFields(selectedBody, cached.formFields, bodyDefaults)
+      : initialFormFieldsForContent(selectedBody, bodyDefaults),
     rawMode: restoreCachedBody ? cached.rawMode : inferRawMode(selectedBody),
     customQueryParams: cached.customQueryParams,
     customHeaders: cached.customHeaders,
@@ -1728,6 +1564,13 @@ export default function ApiDebug() {
       isOAS2: Boolean((swaggerDoc as unknown as Record<string, unknown>).swagger),
     });
   }, [operation, swaggerDoc]);
+  const bodyDefaults = useMemo(
+    () =>
+      swaggerDoc && operation && debugModel
+        ? buildBodyContentDefaults(swaggerDoc, operation, debugModel)
+        : EMPTY_BODY_CONTENT_DEFAULTS,
+    [debugModel, operation, swaggerDoc],
+  );
   const [loading, setLoading] = useState(false);
   const [authModalOpen, setAuthModalOpen] = useState(false);
   const [response, setResponse] = useState<DebugResponsePayload | null>(null);
@@ -1755,9 +1598,9 @@ export default function ApiDebug() {
   const errorKeys = useMemo(() => new Set(validationErrors.map((e) => e.key)), [validationErrors]);
 
   const initialDebugState = useMemo(() => {
-    if (!debugModel || !operation) return null;
-    return buildInitialDebugState(debugModel, operation, defaultBaseUrl);
-  }, [debugModel, operation, defaultBaseUrl]);
+    if (!debugModel || !operation || !swaggerDoc) return null;
+    return buildInitialDebugState(debugModel, operation, swaggerDoc, defaultBaseUrl, bodyDefaults);
+  }, [bodyDefaults, debugModel, operation, swaggerDoc, defaultBaseUrl]);
 
   useLayoutEffect(() => {
     activeDebugCacheKeyRef.current = debugCacheKey;
@@ -1791,7 +1634,7 @@ export default function ApiDebug() {
   useEffect(() => {
     if (!initialDebugState || !debugModel) return;
     const cached = settings.enableRequestCache && debugCacheKey !== null ? readDebugCache(debugCacheKey) : null;
-    const nextInitial = restoreInitialDebugStateFromCache(initialDebugState, cached, debugModel);
+    const nextInitial = restoreInitialDebugStateFromCache(initialDebugState, cached, debugModel, bodyDefaults);
     skipNextDebugCacheWriteRef.current = true;
     requestSeqRef.current += 1;
     sseAbortRef.current?.abort();
@@ -1804,7 +1647,7 @@ export default function ApiDebug() {
     setBuiltRequest(cachedSession?.builtRequest ?? null);
     setSseEvents(cachedSession?.sseEvents ?? null);
     setHydratedDebugCacheKey(debugCacheKey);
-  }, [debugCacheKey, debugModel, initialDebugState, settings.enableRequestCache]);
+  }, [bodyDefaults, debugCacheKey, debugModel, initialDebugState, settings.enableRequestCache]);
 
   useEffect(() => {
     if (debugCacheKey === null || hydratedDebugCacheKey !== debugCacheKey) return;
@@ -2018,7 +1861,7 @@ export default function ApiDebug() {
               <Text type="secondary" style={{ fontSize: 11 }}>
                 {t('apiDebug.desc.default')}
                 <Text code style={{ fontSize: 11 }}>
-                  {stringify(record.default, record.type)}
+                  {stringifyDebugValue(record.default, record.type)}
                 </Text>
               </Text>
             )}
@@ -2026,7 +1869,7 @@ export default function ApiDebug() {
               <Text type="secondary" style={{ fontSize: 11 }}>
                 {t('apiDebug.desc.example')}
                 <Text code style={{ fontSize: 11 }}>
-                  {stringify(record.example, record.type)}
+                  {stringifyDebugValue(record.example, record.type)}
                 </Text>
               </Text>
             )}
@@ -2541,6 +2384,7 @@ export default function ApiDebug() {
         <BodyTab
           key={resetNonce}
           debugModel={debugModel}
+          bodyDefaults={bodyDefaults}
           body={body}
           setBody={setBody}
           selectedContentType={selectedContentType}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import type { BodyContent, OperationDebugModel } from 'knife4j-core';
+import type { MenuOperation, SwaggerDoc } from '../../types/swagger';
+import {
+  buildBodyContentDefaults,
+  buildInitialParamValues,
+  initialBodyValueForContent,
+  initialFormFieldsForContent,
+  mergeCachedFormFields,
+} from './debugDefaultValues';
+
+function operationFrom(doc: SwaggerDoc, path: string, method: string): MenuOperation {
+  const operation = (doc.paths[path] as Record<string, unknown>)[method] as MenuOperation['operation'];
+  return {
+    key: `Test/${method}`,
+    path,
+    method,
+    summary: operation.summary ?? path,
+    operationId: operation.operationId,
+    operation,
+  };
+}
+
+function baseDebugModel(partial: Partial<OperationDebugModel>): OperationDebugModel {
+  return {
+    pathParams: [],
+    queryParams: [],
+    headerParams: [],
+    cookieParams: [],
+    bodyContents: [],
+    bodyRequired: false,
+    ...partial,
+  };
+}
+
+describe('debugDefaultValues', () => {
+  it('initializes params from OpenAPI examples and nested schema examples', () => {
+    const doc: SwaggerDoc = {
+      openapi: '3.0.3',
+      info: { title: 'demo', version: '1.0.0' },
+      paths: {
+        '/pets/{id}': {
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+              examples: { demo: { value: 'pet-42' } },
+            } as never,
+          ],
+          get: {
+            parameters: [
+              {
+                name: 'trace',
+                in: 'query',
+                schema: { type: 'string' },
+                examples: { demo: { value: 'trace-1' } },
+              } as never,
+            ],
+            responses: {},
+          },
+        },
+      },
+    };
+    const debugModel = baseDebugModel({
+      pathParams: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          type: 'string',
+          schema: { type: 'string' },
+        },
+      ],
+      queryParams: [
+        {
+          name: 'trace',
+          in: 'query',
+          required: false,
+          type: 'string',
+          schema: { type: 'string' },
+        },
+        {
+          name: 'filter',
+          in: 'query',
+          required: false,
+          type: 'object',
+          schema: {
+            type: 'object',
+            properties: {
+              status: { type: 'string', example: 'available' },
+              page: { type: 'integer', default: 1 },
+            },
+          },
+        },
+      ],
+    });
+
+    const values = buildInitialParamValues(debugModel, doc, operationFrom(doc, '/pets/{id}', 'get'));
+
+    expect(values['path:id']).toBe('pet-42');
+    expect(values['query:trace']).toBe('trace-1');
+    expect(JSON.parse(values['query:filter'])).toEqual({ status: 'available', page: 1 });
+  });
+
+  it('uses requestBody media examples before schema-generated body examples', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', default: 'schema-name' },
+      },
+    };
+    const bodyContent: BodyContent = {
+      mediaType: 'application/json',
+      category: 'json',
+      schema,
+      exampleValue: JSON.stringify({ name: 'schema-name' }, null, 2),
+    };
+    const doc: SwaggerDoc = {
+      openapi: '3.0.3',
+      info: { title: 'demo', version: '1.0.0' },
+      paths: {
+        '/pets': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema,
+                  examples: {
+                    demo: {
+                      value: { name: 'media-example', age: 3 },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {},
+          },
+        },
+      },
+    };
+    const debugModel = baseDebugModel({ bodyContents: [bodyContent], bodyRequired: true });
+
+    const defaults = buildBodyContentDefaults(doc, operationFrom(doc, '/pets', 'post'), debugModel);
+
+    expect(JSON.parse(initialBodyValueForContent(bodyContent, defaults))).toEqual({
+      name: 'media-example',
+      age: 3,
+    });
+  });
+
+  it('generates form field defaults from nested schema examples and lets cached edits win', () => {
+    const schema = {
+      type: 'object',
+      required: ['meta'],
+      properties: {
+        meta: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', example: 'demo' },
+            count: { type: 'integer', default: 2 },
+          },
+        },
+        ids: {
+          type: 'array',
+          items: { type: 'integer', default: 7 },
+        },
+        enabled: { type: 'boolean', default: false },
+      },
+    };
+    const bodyContent: BodyContent = {
+      mediaType: 'multipart/form-data',
+      category: 'multipart',
+      schema,
+      jsonFields: ['meta'],
+    };
+    const doc: SwaggerDoc = {
+      openapi: '3.0.3',
+      info: { title: 'demo', version: '1.0.0' },
+      paths: {
+        '/upload': {
+          post: {
+            requestBody: {
+              content: {
+                'multipart/form-data': { schema },
+              },
+            },
+            responses: {},
+          },
+        },
+      },
+    };
+    const debugModel = baseDebugModel({ bodyContents: [bodyContent], bodyRequired: true });
+
+    const defaults = buildBodyContentDefaults(doc, operationFrom(doc, '/upload', 'post'), debugModel);
+    const fields = initialFormFieldsForContent(bodyContent, defaults);
+    const merged = mergeCachedFormFields(bodyContent, { meta: '{"manual":true}', ids: '[9]' }, defaults);
+
+    expect(JSON.parse(fields.meta)).toEqual({ name: 'demo', count: 2 });
+    expect(JSON.parse(fields.ids)).toEqual([7]);
+    expect(fields.enabled).toBe('false');
+    expect(merged.meta).toBe('{"manual":true}');
+    expect(merged.ids).toBe('[9]');
+    expect(merged.enabled).toBe('false');
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.test.ts
@@ -150,6 +150,66 @@ describe('debugDefaultValues', () => {
     });
   });
 
+  it('merges requestBody media examples into form field defaults', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        username: { type: 'string', default: 'schema-user' },
+        count: { type: 'integer', default: 1 },
+        prefs: {
+          type: 'object',
+          properties: {
+            theme: { type: 'string', default: 'light' },
+          },
+        },
+        retained: { type: 'string', default: 'schema-retained' },
+      },
+    };
+    const bodyContent: BodyContent = {
+      mediaType: 'application/x-www-form-urlencoded',
+      category: 'urlencoded',
+      schema,
+    };
+    const doc: SwaggerDoc = {
+      openapi: '3.0.3',
+      info: { title: 'demo', version: '1.0.0' },
+      paths: {
+        '/login': {
+          post: {
+            requestBody: {
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema,
+                  examples: {
+                    demo: {
+                      value: {
+                        username: 'alice',
+                        count: 5,
+                        prefs: { theme: 'dark' },
+                        ignored: 'not-a-schema-field',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {},
+          },
+        },
+      },
+    };
+    const debugModel = baseDebugModel({ bodyContents: [bodyContent], bodyRequired: true });
+
+    const defaults = buildBodyContentDefaults(doc, operationFrom(doc, '/login', 'post'), debugModel);
+    const fields = initialFormFieldsForContent(bodyContent, defaults);
+
+    expect(fields.username).toBe('alice');
+    expect(fields.count).toBe('5');
+    expect(JSON.parse(fields.prefs)).toEqual({ theme: 'dark' });
+    expect(fields.retained).toBe('schema-retained');
+    expect(fields.ignored).toBeUndefined();
+  });
+
   it('generates form field defaults from nested schema examples and lets cached edits win', () => {
     const schema = {
       type: 'object',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.ts
@@ -1,0 +1,372 @@
+import { buildSchemaExample, type BodyContent, type DebugParam, type OperationDebugModel } from 'knife4j-core';
+import type { MenuOperation, SwaggerDoc } from '../../types/swagger';
+
+export type ParamValueMap = Record<string, string>;
+
+type JsonRecord = Record<string, unknown>;
+
+export interface SchemaFieldRow {
+  name: string;
+  type: string;
+  format?: string;
+  required: boolean;
+  description?: string;
+  default?: unknown;
+  example?: unknown;
+  enum?: unknown[];
+  isFile: boolean;
+  isMultipleFile: boolean;
+  isJson: boolean;
+  schema?: JsonRecord;
+}
+
+export interface BodyContentDefaults {
+  bodyByMediaType: Record<string, string>;
+  formFieldsByMediaType: Record<string, Record<string, string>>;
+}
+
+export const EMPTY_BODY_CONTENT_DEFAULTS: BodyContentDefaults = {
+  bodyByMediaType: {},
+  formFieldsByMediaType: {},
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function decodePointerPart(part: string): string {
+  const unescaped = part.replace(/~1/g, '/').replace(/~0/g, '~');
+  try {
+    return decodeURIComponent(unescaped);
+  } catch {
+    return unescaped;
+  }
+}
+
+function resolveLocalRef(ref: string | undefined, doc: SwaggerDoc | JsonRecord): unknown {
+  if (!ref?.startsWith('#/')) return undefined;
+  let current: unknown = doc;
+  for (const part of ref.slice(2).split('/').map(decodePointerPart)) {
+    if (!isRecord(current)) return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+function resolveRecord(value: unknown, doc: SwaggerDoc | JsonRecord): JsonRecord | undefined {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.$ref === 'string') {
+    const resolved = resolveLocalRef(value.$ref, doc);
+    return isRecord(resolved) ? resolved : value;
+  }
+  return value;
+}
+
+function firstExamplesValue(examples: unknown, doc: SwaggerDoc | JsonRecord): unknown {
+  if (!isRecord(examples)) return undefined;
+  for (const example of Object.values(examples)) {
+    const resolved = resolveRecord(example, doc);
+    if (!resolved) {
+      if (example !== undefined) return example;
+      continue;
+    }
+    if (resolved.value !== undefined) return resolved.value;
+  }
+  return undefined;
+}
+
+function explicitExampleValue(source: unknown, doc: SwaggerDoc | JsonRecord): unknown {
+  const record = resolveRecord(source, doc);
+  if (!record) return undefined;
+  if (record.example !== undefined) return record.example;
+  return firstExamplesValue(record.examples, doc);
+}
+
+function schemaExampleValue(schema: unknown, doc: SwaggerDoc | JsonRecord): unknown {
+  const resolvedSchema = resolveRecord(schema, doc);
+  if (!resolvedSchema) return undefined;
+  const explicit = explicitExampleValue(resolvedSchema, doc);
+  if (explicit !== undefined) return explicit;
+  try {
+    return buildSchemaExample(resolvedSchema, {
+      doc: doc as unknown as Record<string, unknown>,
+      maxDepth: 8,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyDebugValue(value: unknown, type?: string): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  if ((type === 'array' || type === 'object') && typeof value === 'string') {
+    return value;
+  }
+  return String(value);
+}
+
+function stringifyBodyValue(value: unknown, bodyContent: BodyContent): string {
+  if (value === undefined || value === null) return '';
+  if (bodyContent.category === 'json') {
+    if (typeof value === 'string') {
+      const schemaType = isRecord(bodyContent.schema) ? bodyContent.schema.type : undefined;
+      return schemaType === 'string' ? JSON.stringify(value, null, 2) : value;
+    }
+    return JSON.stringify(value, null, 2);
+  }
+  if (typeof value === 'object') return stringifyDebugValue(value);
+  return String(value);
+}
+
+export function paramKey(param: DebugParam): string {
+  return `${param.in}:${param.name}`;
+}
+
+function operationObjectFromDoc(doc: SwaggerDoc, operation: MenuOperation): JsonRecord | undefined {
+  const pathItem = doc.paths?.[operation.path] as JsonRecord | undefined;
+  const fromDoc = pathItem?.[operation.method.toLowerCase()];
+  return resolveRecord(fromDoc, doc) ?? (operation.operation as unknown as JsonRecord);
+}
+
+function rawParametersForOperation(doc: SwaggerDoc, operation: MenuOperation): Map<string, JsonRecord> {
+  const map = new Map<string, JsonRecord>();
+  const pathItem = doc.paths?.[operation.path] as JsonRecord | undefined;
+  const operationObject = operationObjectFromDoc(doc, operation);
+  const rawParams = [
+    ...(Array.isArray(pathItem?.parameters) ? pathItem.parameters : []),
+    ...(Array.isArray(operationObject?.parameters) ? operationObject.parameters : []),
+  ];
+
+  for (const rawParam of rawParams) {
+    const param = resolveRecord(rawParam, doc);
+    if (!param || typeof param.name !== 'string' || typeof param.in !== 'string') continue;
+    map.set(`${param.in}:${param.name}`, param);
+  }
+  return map;
+}
+
+function firstContentExample(content: unknown, doc: SwaggerDoc): unknown {
+  if (!isRecord(content)) return undefined;
+  const mediaObjects = Object.entries(content);
+  const preferred = mediaObjects.find(([mediaType]) => mediaType.includes('json')) ?? mediaObjects[0];
+  return preferred ? explicitExampleValue(preferred[1], doc) : undefined;
+}
+
+export function initialValueForDebugParam(
+  param: DebugParam,
+  options: { doc: SwaggerDoc; rawParam?: JsonRecord },
+): string {
+  const rawExample =
+    explicitExampleValue(options.rawParam, options.doc) ?? firstContentExample(options.rawParam?.content, options.doc);
+  if (rawExample !== undefined && rawExample !== null) {
+    return stringifyDebugValue(rawExample, param.type);
+  }
+  if (param.example !== undefined && param.example !== null) {
+    return stringifyDebugValue(param.example, param.type);
+  }
+  if (param.default !== undefined && param.default !== null) {
+    return stringifyDebugValue(param.default, param.type);
+  }
+  if (param.schema && (param.type === 'array' || param.type === 'object')) {
+    const schemaExample = schemaExampleValue(param.schema, options.doc);
+    if (schemaExample !== undefined && schemaExample !== null) {
+      return stringifyDebugValue(schemaExample, param.type);
+    }
+  }
+  return '';
+}
+
+export function buildInitialParamValues(
+  debugModel: OperationDebugModel,
+  doc: SwaggerDoc,
+  operation: MenuOperation,
+): ParamValueMap {
+  const rawParams = rawParametersForOperation(doc, operation);
+  const paramValues: ParamValueMap = {};
+  const allParams = [
+    ...debugModel.pathParams,
+    ...debugModel.queryParams,
+    ...debugModel.headerParams,
+    ...debugModel.cookieParams,
+  ];
+  for (const param of allParams) {
+    paramValues[paramKey(param)] = initialValueForDebugParam(param, {
+      doc,
+      rawParam: rawParams.get(paramKey(param)),
+    });
+  }
+  return paramValues;
+}
+
+function requestBodyForOperation(doc: SwaggerDoc, operation: MenuOperation): JsonRecord | undefined {
+  const operationObject = operationObjectFromDoc(doc, operation);
+  return resolveRecord(operationObject?.requestBody, doc);
+}
+
+function mediaObjectsForOperation(doc: SwaggerDoc, operation: MenuOperation): Map<string, JsonRecord> {
+  const requestBody = requestBodyForOperation(doc, operation);
+  const content = requestBody?.content;
+  const map = new Map<string, JsonRecord>();
+  if (!isRecord(content)) return map;
+  for (const [mediaType, mediaObject] of Object.entries(content)) {
+    const resolved = resolveRecord(mediaObject, doc);
+    if (resolved) map.set(mediaType, resolved);
+  }
+  return map;
+}
+
+function mediaObjectForBodyContent(
+  mediaObjects: Map<string, JsonRecord>,
+  bodyContent: BodyContent,
+): JsonRecord | undefined {
+  const direct = mediaObjects.get(bodyContent.mediaType);
+  if (direct) return direct;
+  if (mediaObjects.size === 1) return Array.from(mediaObjects.values())[0];
+  return undefined;
+}
+
+export function initialBodyValueForContent(
+  bodyContent: BodyContent | undefined,
+  defaults: BodyContentDefaults,
+): string {
+  if (!bodyContent) return '';
+  return defaults.bodyByMediaType[bodyContent.mediaType] ?? bodyContent.exampleValue ?? '';
+}
+
+export function initialFormFieldsForContent(
+  bodyContent: BodyContent | undefined,
+  defaults: BodyContentDefaults,
+): Record<string, string> {
+  if (!bodyContent) return {};
+  return { ...(defaults.formFieldsByMediaType[bodyContent.mediaType] ?? {}) };
+}
+
+export function buildBodyContentDefaults(
+  doc: SwaggerDoc,
+  operation: MenuOperation,
+  debugModel: OperationDebugModel,
+): BodyContentDefaults {
+  const mediaObjects = mediaObjectsForOperation(doc, operation);
+  const bodyByMediaType: Record<string, string> = {};
+  const formFieldsByMediaType: Record<string, Record<string, string>> = {};
+
+  for (const bodyContent of debugModel.bodyContents) {
+    const mediaObject = mediaObjectForBodyContent(mediaObjects, bodyContent);
+    const mediaExample = explicitExampleValue(mediaObject, doc);
+    const schema = mediaObject?.schema ?? bodyContent.schema;
+    if (bodyContent.category === 'json' || bodyContent.category === 'raw') {
+      const example = mediaExample ?? schemaExampleValue(schema, doc);
+      bodyByMediaType[bodyContent.mediaType] =
+        example !== undefined && example !== null
+          ? stringifyBodyValue(example, bodyContent)
+          : (bodyContent.exampleValue ?? '');
+    }
+    formFieldsByMediaType[bodyContent.mediaType] = initialFormFieldsFor(bodyContent, doc);
+  }
+
+  return {
+    bodyByMediaType,
+    formFieldsByMediaType,
+  };
+}
+
+export function extractSchemaFields(bodyContent: BodyContent): SchemaFieldRow[] {
+  const schema = bodyContent.schema;
+  if (!isRecord(schema) || schema.type !== 'object' || !isRecord(schema.properties)) return [];
+
+  const props = schema.properties as Record<string, JsonRecord>;
+  const requiredSet = new Set<string>(Array.isArray(schema.required) ? (schema.required as string[]) : []);
+  const fileFields = new Set(bodyContent.fileFields ?? []);
+  const multipleFileFields = new Set(bodyContent.fileFieldsMultiple ?? []);
+  const jsonFields = new Set(bodyContent.jsonFields ?? []);
+
+  return Object.entries(props)
+    .filter(([, prop]) => !prop.readOnly)
+    .map(([name, prop]) => {
+      const t = typeof prop.type === 'string' ? prop.type : 'string';
+      const format = typeof prop.format === 'string' ? prop.format : undefined;
+      const isFile =
+        fileFields.has(name) ||
+        t === 'file' ||
+        (t === 'string' && prop.format === 'binary') ||
+        (t === 'string' && prop.format === 'base64');
+
+      let isMultipleFile = false;
+      if (isFile && t === 'array' && isRecord(prop.items)) {
+        const hasBinaryFormat = prop.items.format === 'binary' || prop.items.format === 'base64';
+        const typeOk = prop.items.type === undefined || prop.items.type === 'string';
+        isMultipleFile = hasBinaryFormat && typeOk;
+      }
+      if (isFile && multipleFileFields.has(name)) {
+        isMultipleFile = true;
+      }
+
+      return {
+        name,
+        type: isFile ? 'file' : t,
+        format,
+        required: requiredSet.has(name),
+        description: typeof prop.description === 'string' ? prop.description : undefined,
+        default: prop.default,
+        example: explicitExampleValue(prop, bodyContent.schema ?? {}),
+        enum: Array.isArray(prop.enum) ? prop.enum : undefined,
+        isFile,
+        isMultipleFile,
+        isJson: !isFile && jsonFields.has(name),
+        schema: prop,
+      };
+    });
+}
+
+export function initialFieldValue(field: SchemaFieldRow, doc: SwaggerDoc | JsonRecord): string {
+  if (field.isFile) return '';
+  if (field.example !== undefined && field.example !== null) return stringifyDebugValue(field.example, field.type);
+  if (field.default !== undefined && field.default !== null) return stringifyDebugValue(field.default, field.type);
+  if (
+    field.isJson ||
+    field.type === 'array' ||
+    field.type === 'object' ||
+    field.schema?.$ref ||
+    field.schema?.items ||
+    field.schema?.properties
+  ) {
+    const example = schemaExampleValue(field.schema, doc);
+    if (example !== undefined && example !== null) return stringifyDebugValue(example, field.type);
+    if (field.isJson) return '{}';
+  }
+  if (field.enum && field.enum.length > 0) return String(field.enum[0]);
+  if (field.type === 'boolean') return 'true';
+  if (field.type === 'integer' || field.type === 'number') return '0';
+  return '';
+}
+
+function initialFormFieldsFor(bodyContent: BodyContent, doc: SwaggerDoc | JsonRecord): Record<string, string> {
+  if (bodyContent.category !== 'urlencoded' && bodyContent.category !== 'multipart') return {};
+  const initial: Record<string, string> = {};
+  for (const field of extractSchemaFields(bodyContent)) {
+    initial[field.name] = initialFieldValue(field, doc);
+  }
+  return initial;
+}
+
+export function mergeCachedFormFields(
+  bodyContent: BodyContent | undefined,
+  cached: Record<string, string>,
+  defaults: BodyContentDefaults,
+): Record<string, string> {
+  const next = initialFormFieldsForContent(bodyContent, defaults);
+  const allowedFields = new Set(Object.keys(next));
+  for (const [key, value] of Object.entries(cached)) {
+    if (allowedFields.has(key)) {
+      next[key] = value;
+    }
+  }
+  return next;
+}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/debugDefaultValues.ts
@@ -268,7 +268,7 @@ export function buildBodyContentDefaults(
           ? stringifyBodyValue(example, bodyContent)
           : (bodyContent.exampleValue ?? '');
     }
-    formFieldsByMediaType[bodyContent.mediaType] = initialFormFieldsFor(bodyContent, doc);
+    formFieldsByMediaType[bodyContent.mediaType] = initialFormFieldsFor(bodyContent, doc, mediaExample);
   }
 
   return {
@@ -347,11 +347,25 @@ export function initialFieldValue(field: SchemaFieldRow, doc: SwaggerDoc | JsonR
   return '';
 }
 
-function initialFormFieldsFor(bodyContent: BodyContent, doc: SwaggerDoc | JsonRecord): Record<string, string> {
+function initialFormFieldsFor(
+  bodyContent: BodyContent,
+  doc: SwaggerDoc | JsonRecord,
+  mediaExample?: unknown,
+): Record<string, string> {
   if (bodyContent.category !== 'urlencoded' && bodyContent.category !== 'multipart') return {};
   const initial: Record<string, string> = {};
-  for (const field of extractSchemaFields(bodyContent)) {
+  const fields = extractSchemaFields(bodyContent);
+  for (const field of fields) {
     initial[field.name] = initialFieldValue(field, doc);
+  }
+  if (isRecord(mediaExample)) {
+    for (const field of fields) {
+      if (field.isFile) continue;
+      const exampleValue = mediaExample[field.name];
+      if (exampleValue !== undefined && exampleValue !== null) {
+        initial[field.name] = stringifyDebugValue(exampleValue, field.type);
+      }
+    }
   }
   return initial;
 }


### PR DESCRIPTION
## 关联 Issue

关联 #480。

## 变更内容

- 新增 `debugDefaultValues.ts`，集中生成调试表单默认值。
- 调试页初始化参数、JSON/raw request body、urlencoded/multipart 表单字段时，优先复用 OpenAPI `example`、`examples`、schema `example/default` 和嵌套 schema 示例生成结果。
- 保留请求缓存覆盖逻辑：已有缓存或用户编辑值继续优先生效，切换接口或 content-type 时再按当前接口重新初始化。
- 新增 `debugDefaultValues.test.ts`，覆盖参数 `examples`、嵌套对象/数组示例、requestBody media examples 优先级，以及缓存值覆盖默认值。

## 范围说明

本 PR 只改 OpenAPI 3 主线 React UI：`knife4j-front/knife4j-ui-react`。不扩展 OAS2，不改 Java starter，不修改发布流程。

## 协作门禁

- worker：曾启动短命 worker，但运行期间未返回 handoff；它在工作区留下的 diff 已由 coordinator 审查、补验并收束后提交。此处按 worker handoff 不可用记录例外。
- reviewer：当前工具策略不允许在维护者未明确要求 sub-agent 的情况下再启动独立 reviewer；本 PR 保持 draft，等待维护者人工 review 或后续独立 reviewer 后再进入 `status:review`。

## 验证

- `./scripts/test-front-core.sh`：通过。
- `cd knife4j-front/knife4j-ui-react && bun test src/pages/api/debugDefaultValues.test.ts`：通过，3 tests / 10 expects。
- `cd knife4j-front/knife4j-ui-react && bun run format`：通过，无文件变更。
- `git diff --check`：通过。

## 风险

- 默认调试值现在会更积极地填充示例值，符合 #480 诉求；请求缓存仍会覆盖默认值，避免覆盖用户已编辑内容。
- media `examples` 取第一个示例值，当前未新增 UI 选择多个 example 的交互。