### PR TITLE
fix: 修复自定义 Footer 配置生效优先级

### DIFF
--- a/docs-site/guide/features.md
+++ b/docs-site/guide/features.md
@@ -210,12 +210,12 @@ knife4j:
 knife4j:
   enable: true
   setting:
-    enable-footer: true           # 保持 Footer 区域显示
+    enable-footer: true           # 显示默认 Footer
     enable-footer-custom: true    # 启用自定义 Footer 文案
     footer-custom-content: Apache License 2.0 | Copyright 2019-[Knife4j](https://github.com/songxychn/knife4j-next)
 ```
 
-`footer-custom-content` 支持 Markdown 格式。React 新前端会复用自身的 Markdown 安全清洗能力渲染该内容；当 `enable-footer=false` 时，Footer 仍会整体隐藏。
+`footer-custom-content` 支持 Markdown 格式。React 新前端会复用自身的 Markdown 安全清洗能力渲染该内容；当 `enable-footer-custom=true` 且内容非空时，自定义 Footer 优先展示，`enable-footer=false` 仅隐藏默认 Footer。
 
 ### 自定义 Host
 

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -81,7 +81,7 @@ public OpenAPI customOpenAPI() {
 | `knife4j.setting.enableHostText` | `String` | `""` | Host 地址 | ✅ |
 | `knife4j.setting.enableDynamicParameter` | `boolean` | `false` | 启用动态请求参数 | ⚠️ |
 | `knife4j.setting.enableDebug` | `boolean` | `true` | 启用调试功能 | ✅ |
-| `knife4j.setting.enableFooter` | `boolean` | `true` | 显示底部 Footer | ✅ |
+| `knife4j.setting.enableFooter` | `boolean` | `true` | 显示默认 Footer | ✅ |
 | `knife4j.setting.enableFooterCustom` | `boolean` | `false` | 自定义 Footer | ✅ |
 | `knife4j.setting.footerCustomContent` | `String` | — | 自定义 Footer 内容（支持 Markdown） | ✅ |
 | `knife4j.setting.enableSearch` | `boolean` | `true` | 显示搜索框 | ✅ |

--- a/knife4j-front/knife4j-ui-react/src/types/settings.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/settings.ts
@@ -27,7 +27,7 @@ export interface AppSettings {
   enableGroup: boolean;
   /** Whether the default footer is shown. */
   enableFooter: boolean;
-  /** Whether custom Markdown footer content is shown when footer is enabled. */
+  /** Whether non-empty custom Markdown footer content is shown. */
   enableFooterCustom: boolean;
   /** Backend-provided custom footer Markdown content. */
   footerCustomContent: string;

--- a/knife4j-front/knife4j-ui-react/src/utils/footer.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/footer.test.ts
@@ -8,8 +8,10 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
 }
 
 describe('footer content resolution', () => {
-  it('hides footer when enableFooter is false', () => {
-    expect(resolveFooterContent(settings({ enableFooter: false }), 'Default footer')).toBeNull();
+  it('hides default footer when enableFooter is false', () => {
+    expect(
+      resolveFooterContent(settings({ enableFooter: false, enableFooterCustom: false }), 'Default footer'),
+    ).toBeNull();
   });
 
   it('uses default footer when custom footer is disabled', () => {
@@ -34,6 +36,22 @@ describe('footer content resolution', () => {
     ).toEqual({
       kind: 'custom',
       content: 'Apache License 2.0 | [Knife4j](https://github.com/songxychn/knife4j-next)',
+    });
+  });
+
+  it('uses custom footer when default footer is disabled', () => {
+    expect(
+      resolveFooterContent(
+        settings({
+          enableFooter: false,
+          enableFooterCustom: true,
+          footerCustomContent: 'Apache License 2.0 | Copyright 2022-[wxp](https://gitee.com/wxpid1)',
+        }),
+        'Default footer',
+      ),
+    ).toEqual({
+      kind: 'custom',
+      content: 'Apache License 2.0 | Copyright 2022-[wxp](https://gitee.com/wxpid1)',
     });
   });
 

--- a/knife4j-front/knife4j-ui-react/src/utils/footer.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/footer.ts
@@ -11,14 +11,14 @@ export type ResolvedFooterContent =
     };
 
 export function resolveFooterContent(settings: AppSettings, defaultContent: string): ResolvedFooterContent | null {
-  if (!settings.enableFooter) return null;
-
   if (settings.enableFooterCustom && settings.footerCustomContent.trim()) {
     return {
       kind: 'custom',
       content: settings.footerCustomContent,
     };
   }
+
+  if (!settings.enableFooter) return null;
 
   return {
     kind: 'default',


### PR DESCRIPTION
## 关联 Issue

Fixes #488

## 变更内容

- 调整 React Footer 解析优先级：当 `enableFooterCustom=true` 且 `footerCustomContent` 非空时，优先渲染自定义 Footer Markdown。
- 保留 `enableFooter=false` 隐藏默认 Footer 的能力，不再让它覆盖已启用且有内容的自定义 Footer。
- 增加单测覆盖 `enableFooter=false`、`enableFooterCustom=true`、`footerCustomContent` 非空的 issue 复现组合。
- 同步文档说明：`enable-footer` 控制默认 Footer，自定义 Footer 内容非空且启用时优先展示。

## Worker / Reviewer

- Worker：本次是低风险 React 工具函数小切片，由 coordinator 直接实现；未启动独立 worker。替代验证为新增回归单测、前端完整门禁和文档构建。
- Reviewer：独立 reviewer 已审查当前 diff，结论为 `approve`；唯一 low 级建议是同步 `enableFooterCustom` 类型注释，已处理。

## 验证

- `./scripts/test-front-core.sh`：通过。
- `./scripts/test-docs.sh`：通过。
- `git diff --check`：通过。

## 风险与范围

- 不修改 Java starter 的 `x-openapi.x-setting` 注入逻辑。
- 不触碰 OAS2 / Vue3 兼容线。
- 行为变化仅限 React UI Footer 内容解析优先级。