### PR TITLE
fix: 支持描述信息换行展示

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
+++ b/knife4j-front/knife4j-ui-react/src/compoents/SidebarSearchMenu.tsx
@@ -138,7 +138,11 @@ const SidebarSearchMenu: React.FC<SidebarSearchMenuProps> = ({ selectedKey, onMe
     filteredByTag.forEach((apis, tag) => {
       const tagDesc = tagDescMap.get(tag);
       const labelContent = tagDesc ? (
-        <Tooltip title={<Markdown source={tagDesc} />} placement="right" styles={{ root: { maxWidth: 400 } }}>
+        <Tooltip
+          title={<Markdown source={tagDesc} preserveLineBreaks />}
+          placement="right"
+          styles={{ root: { maxWidth: 400 } }}
+        >
           <span>{tag}</span>
         </Tooltip>
       ) : (

--- a/knife4j-front/knife4j-ui-react/src/components/DescriptionText.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/DescriptionText.tsx
@@ -1,0 +1,24 @@
+import { Typography } from 'antd';
+import type { CSSProperties, ReactNode } from 'react';
+
+const { Text } = Typography;
+
+const descriptionTextStyle: CSSProperties = {
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
+};
+
+interface DescriptionTextProps {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  type?: 'secondary' | 'success' | 'warning' | 'danger';
+}
+
+export default function DescriptionText({ children, style, ...textProps }: DescriptionTextProps) {
+  return (
+    <Text {...textProps} style={{ ...descriptionTextStyle, ...style }}>
+      {children}
+    </Text>
+  );
+}

--- a/knife4j-front/knife4j-ui-react/src/components/Markdown.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/Markdown.tsx
@@ -1,17 +1,17 @@
 import { memo, useMemo } from 'react';
-import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import { parseMarkdown } from '../utils/markdown';
 
 interface MarkdownProps {
   source: string;
+  preserveLineBreaks?: boolean;
 }
 
-const Markdown = memo(({ source }: MarkdownProps) => {
+const Markdown = memo(({ source, preserveLineBreaks = false }: MarkdownProps) => {
   const html = useMemo(() => {
-    if (!source) return '';
-    const rawHtml = marked.parse(source, { async: false }) as string;
+    const rawHtml = parseMarkdown(source, { preserveLineBreaks });
     return DOMPurify.sanitize(rawHtml);
-  }, [source]);
+  }, [preserveLineBreaks, source]);
 
   return <div dangerouslySetInnerHTML={{ __html: html }} />;
 });

--- a/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
+++ b/knife4j-front/knife4j-ui-react/src/components/schema/SchemaFieldTable.tsx
@@ -7,6 +7,7 @@ import { Resizable, type ResizeCallbackData } from 'react-resizable';
 import { useTranslation } from 'react-i18next';
 import { useGroup } from '../../context/GroupContext';
 import type { SchemaObject, SwaggerDoc } from '../../types/swagger';
+import DescriptionText from '../DescriptionText';
 import {
   SCHEMA_FIELD_COLUMN_MIN_WIDTHS,
   schemaFieldTableLayout,
@@ -87,9 +88,9 @@ export function SchemaTypeLink({ node }: SchemaTypeLinkProps) {
   const content = (
     <div style={{ maxWidth: 420 }}>
       {schema.description && (
-        <Text type="secondary" style={{ display: 'block', marginBottom: 8 }}>
+        <DescriptionText type="secondary" style={{ display: 'block', marginBottom: 8 }}>
           {schema.description}
-        </Text>
+        </DescriptionText>
       )}
       <Space direction="vertical" size={4} style={{ width: '100%' }}>
         {previewFields.map((field) => (
@@ -266,12 +267,12 @@ export default function SchemaFieldTable({ fields, emptyText }: SchemaFieldTable
       onHeaderCell: () => resizableHeader('description'),
       render: (value, record) => (
         <Space size={6} wrap>
-          {value ? <span>{value}</span> : <Text type="secondary">-</Text>}
+          {value ? <DescriptionText>{value}</DescriptionText> : <Text type="secondary">-</Text>}
           {record.refDescription && record.refDescription !== value && (
-            <Text type="secondary" style={{ fontSize: 12 }}>
+            <DescriptionText type="secondary" style={{ fontSize: 12 }}>
               {record.refTitle ? `[${record.refTitle}] ` : ''}
               {record.refDescription}
-            </Text>
+            </DescriptionText>
           )}
           {record.deprecated && <Tag color="red">{t('schema.flag.deprecated')}</Tag>}
           {record.readOnly && <Tag color="default">{t('schema.flag.readOnly')}</Tag>}

--- a/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useGroup } from '../context/GroupContext';
 import { useSettings } from '../context/SettingsContext';
+import DescriptionText from '../components/DescriptionText';
 import Markdown from '../components/Markdown';
 import type { SwaggerServer } from '../types/swagger';
 import { getCustomHomeMarkdown } from '../utils/knife4jSettings';
@@ -387,7 +388,7 @@ export default function Home() {
               fontSize: 14,
             }}
           >
-            <Markdown source={heroDescription} />
+            <Markdown source={heroDescription} preserveLineBreaks />
           </Paragraph>
         )}
       </div>
@@ -551,7 +552,16 @@ export default function Home() {
                       <CloudServerOutlined />,
                       <Space direction="vertical" size={2} style={{ width: '100%' }}>
                         {servers.map((s, idx) => (
-                          <Tooltip key={`${s.url}-${idx}`} title={s.description}>
+                          <Tooltip
+                            key={`${s.url}-${idx}`}
+                            title={
+                              s.description ? (
+                                <span style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>
+                                  {s.description}
+                                </span>
+                              ) : undefined
+                            }
+                          >
                             <span style={{ display: 'block' }}>
                               {s.name && (
                                 <Text strong style={{ display: 'block', fontSize: 12, overflowWrap: 'anywhere' }}>
@@ -569,7 +579,7 @@ export default function Home() {
                                 {s.url}
                               </span>
                               {s.description && (
-                                <Text
+                                <DescriptionText
                                   type="secondary"
                                   style={{
                                     display: 'block',
@@ -579,7 +589,7 @@ export default function Home() {
                                   }}
                                 >
                                   {s.description}
-                                </Text>
+                                </DescriptionText>
                               )}
                             </span>
                           </Tooltip>

--- a/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Schema.tsx
@@ -8,6 +8,7 @@ import { normalizeGenericTitle } from '../components/schema/schemaUtils';
 import { useGroup } from '../context/GroupContext';
 import { useSettings } from '../context/SettingsContext';
 import type { SchemaObject, SwaggerDoc } from '../types/swagger';
+import DescriptionText from '../components/DescriptionText';
 import { resolveSchemaActiveKeys } from './schemaActiveKeys';
 
 const { Title, Text } = Typography;
@@ -116,9 +117,9 @@ export default function Schema() {
             </Text>
           )}
           {model.description && (
-            <Text type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
+            <DescriptionText type="secondary" style={{ marginLeft: 12, fontSize: 12 }}>
               {model.description}
-            </Text>
+            </DescriptionText>
           )}
           <Tag style={{ marginLeft: 12 }} color="default">
             {model.fields.length} {t('schema.fields')}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -46,6 +46,7 @@ import {
 } from 'knife4j-core';
 import { OperationModeLayout, useCurrentOperation } from './useCurrentOperation';
 import CodeEditor, { type CodeEditorLanguage } from '../../components/CodeEditor';
+import DescriptionText from '../../components/DescriptionText';
 import { useAuth } from '../../context/AuthContext';
 import { useGlobalParam } from '../../context/GlobalParamContext';
 import { useSettings } from '../../context/SettingsContext';
@@ -968,7 +969,7 @@ function UrlencodedForm({ bodyContent, formFields, setFormFields }: UrlencodedFo
       width: 240,
       render: (_value, record: SchemaFieldRow) => (
         <Space size={2} direction="vertical" style={{ lineHeight: 1.35, fontSize: 12 }}>
-          {record.description && <Text style={{ fontSize: 12 }}>{record.description}</Text>}
+          {record.description && <DescriptionText style={{ fontSize: 12 }}>{record.description}</DescriptionText>}
           {record.default !== undefined && (
             <Text type="secondary" style={{ fontSize: 11 }}>
               {t('apiDebug.desc.default')}
@@ -1113,7 +1114,7 @@ function MultipartForm({ bodyContent, formFields, setFormFields, fileFieldsRef }
       width: 240,
       render: (_value, record: SchemaFieldRow) => (
         <Space size={2} direction="vertical" style={{ lineHeight: 1.35, fontSize: 12 }}>
-          {record.description && <Text style={{ fontSize: 12 }}>{record.description}</Text>}
+          {record.description && <DescriptionText style={{ fontSize: 12 }}>{record.description}</DescriptionText>}
         </Space>
       ),
     },
@@ -1856,7 +1857,7 @@ export default function ApiDebug() {
         width: 280,
         render: (_value, record: DebugParam) => (
           <Space size={2} direction="vertical" style={{ lineHeight: 1.35, fontSize: 12 }}>
-            {record.description && <Text style={{ fontSize: 12 }}>{record.description}</Text>}
+            {record.description && <DescriptionText style={{ fontSize: 12 }}>{record.description}</DescriptionText>}
             {record.default !== undefined && (
               <Text type="secondary" style={{ fontSize: 11 }}>
                 {t('apiDebug.desc.default')}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import type { ParameterObject, RequestBodyObject, ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
 import { OperationModeLayout, useCurrentOperation } from './useCurrentOperation';
+import DescriptionText from '../../components/DescriptionText';
 import Markdown from '../../components/Markdown';
 import { copyToClipboard } from '../../utils/clipboard';
 import SchemaFieldTable, { SchemaTypeLink } from '../../components/schema/SchemaFieldTable';
@@ -321,12 +322,12 @@ export default function ApiDoc() {
       dataIndex: 'description',
       render: (value: string, record: ParamRow) => (
         <Space size={4} direction="vertical" style={{ width: '100%' }}>
-          {value ? <span>{value}</span> : <Text type="secondary">-</Text>}
+          {value ? <DescriptionText>{value}</DescriptionText> : <Text type="secondary">-</Text>}
           {record.refDescription && record.refDescription !== value && (
-            <Text type="secondary" style={{ fontSize: 12 }}>
+            <DescriptionText type="secondary" style={{ fontSize: 12 }}>
               {record.refTitle ? `[${record.refTitle}] ` : ''}
               {record.refDescription}
-            </Text>
+            </DescriptionText>
           )}
         </Space>
       ),
@@ -435,7 +436,7 @@ export default function ApiDoc() {
           </Space>
         )}
       </div>
-      {op.description && <Markdown source={op.description} />}
+      {op.description && <Markdown source={op.description} preserveLineBreaks />}
 
       {relatedModelNames.length > 0 && (
         <Space size={6} wrap style={{ marginTop: 4, marginBottom: 8 }}>
@@ -532,9 +533,9 @@ export default function ApiDoc() {
                         <Space size={8} style={{ marginBottom: 6 }}>
                           <Tag color={color}>{row.statusCode}</Tag>
                           {row.description && (
-                            <Text type="secondary" style={{ fontSize: 13 }}>
+                            <DescriptionText type="secondary" style={{ fontSize: 13 }}>
                               {row.description}
-                            </Text>
+                            </DescriptionText>
                           )}
                           {row.schema && <SchemaTypeLink node={schemaToTypeNode(row.schema)} />}
                         </Space>

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ResponsePanel.tsx
@@ -176,7 +176,7 @@ const jsonDescStyle: React.CSSProperties = {
   paddingLeft: 12,
   minHeight: '1.55em',
   lineHeight: 1.55,
-  whiteSpace: 'normal',
+  whiteSpace: 'pre-wrap',
   overflowWrap: 'break-word',
   minWidth: 0,
 };

--- a/knife4j-front/knife4j-ui-react/src/utils/markdown.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/markdown.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMarkdown } from './markdown';
+
+describe('parseMarkdown', () => {
+  it('preserves explicit line breaks when requested', () => {
+    expect(parseMarkdown('第一行\n第二行', { preserveLineBreaks: true })).toContain('<br');
+  });
+
+  it('keeps default Markdown soft line break behavior', () => {
+    expect(parseMarkdown('第一行\n第二行')).not.toContain('<br');
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/utils/markdown.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/markdown.ts
@@ -1,0 +1,10 @@
+import { marked } from 'marked';
+
+export interface MarkdownRenderOptions {
+  preserveLineBreaks?: boolean;
+}
+
+export function parseMarkdown(source: string, options: MarkdownRenderOptions = {}): string {
+  if (!source) return '';
+  return marked.parse(source, { async: false, breaks: options.preserveLineBreaks ?? false }) as string;
+}


### PR DESCRIPTION
## 关联 Issue
- Closes #490

## 变更内容
- 新增 `DescriptionText`，用于纯文本说明字段，保留 `\n` 换行并保持长文本自动换行。
- 新增 `parseMarkdown(..., { preserveLineBreaks })`，仅在描述类 Markdown 展示处把软换行渲染为换行；普通 Markdown 默认行为保持不变。
- 覆盖 OpenAPI 3 React UI 中的首页描述、server/tag 描述、接口文档参数与响应描述、模型字段描述、调试页参数/表单字段描述和响应 JSON schema 描述。

## Worker Handoff
- worker 修改范围限定在 `knife4j-front/knife4j-ui-react`，未触碰 `knife4j-vue3` 或 Java starter。
- worker 初次验证曾遇到 format/lint 问题，已通过 Prettier 和组件导出调整修复。

## Reviewer Handoff
- 首轮 reviewer 发现新增文件仍为 untracked，存在 PR 漏文件风险，结论为 `revise`。
- coordinator 显式 stage 本次 11 个目标文件后复跑验证。
- 复审 reviewer 确认新增文件已纳入 staged diff、无未暂存/未跟踪目标文件、无范围漂移，结论为 `approve`。

## 验证
- `git diff --cached --check`：通过。
- `./scripts/test-front-core.sh`：通过。
  - `knife4j-core`：15 suites / 192 tests passed，format/lint/build 通过。
  - `knife4j-ui-react`：18 test files / 80 tests passed，format/build/lint 通过。

## 已知风险与范围外事项
- 未做浏览器视觉截图；本次依赖单元测试、格式检查、类型构建、生产构建和 lint 验证。
- 本 PR 不实现“表格扩展数据”能力，只处理描述文本换行展示。
- 本 PR 不改变 OAS2 `knife4j-vue3` 行为，也不修改 Java starter。