### PR TITLE
修复调试页清空枚举参数后的表格布局错乱

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -83,9 +83,11 @@ import {
   type ParamValueMap,
   type SchemaFieldRow,
 } from './debugDefaultValues';
+import { API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS, apiDebugParamTableScrollX } from './apiDebugParamTableLayout';
 
 const { TextArea } = Input;
 const { Text, Title } = Typography;
+const PARAM_TABLE_SCROLL = { x: apiDebugParamTableScrollX() };
 
 const METHOD_COLORS: Record<string, string> = {
   GET: 'green',
@@ -562,10 +564,10 @@ function ParamInput({ param, value, onChange, hasError }: ParamInputProps) {
       <Select
         size="small"
         value={value || undefined}
-        onChange={onChange}
+        onChange={(next) => onChange(next ?? '')}
         allowClear
         status={status}
-        placeholder={param.description ?? t('apiDebug.enum.placeholder')}
+        placeholder={t('apiDebug.enum.placeholder')}
         options={param.enum.map((item) => ({
           value: String(item),
           label: String(item),
@@ -1800,7 +1802,7 @@ export default function ApiDebug() {
       {
         title: t('apiDebug.col.enabled'),
         key: 'enabled',
-        width: 48,
+        width: API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS.enabled,
         render: (_value: unknown, record: DebugParam) => (
           <Checkbox
             checked={paramEnabled[paramKey(record)] !== false}
@@ -1817,14 +1819,14 @@ export default function ApiDebug() {
         title: t('apiDebug.col.paramName'),
         dataIndex: 'name',
         key: 'name',
-        width: 220,
+        width: API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS.paramName,
         render: (_value: string, record: DebugParam) => <ParamNameCell param={record} />,
       },
       {
         title: t('apiDebug.col.type'),
         dataIndex: 'type',
         key: 'type',
-        width: 110,
+        width: API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS.type,
         render: (_value: string, record: DebugParam) => (
           <Space size={2} direction="vertical" style={{ lineHeight: 1.3 }}>
             <Text code style={{ fontSize: 12 }}>
@@ -1842,6 +1844,7 @@ export default function ApiDebug() {
         title: t('apiDebug.col.value'),
         dataIndex: 'value',
         key: 'value',
+        width: API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS.value,
         render: (_value: string, record: DebugParam) => (
           <ParamInput
             param={record}
@@ -1854,7 +1857,7 @@ export default function ApiDebug() {
       {
         title: t('apiDebug.col.description'),
         key: 'description',
-        width: 280,
+        width: API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS.description,
         render: (_value, record: DebugParam) => (
           <Space size={2} direction="vertical" style={{ lineHeight: 1.35, fontSize: 12 }}>
             {record.description && <DescriptionText style={{ fontSize: 12 }}>{record.description}</DescriptionText>}
@@ -2288,6 +2291,8 @@ export default function ApiDebug() {
           columns={paramColumns}
           pagination={false}
           rowKey={paramKey}
+          tableLayout="fixed"
+          scroll={PARAM_TABLE_SCROLL}
           locale={{ emptyText: t('apiDebug.noPathParams') }}
         />
       ),
@@ -2306,6 +2311,8 @@ export default function ApiDebug() {
             columns={paramColumns}
             pagination={false}
             rowKey={paramKey}
+            tableLayout="fixed"
+            scroll={PARAM_TABLE_SCROLL}
             locale={{ emptyText: t('apiDebug.noQueryParams') }}
           />
           <CustomParamsSection
@@ -2333,6 +2340,8 @@ export default function ApiDebug() {
             columns={paramColumns}
             pagination={false}
             rowKey={paramKey}
+            tableLayout="fixed"
+            scroll={PARAM_TABLE_SCROLL}
             locale={{
               emptyText:
                 debugModel.bodyContents.length > 0 ? t('apiDebug.header.autoInject') : t('apiDebug.noHeaderParams'),
@@ -2364,6 +2373,8 @@ export default function ApiDebug() {
             columns={paramColumns}
             pagination={false}
             rowKey={paramKey}
+            tableLayout="fixed"
+            scroll={PARAM_TABLE_SCROLL}
             locale={{ emptyText: t('apiDebug.noCookieParams') }}
           />
           <CustomParamsSection

--- a/knife4j-front/knife4j-ui-react/src/pages/api/apiDebugParamTableLayout.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/apiDebugParamTableLayout.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS, apiDebugParamTableScrollX } from './apiDebugParamTableLayout';
+
+describe('apiDebugParamTableLayout', () => {
+  it('keeps value and description columns wide enough after enum selects are cleared', () => {
+    expect(API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS).toEqual({
+      enabled: 56,
+      paramName: 220,
+      type: 110,
+      value: 320,
+      description: 320,
+    });
+    expect(apiDebugParamTableScrollX()).toBe(1026);
+  });
+
+  it('uses the current column widths for horizontal scrolling', () => {
+    expect(
+      apiDebugParamTableScrollX({
+        enabled: 56,
+        paramName: 240,
+        type: 120,
+        value: 360,
+        description: 360,
+      }),
+    ).toBe(1136);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/apiDebugParamTableLayout.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/apiDebugParamTableLayout.ts
@@ -1,0 +1,20 @@
+const PARAM_TABLE_MIN_SCROLL_WIDTH = 1024;
+
+export type ApiDebugParamTableColumnKey = 'enabled' | 'paramName' | 'type' | 'value' | 'description';
+
+export type ApiDebugParamTableColumnWidths = Record<ApiDebugParamTableColumnKey, number>;
+
+export const API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS: ApiDebugParamTableColumnWidths = {
+  enabled: 56,
+  paramName: 220,
+  type: 110,
+  value: 320,
+  description: 320,
+};
+
+export function apiDebugParamTableScrollX(widths = API_DEBUG_PARAM_TABLE_COLUMN_WIDTHS): number {
+  return Math.max(
+    PARAM_TABLE_MIN_SCROLL_WIDTH,
+    widths.enabled + widths.paramName + widths.type + widths.value + widths.description,
+  );
+}


### PR DESCRIPTION
## 关联 Issue

Fixes #496

## 变更内容

- 为调试页 path/query/header/cookie 参数表统一固定列宽、`tableLayout="fixed"` 和横向滚动宽度，避免 enum 下拉框清空后触发表格自动布局压缩。
- enum 参数 Select 清空时写回空字符串，保持“空值不发送参数”的调试语义。
- enum 参数清空后的占位文案使用通用“选择一个枚举值”，避免把完整参数说明重复显示在“值”列。
- 新增 `apiDebugParamTableLayout` 窄测试，锁定参数表列宽与滚动宽度。

## Worker / Reviewer

- Worker：已完成 `ApiDebug.tsx`、`apiDebugParamTableLayout.ts` 和测试的窄范围实现。
- Reviewer：独立 reviewer 已审查当前 diff，结论 `approve`，无发现项。

## 验证

- `bun test src/pages/api/apiDebugParamTableLayout.test.ts` 通过。
- `./scripts/test-front-core.sh` 通过。
- 浏览器复现：使用 issue 附件 `demo-business.json` 本地 mock `POST /demo/enum/test/post`，清空 `httpCode` 后宽桌面列宽保持约 `56/221/111/322/322`，`scrollWidth=1032`，说明列正常横排。

## 风险

- 改动限定在 React UI 调试页参数表布局，不触碰 Java starter、文档、发布或 OpenAPI 解析逻辑。
- 窄窗口会保留横向滚动，优先保证列宽稳定而不是压缩说明列。