### PR TITLE
chore: 升级 GitHub Actions 至 Node 24 运行时

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,20 +49,20 @@ jobs:
         working-directory: .
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify release module list
         run: scripts/verify-release-modules.sh
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
           cache: maven
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
@@ -128,10 +128,10 @@ jobs:
         working-directory: .
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
@@ -148,7 +148,7 @@ jobs:
         working-directory: .
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -39,16 +39,16 @@ jobs:
             image: knife4j-next-demo-openapi2
             context: knife4j/knife4j-demo-openapi2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
@@ -68,7 +68,7 @@ jobs:
         run: mvn -B -ntp -pl ${{ matrix.module }} -am package -DskipTests
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -76,7 +76,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image }}
           tags: |
@@ -84,7 +84,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,14 @@ jobs:
         working-directory: knife4j
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify release module list
         run: scripts/verify-release-modules.sh
         working-directory: .
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -43,7 +43,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 


### PR DESCRIPTION
## 背景

- 处理 GitHub Actions Node.js 20 退役警告：`actions/checkout@v4`、`actions/setup-java@v4`、`actions/setup-node@v4`、`docker/login-action@v3`、`docker/metadata-action@v5`、`docker/build-push-action@v6` 已被 runner 强制以 Node.js 24 运行。
- 无对应 issue；这是维护者现场指出的 repo/CI 维护任务。
- 参考官方公告：https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## 变更内容

- 将 `.github/workflows/release.yml` 中的 `checkout`、`setup-java`、`setup-node` 升级到声明 `runs.using: node24` 的主版本。
- 将 `.github/workflows/deploy-demo.yml` 中的 `checkout`、`setup-java`、`setup-node` 以及 Docker 登录、metadata、build/push action 升级到 Node 24 主版本。
- 将 `.github/workflows/build.yml` 中的 `checkout`、`setup-java`、`setup-node` 升级到 Node 24 主版本。
- 不修改 workflow 触发条件、权限、secret、发布命令或构建命令。

## 协作门禁

- Worker：已跳过。原因是当前 Codex 运行时的 sub-agent 工具策略只允许在用户显式要求派子 agent 时启动；本次为维护者现场指定的最小 workflow 版本号维护。
- Reviewer：未启动独立 reviewer。本 PR 需要维护者或 GitHub PR review 覆盖 action 主版本升级兼容性；不会把这次改动叙述为已独立审查完成。

## 验证

- `rg -n "actions/(checkout|setup-java|setup-node)@v4|docker/(login-action@v3|metadata-action@v5|build-push-action@v6)" .github/workflows`：无匹配。
- `git diff --check`：通过。
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/build.yml .github/workflows/deploy-demo.yml .github/workflows/release.yml`：三份 workflow 均可解析。
- 已用 GitHub/Docker 官方 raw `action.yml` 核对目标 tag：`actions/checkout@v7`、`actions/setup-java@v5`、`actions/setup-node@v6`、`docker/login-action@v4`、`docker/metadata-action@v6`、`docker/build-push-action@v7` 均声明 `runs.using: node24`。

## 风险

- 本机没有 `actionlint`，未运行 actionlint 静态检查。
- 仍需 PR CI 在 GitHub runner 上验证实际 workflow 兼容性。
