### PR TITLE
修复响应字段说明布局重叠

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
@@ -145,17 +145,20 @@ const annotatedJsonPreStyle: React.CSSProperties = {
 
 const jsonLineStyle: React.CSSProperties = {
   display: 'grid',
-  gridTemplateColumns: 'minmax(0, 56ch) minmax(180px, 320px)',
+  gridTemplateColumns: 'minmax(0, 1fr) minmax(180px, 320px)',
+  columnGap: 16,
   alignItems: 'stretch',
-  minWidth: 'calc(56ch + 260px)',
+  width: '100%',
+  minWidth: 0,
 };
 
 /** Monospace, normal color — matches the surrounding <pre>. */
 const jsonCodeStyle: React.CSSProperties = {
   fontFamily: "Menlo, Monaco, Consolas, 'Courier New', monospace",
   color: '#24292e',
-  whiteSpace: 'pre',
-  paddingRight: 14,
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
+  wordBreak: 'break-word',
   minWidth: 0,
 };
 
@@ -174,6 +177,8 @@ const jsonDescStyle: React.CSSProperties = {
   minHeight: '1.55em',
   lineHeight: 1.55,
   whiteSpace: 'normal',
+  overflowWrap: 'break-word',
+  minWidth: 0,
 };
 
 export default function ResponsePanel({


### PR DESCRIPTION
## 关联 Issue

Closes #483

## 变更内容

- 调整 React 调试页响应 Content 中的字段说明布局。
- 将 JSON 内容列改为弹性列，右侧字段说明保持固定宽度和间距。
- 长字段值会在内容列内换行，避免画到字段说明列里。

## 验证

- `./scripts/test-front-core.sh`：通过

## 协作说明

- Worker：本次未启动独立 worker。原因是当前 Codex 子代理工具策略要求仅在用户显式要求子代理时使用；该任务为单文件低风险 UI 布局修复，由 coordinator 直接处理。
- Reviewer：暂未启动独立 reviewer，同上。进入 `status:review` 前仍需 PR CI 通过，并由维护者或人工 review 给出结论。

## 风险与范围外

- 仅影响 `knife4j-front/knife4j-ui-react` 调试响应中“显示字段说明”开启时的 JSON 注释布局。
- Raw、Headers、字段说明关闭状态和请求发送逻辑不变。