### PR TITLE
修复 ApiSupport 全局扫描包排序

### DIFF
--- a/docs-site/reference/annotations.md
+++ b/docs-site/reference/annotations.md
@@ -393,8 +393,11 @@ private String name;
 
 1. 确认 `knife4j.enable=true` 已配置。
 2. 确认使用的是 WebMvc Starter（非 WebFlux，WebFlux 不支持后端增强）。
-3. 确认使用的是 OAS3 WebMvc starter，并且 `/v3/api-docs` 的 `tags` 或 operation 中已写入 `x-order`。
-4. 如果 OpenAPI spec 中没有 `x-order`，先检查 `springdoc.group-configs.packages-to-scan` 是否覆盖到对应 Controller。
+3. 确认 Controller 同时有 OpenAPI3 的 `@Tag(name = "...")` 与 Knife4j 的 `@ApiSupport(order = N)`。
+4. 确认 `/v3/api-docs` 的 `tags` 或 operation 中已写入 `x-order`。
+5. 如果 Tag 级 `x-order` 缺失，检查 `springdoc.packages-to-scan` 或 `springdoc.group-configs[].packages-to-scan` 是否覆盖到对应 Controller。
+
+`@ApiSupport.author/authors` 在 React UI 中展示在接口详情页的 operation 头部，不展示在左侧分组菜单或 Tag 标题上；如果 `/v3/api-docs` 的 operation 已有 `x-author`，说明后端增强已生效。
 
 ### `@Ignore` vs `@Hidden` 用哪个？
 

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -27,6 +27,25 @@ title: 配置参考
 
 OpenAPI3 starter 会暴露 `/knife4j/config` 作为 Knife4j UI 的运行时发现入口。该接口不属于 springdoc 标准接口，由 UI 内部调用，并会从 OpenAPI 文档中隐藏，不展示在 `doc.html` 接口列表里。它用于在自定义 `springdoc.api-docs.path` 时返回实际的 `apiDocsUrl` 与 `swaggerConfigUrl`；响应通过 `schemaVersion` 标识契约版本，后续 Knife4j 运行时能力也应挂载在这个结构下。
 
+### OpenAPI3 文档标题与版本
+
+OpenAPI3 系列 starter（含 Boot 4）不会读取 `knife4j.openapi.title` / `knife4j.openapi.version`。React UI 的浏览器标题、首页标题和版本号都来自 OpenAPI 标准字段 `info.title` 与 `info.version`；未配置时 springdoc 默认会给出 `OpenAPI definition` 与 `v0`。
+
+推荐用 springdoc/OpenAPI 标准方式配置：
+
+```java
+@Bean
+public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+            .info(new Info()
+                    .title("用户中心接口文档")
+                    .version("1.0.0")
+                    .description("用户中心 OpenAPI 文档"));
+}
+```
+
+也可以在启动类上使用 `@OpenAPIDefinition(info = @Info(...))`。`knife4j.openapi.*` 只保留给 openapi2 starter 的自动 Docket 注册使用。
+
 ::: warning 反向代理 / 网关放行
 当应用部署在网关或反向代理之后时，请确保 `/knife4j/config`（与 `/doc.html`、`/v3/api-docs/**`、`/swagger-ui/**`、`/webjars/**` 一起）能透传到后端。常见情况：
 
@@ -385,6 +404,8 @@ springdoc:
   swagger-ui:
     tags-sorter: alpha
 ```
+
+`@ApiSupport.order` 的 Tag 排序增强会按 `springdoc.packages-to-scan` 和 `springdoc.group-configs[].packages-to-scan` 扫描 Controller；如果没有配置扫描包，operation 级 `x-order` 仍会写入，但 Tag 级排序可能无法推断。
 
 ### 生产环境配置
 

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
@@ -72,17 +72,8 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
      * @param openApi openApi
      */
     private void addOrderExtension(OpenAPI openApi) {
-        if (Objects.isNull(properties.getGroupConfigs())
-                || properties.getGroupConfigs().isEmpty()) {
-            return;
-        }
         // 获取包扫描路径
-        Set<String> packagesToScan =
-                properties.getGroupConfigs().stream()
-                        .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
-                        .filter(toScan -> !CollectionUtils.isEmpty(toScan))
-                        .flatMap(List::stream)
-                        .collect(Collectors.toSet());
+        Set<String> packagesToScan = collectPackagesToScan();
         if (CollectionUtils.isEmpty(packagesToScan)) {
             return;
         }
@@ -117,6 +108,23 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
                                 });
             }
         }
+    }
+
+    private Set<String> collectPackagesToScan() {
+        Set<String> packagesToScan = new LinkedHashSet<>();
+        if (properties == null) {
+            return packagesToScan;
+        }
+        if (!CollectionUtils.isEmpty(properties.getPackagesToScan())) {
+            packagesToScan.addAll(properties.getPackagesToScan());
+        }
+        if (!CollectionUtils.isEmpty(properties.getGroupConfigs())) {
+            properties.getGroupConfigs().stream()
+                    .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
+                    .filter(toScan -> !CollectionUtils.isEmpty(toScan))
+                    .forEach(packagesToScan::addAll);
+        }
+        return packagesToScan;
     }
 
     private Tag getTag(Class<?> clazz) {

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
@@ -80,6 +80,14 @@ public class Knife4jOpenApiCustomizerOrderTest {
         return new Knife4jOpenApiCustomizer(props, docProps);
     }
 
+    private Knife4jOpenApiCustomizer buildCustomizerWithRootPackages(String... packages) {
+        Knife4jProperties props = new Knife4jProperties();
+        props.setEnable(true);
+        SpringDocConfigProperties docProps = new SpringDocConfigProperties();
+        docProps.setPackagesToScan(java.util.Arrays.asList(packages));
+        return new Knife4jOpenApiCustomizer(props, docProps);
+    }
+
     private OpenAPI buildOpenApi(String... tagNames) {
         OpenAPI openApi = new OpenAPI();
         for (String name : tagNames) {
@@ -94,6 +102,23 @@ public class Knife4jOpenApiCustomizerOrderTest {
     public void tagOrderAppliedWhenPackageScanConfigured() {
         String pkg = AlphaController.class.getPackage().getName();
         Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha", "Beta");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag alpha = openApi.getTags().stream()
+                .filter(t -> "Alpha".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+        io.swagger.v3.oas.models.tags.Tag beta = openApi.getTags().stream()
+                .filter(t -> "Beta".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+
+        Assert.assertEquals(10, alpha.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+        Assert.assertEquals(20, beta.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    @Test
+    public void tagOrderAppliedWhenRootPackageScanConfigured() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizerWithRootPackages(pkg);
 
         OpenAPI openApi = buildOpenApi("Alpha", "Beta");
         customizer.customise(openApi);

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizer.java
@@ -77,16 +77,8 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
      * @param openApi openApi
      */
     private void addOrderExtension(OpenAPI openApi) {
-        if (CollectionUtils.isEmpty(properties.getGroupConfigs())) {
-            return;
-        }
         // 获取包扫描路径
-        Set<String> packagesToScan =
-                properties.getGroupConfigs().stream()
-                        .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
-                        .filter(toScan -> !CollectionUtils.isEmpty(toScan))
-                        .flatMap(List::stream)
-                        .collect(Collectors.toSet());
+        Set<String> packagesToScan = collectPackagesToScan();
         if (CollectionUtils.isEmpty(packagesToScan)) {
             return;
         }
@@ -121,6 +113,23 @@ public class Knife4jOpenApiCustomizer implements GlobalOpenApiCustomizer {
                                 });
             }
         }
+    }
+
+    private Set<String> collectPackagesToScan() {
+        Set<String> packagesToScan = new LinkedHashSet<>();
+        if (properties == null) {
+            return packagesToScan;
+        }
+        if (!CollectionUtils.isEmpty(properties.getPackagesToScan())) {
+            packagesToScan.addAll(properties.getPackagesToScan());
+        }
+        if (!CollectionUtils.isEmpty(properties.getGroupConfigs())) {
+            properties.getGroupConfigs().stream()
+                    .map(SpringDocConfigProperties.GroupConfig::getPackagesToScan)
+                    .filter(toScan -> !CollectionUtils.isEmpty(toScan))
+                    .forEach(packagesToScan::addAll);
+        }
+        return packagesToScan;
     }
 
     private Tag getTag(Class<?> clazz) {

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOpenApiCustomizerOrderTest.java
@@ -68,6 +68,14 @@ public class Knife4jOpenApiCustomizerOrderTest {
         return new Knife4jOpenApiCustomizer(props, docProps);
     }
 
+    private Knife4jOpenApiCustomizer buildCustomizerWithRootPackages(String... packages) {
+        Knife4jProperties props = new Knife4jProperties();
+        props.setEnable(true);
+        SpringDocConfigProperties docProps = new SpringDocConfigProperties();
+        docProps.setPackagesToScan(java.util.Arrays.asList(packages));
+        return new Knife4jOpenApiCustomizer(props, docProps);
+    }
+
     private OpenAPI buildOpenApi(String... tagNames) {
         OpenAPI openApi = new OpenAPI();
         for (String name : tagNames) {
@@ -82,6 +90,23 @@ public class Knife4jOpenApiCustomizerOrderTest {
     public void tagOrderAppliedWhenPackageScanConfigured() {
         String pkg = AlphaController.class.getPackage().getName();
         Knife4jOpenApiCustomizer customizer = buildCustomizer(pkg);
+
+        OpenAPI openApi = buildOpenApi("Alpha", "Beta");
+        customizer.customise(openApi);
+
+        io.swagger.v3.oas.models.tags.Tag alpha = openApi.getTags().stream()
+                .filter(t -> "Alpha".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+        io.swagger.v3.oas.models.tags.Tag beta = openApi.getTags().stream()
+                .filter(t -> "Beta".equals(t.getName())).findFirst().orElseThrow(AssertionError::new);
+
+        Assert.assertEquals(10, alpha.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+        Assert.assertEquals(20, beta.getExtensions().get(ExtensionsConstants.EXTENSION_ORDER));
+    }
+
+    @Test
+    public void tagOrderAppliedWhenRootPackageScanConfigured() {
+        String pkg = AlphaController.class.getPackage().getName();
+        Knife4jOpenApiCustomizer customizer = buildCustomizerWithRootPackages(pkg);
 
         OpenAPI openApi = buildOpenApi("Alpha", "Beta");
         customizer.customise(openApi);

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot4/Boot4JakartaDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot4/Boot4JakartaDocHttpSmokeTest.java
@@ -17,6 +17,7 @@
 
 package com.github.xiaoymin.knife4j.smoke.boot4;
 
+import com.github.xiaoymin.knife4j.annotations.ApiSupport;
 import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -255,6 +256,43 @@ public class Boot4JakartaDocHttpSmokeTest {
         Assert.assertTrue(customConfig.body.contains("/api/openapi"));
     }
 
+    @Test
+    public void shouldExposeApiSupportOrderAndAuthorExtensions() throws IOException {
+        context = new SpringApplicationBuilder(TestApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(
+                        "server.port=0",
+                        "knife4j.enable=true",
+                        "springdoc.packages-to-scan=com.github.xiaoymin.knife4j.smoke.boot4",
+                        "logging.level.root=ERROR")
+                .run();
+
+        int port = context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+
+        HttpResponse apiDocs = get(port, "/v3/api-docs");
+        Assert.assertEquals(200, apiDocs.statusCode);
+
+        JsonNode apiDocsJson = OBJECT_MAPPER.readTree(apiDocs.body);
+        JsonNode apiSupportTag = null;
+        for (JsonNode tag : apiDocsJson.path("tags")) {
+            if ("ApiSupport 示例接口".equals(tag.path("name").asText())) {
+                apiSupportTag = tag;
+                break;
+            }
+        }
+        Assert.assertNotNull("api-docs should contain ApiSupport tag:\n" + apiDocs.body, apiSupportTag);
+        Assert.assertEquals("@ApiSupport.order should write tag x-order from springdoc.packages-to-scan (#472)",
+                1, apiSupportTag.path("x-order").asInt());
+
+        JsonNode operation = apiDocsJson.path("paths").path("/api/api-support/list").path("get");
+        Assert.assertFalse("api-docs should contain GET /api/api-support/list operation:\n" + apiDocs.body,
+                operation.isMissingNode());
+        Assert.assertEquals("@ApiSupport.author should write operation x-author (#472)",
+                "yilers", operation.path("x-author").asText());
+        Assert.assertEquals("@ApiSupport.order should also write operation x-order (#472)",
+                1, operation.path("x-order").asInt());
+    }
+
     private JsonNode schemaProperties(JsonNode apiDocsJson, JsonNode schema) {
         JsonNode ref = schema.path("$ref");
         if (ref.isTextual() && ref.asText().startsWith("#/components/schemas/")) {
@@ -392,6 +430,19 @@ public class Boot4JakartaDocHttpSmokeTest {
             return List.of(
                     new UserVO(1L, "张三", "zhangsan@example.com"),
                     new UserVO(2L, "李四", "lisi@example.com"));
+        }
+    }
+
+    @Tag(name = "ApiSupport 示例接口", description = "Boot4 ApiSupport 示例接口")
+    @ApiSupport(order = 1, author = "yilers")
+    @RestController
+    @RequestMapping("/api/api-support")
+    public static class ApiSupportController {
+
+        @Operation(summary = "获取 ApiSupport 示例列表")
+        @GetMapping("/list")
+        public List<String> list() {
+            return List.of("api-support");
         }
     }
 


### PR DESCRIPTION
## 关联 Issue

- 修复 #472

## 变更内容

- 修复 OpenAPI3 普通 starter 和 Jakarta starter 的 `@ApiSupport.order` Tag 排序扫描来源：除 `springdoc.group-configs[].packages-to-scan` 外，也读取顶层 `springdoc.packages-to-scan`。
- 增加普通/Jakarta starter 单测，覆盖顶层扫描包配置下的 `x-order` 写入。
- 增加 Boot4 Jakarta smoke 场景，验证 `/v3/api-docs` 中 Tag `x-order` 以及 Operation `x-author` / `x-order`。
- 补充文档：OpenAPI3 的页面标题与版本来自 OpenAPI `info.title` / `info.version`；默认 `v0` 来自 springdoc 默认值；`@ApiSupport.author` 展示在接口详情而不是左侧菜单。

## 验证

- `git diff --check`
- `./scripts/test-docs.sh`
- `mvn -pl knife4j-openapi3-spring-boot-starter -am -Dknife4j-skipTests=false -Dtest=Knife4jOpenApiCustomizerOrderTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl knife4j-openapi3-jakarta-spring-boot-starter -am -Dknife4j-skipTests=false -Dtest=Knife4jOpenApiCustomizerOrderTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl knife4j-smoke-tests/boot4-jakarta-app -am -Dknife4j-skipTests=false test`
- `./scripts/test-java.sh`，包含 `Smoke-tests evidence OK (12 modules)`

## 协作记录

- Worker 已完成问题定位与实现交接。
- Reviewer 已完成只读审查，结论：未发现阻塞 PR 的问题。

## 风险说明

- 仓库当前 Boot4 smoke 基线为 Spring Boot 4.0.6，不是 issue 报告中的 4.1.0；本次修复点位于 Knife4j customizer 读取 springdoc 扫描包配置，和 Boot 4 minor 版本耦合较低。
- 同一个 `@Tag(name)` 如果被多个 Controller 以不同 `@ApiSupport.order` 标注，仍沿用现有先扫描到的顺序值；这不是本次新增行为。
