### PR TITLE
修复 HTTPS 服务地址端口显示

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/Home.tsx
@@ -21,6 +21,7 @@ import Markdown from '../components/Markdown';
 import type { SwaggerServer } from '../types/swagger';
 import { getCustomHomeMarkdown } from '../utils/knife4jSettings';
 import knife4jMark from '../assets/logo/knife4j-next-mark.svg';
+import { currentHomeOrigin, normalizeHomeHost, resolveHomeHostLabel, resolveHomeServers } from './homeServerInfo';
 import { buildHomeStats, HOME_HTTP_METHODS, type HomeHttpMethod } from './homeStats';
 
 const { Title, Text, Paragraph, Link } = Typography;
@@ -80,21 +81,9 @@ export default function Home() {
   const { settings } = useSettings();
   const { token } = theme.useToken();
   const customHomeMarkdown = getCustomHomeMarkdown(settings);
+  const pageOrigin = currentHomeOrigin();
 
-  // Servers: prefer OAS3 servers, fall back to OAS2 host/basePath/schemes
-  const servers = useMemo<SwaggerServer[]>(() => {
-    if (!swaggerDoc) return [];
-    if (swaggerDoc.servers && swaggerDoc.servers.length > 0) {
-      return swaggerDoc.servers;
-    }
-    if (swaggerDoc.host) {
-      const schemes = swaggerDoc.schemes && swaggerDoc.schemes.length > 0 ? swaggerDoc.schemes : ['http'];
-      return schemes.map((scheme) => ({
-        url: `${scheme}://${swaggerDoc.host}${swaggerDoc.basePath ?? ''}`,
-      }));
-    }
-    return [];
-  }, [swaggerDoc]);
+  const servers = useMemo<SwaggerServer[]>(() => resolveHomeServers(swaggerDoc, pageOrigin), [pageOrigin, swaggerDoc]);
 
   const stats = useMemo(() => buildHomeStats(swaggerDoc, menuTags), [swaggerDoc, menuTags]);
 
@@ -128,18 +117,8 @@ export default function Home() {
       : 'OpenAPI';
 
   const versionLabel = info.version ? (/^v/i.test(info.version) ? info.version : `v${info.version}`) : '-';
-  const primaryServerUrl = servers[0]?.url;
-  const hostLabel =
-    swaggerDoc.host ||
-    (() => {
-      if (!primaryServerUrl) return '-';
-      try {
-        const parsed = new URL(primaryServerUrl, window.location.origin);
-        return parsed.host || primaryServerUrl;
-      } catch {
-        return primaryServerUrl;
-      }
-    })();
+  const hostLabel = resolveHomeHostLabel(swaggerDoc, servers, pageOrigin);
+  const sourceHost = normalizeHomeHost(swaggerDoc.host, pageOrigin);
 
   const securitySchemes = swaggerDoc.components?.securitySchemes ?? swaggerDoc.securityDefinitions ?? {};
   const securitySchemeCount = Object.keys(securitySchemes).length;
@@ -181,7 +160,7 @@ export default function Home() {
       value: activeSwaggerGroup?.location,
       icon: <CloudServerOutlined />,
     },
-    { key: 'host', label: 'home.meta.host', value: swaggerDoc.host, icon: <CloudServerOutlined /> },
+    { key: 'host', label: 'home.meta.host', value: sourceHost, icon: <CloudServerOutlined /> },
     { key: 'basePath', label: 'home.meta.basePath', value: swaggerDoc.basePath, icon: <LinkOutlined /> },
   ].flatMap((row) => (typeof row.value === 'string' && row.value.length > 0 ? [{ ...row, value: row.value }] : []));
   const hasSourceInfo = sourceRows.length > 0;

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
@@ -81,6 +81,37 @@ describe('request base URL resolution', () => {
     ).toBe('https://mini.xxx.com:27000');
   });
 
+  it('preserves explicit same-host server ports while upgrading to the HTTPS origin protocol', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://mini.xxx.com:18080/api']),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'https://mini.xxx.com:27000',
+      }),
+    ).toBe('https://mini.xxx.com:18080/api');
+  });
+
+  it('does not replace explicit same-host default ports with the HTTPS origin port', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://mini.xxx.com:443/api']),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'https://mini.xxx.com:27000',
+      }),
+    ).toBe('https://mini.xxx.com/api');
+
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['https://mini.xxx.com:443/api']),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'https://mini.xxx.com:27000',
+      }),
+    ).toBe('https://mini.xxx.com/api');
+  });
+
   it('keeps cross-host OpenAPI server URLs on their declared protocol', () => {
     expect(
       resolveRequestBaseUrl({

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.test.ts
@@ -70,6 +70,17 @@ describe('request base URL resolution', () => {
     ).toBe('https://api.example.test/api');
   });
 
+  it('keeps the HTTPS origin port for same-host generated server URLs when the server URL omits a port', () => {
+    expect(
+      resolveRequestBaseUrl({
+        swaggerDoc: docWithServers(['http://mini.xxx.com']),
+        enableHost: false,
+        enableHostText: '',
+        origin: 'https://mini.xxx.com:27000',
+      }),
+    ).toBe('https://mini.xxx.com:27000');
+  });
+
   it('keeps cross-host OpenAPI server URLs on their declared protocol', () => {
     expect(
       resolveRequestBaseUrl({

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
@@ -29,11 +29,32 @@ function trimTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
-function alignSameHostWithHttpsOrigin(url: URL, origin: URL): void {
+function explicitPortFromAuthority(authority: string): string | undefined {
+  const hostPort = authority.slice(authority.lastIndexOf('@') + 1);
+  const ipv6PortMatch = /^\[[^\]]+\]:(\d+)$/.exec(hostPort);
+  if (ipv6PortMatch) return ipv6PortMatch[1];
+  if (hostPort.startsWith('[')) return undefined;
+
+  return /:(\d+)$/.exec(hostPort)?.[1];
+}
+
+function explicitPortFromUrlText(url: string): string | undefined {
+  const absoluteAuthority = /^[a-z][a-z\d+\-.]*:\/\/([^/?#]*)/i.exec(url)?.[1];
+  const protocolRelativeAuthority = /^\/\/([^/?#]*)/.exec(url)?.[1];
+  const authority = absoluteAuthority ?? protocolRelativeAuthority;
+
+  return authority ? explicitPortFromAuthority(authority) : undefined;
+}
+
+function alignSameHostWithHttpsOrigin(url: URL, origin: URL, explicitPort: string | undefined): void {
   if (origin.protocol !== 'https:' || url.hostname !== origin.hostname) return;
 
   if (url.protocol === 'http:') {
     url.protocol = origin.protocol;
+  }
+  if (explicitPort) {
+    url.port = explicitPort;
+    return;
   }
   if (origin.port && !url.port) {
     url.port = origin.port;
@@ -52,7 +73,7 @@ export function normalizeRequestBaseUrl(
     const originUrl = new URL(`${origin.replace(/\/+$/, '')}/`);
     const requestUrl = new URL(trimmed, originUrl);
     if (options.preferHttpsOriginForSameHost) {
-      alignSameHostWithHttpsOrigin(requestUrl, originUrl);
+      alignSameHostWithHttpsOrigin(requestUrl, originUrl, explicitPortFromUrlText(trimmed));
     }
     return trimTrailingSlashes(requestUrl.toString());
   } catch {

--- a/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/requestBaseUrl.ts
@@ -17,8 +17,8 @@ export interface RequestServerOption {
   description?: string;
 }
 
-interface NormalizeRequestBaseUrlOptions {
-  upgradeSameHostHttpToHttps?: boolean;
+export interface NormalizeRequestBaseUrlOptions {
+  preferHttpsOriginForSameHost?: boolean;
 }
 
 export function currentOrigin(): string {
@@ -29,8 +29,15 @@ function trimTrailingSlashes(url: string): string {
   return url.replace(/\/+$/, '');
 }
 
-function shouldUpgradeSameHostHttpUrl(url: URL, origin: URL): boolean {
-  return origin.protocol === 'https:' && url.protocol === 'http:' && url.hostname === origin.hostname;
+function alignSameHostWithHttpsOrigin(url: URL, origin: URL): void {
+  if (origin.protocol !== 'https:' || url.hostname !== origin.hostname) return;
+
+  if (url.protocol === 'http:') {
+    url.protocol = origin.protocol;
+  }
+  if (origin.port && !url.port) {
+    url.port = origin.port;
+  }
 }
 
 export function normalizeRequestBaseUrl(
@@ -44,8 +51,8 @@ export function normalizeRequestBaseUrl(
   try {
     const originUrl = new URL(`${origin.replace(/\/+$/, '')}/`);
     const requestUrl = new URL(trimmed, originUrl);
-    if (options.upgradeSameHostHttpToHttps && shouldUpgradeSameHostHttpUrl(requestUrl, originUrl)) {
-      requestUrl.protocol = originUrl.protocol;
+    if (options.preferHttpsOriginForSameHost) {
+      alignSameHostWithHttpsOrigin(requestUrl, originUrl);
     }
     return trimTrailingSlashes(requestUrl.toString());
   } catch {
@@ -67,7 +74,7 @@ function appendServerOptions(
     if (!rawUrl) continue;
 
     const url = normalizeRequestBaseUrl(rawUrl, origin, {
-      upgradeSameHostHttpToHttps: true,
+      preferHttpsOriginForSameHost: true,
     });
     if (seen.has(url)) continue;
 

--- a/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { SwaggerDoc } from '../types/swagger';
+import { normalizeHomeHost, resolveHomeHostLabel, resolveHomeServers } from './homeServerInfo';
+
+function docWithServers(urls: Array<{ url: string; description?: string }>): SwaggerDoc {
+  return {
+    openapi: '3.0.1',
+    info: { title: 'test', version: '1.0.0' },
+    paths: {},
+    servers: urls,
+  };
+}
+
+describe('home server info', () => {
+  it('keeps the HTTPS origin protocol and port for same-host generated server URLs', () => {
+    const origin = 'https://mini.xxx.com:27000';
+    const swaggerDoc = docWithServers([{ url: 'http://mini.xxx.com', description: 'Generated server url' }]);
+
+    const servers = resolveHomeServers(swaggerDoc, origin);
+
+    expect(servers).toEqual([{ url: 'https://mini.xxx.com:27000', description: 'Generated server url' }]);
+    expect(resolveHomeHostLabel(swaggerDoc, servers, origin)).toBe('mini.xxx.com:27000');
+  });
+
+  it('preserves explicit same-host server ports while upgrading protocol', () => {
+    const servers = resolveHomeServers(
+      docWithServers([{ url: 'http://mini.xxx.com:18080/api' }]),
+      'https://mini.xxx.com:27000',
+    );
+
+    expect(servers[0].url).toBe('https://mini.xxx.com:18080/api');
+  });
+
+  it('keeps cross-host server URLs unchanged', () => {
+    const servers = resolveHomeServers(docWithServers([{ url: 'http://api.xxx.com' }]), 'https://mini.xxx.com:27000');
+
+    expect(servers[0].url).toBe('http://api.xxx.com');
+    expect(resolveHomeHostLabel(null, servers, 'https://mini.xxx.com:27000')).toBe('api.xxx.com');
+  });
+
+  it('adds the HTTPS origin port to same-host legacy Host labels when the port is missing', () => {
+    expect(normalizeHomeHost('mini.xxx.com', 'https://mini.xxx.com:27000')).toBe('mini.xxx.com:27000');
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.test.ts
@@ -31,6 +31,15 @@ describe('home server info', () => {
     expect(servers[0].url).toBe('https://mini.xxx.com:18080/api');
   });
 
+  it('does not replace explicit same-host default server ports with the HTTPS origin port', () => {
+    const servers = resolveHomeServers(
+      docWithServers([{ url: 'http://mini.xxx.com:443/api' }, { url: 'https://mini.xxx.com:443/api' }]),
+      'https://mini.xxx.com:27000',
+    );
+
+    expect(servers.map((server) => server.url)).toEqual(['https://mini.xxx.com/api', 'https://mini.xxx.com/api']);
+  });
+
   it('keeps cross-host server URLs unchanged', () => {
     const servers = resolveHomeServers(docWithServers([{ url: 'http://api.xxx.com' }]), 'https://mini.xxx.com:27000');
 
@@ -40,5 +49,9 @@ describe('home server info', () => {
 
   it('adds the HTTPS origin port to same-host legacy Host labels when the port is missing', () => {
     expect(normalizeHomeHost('mini.xxx.com', 'https://mini.xxx.com:27000')).toBe('mini.xxx.com:27000');
+  });
+
+  it('keeps explicit same-host default legacy Host label ports', () => {
+    expect(normalizeHomeHost('mini.xxx.com:443', 'https://mini.xxx.com:27000')).toBe('mini.xxx.com:443');
   });
 });

--- a/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.ts
@@ -13,6 +13,18 @@ function normalizeHomeServerUrl(url: string, origin: string): string {
   });
 }
 
+function explicitPortFromHostText(host: string): string | undefined {
+  const absoluteAuthority = /^[a-z][a-z\d+\-.]*:\/\/([^/?#]*)/i.exec(host)?.[1];
+  const protocolRelativeAuthority = /^\/\/([^/?#]*)/.exec(host)?.[1];
+  const authority = absoluteAuthority ?? protocolRelativeAuthority ?? host.split(/[/?#]/)[0];
+  const hostPort = authority.slice(authority.lastIndexOf('@') + 1);
+  const ipv6PortMatch = /^\[[^\]]+\]:(\d+)$/.exec(hostPort);
+  if (ipv6PortMatch) return ipv6PortMatch[1];
+  if (hostPort.startsWith('[')) return undefined;
+
+  return /:(\d+)$/.exec(hostPort)?.[1];
+}
+
 export function normalizeHomeHost(host: string | undefined, origin: string): string | undefined {
   const trimmed = host?.trim();
   if (!trimmed) return undefined;
@@ -20,7 +32,13 @@ export function normalizeHomeHost(host: string | undefined, origin: string): str
   try {
     const originUrl = new URL(`${origin.replace(/\/+$/, '')}/`);
     const hostUrl = new URL(trimmed.includes('://') ? trimmed : `${originUrl.protocol}//${trimmed}`);
-    if (originUrl.protocol === 'https:' && hostUrl.hostname === originUrl.hostname && originUrl.port && !hostUrl.port) {
+    if (
+      originUrl.protocol === 'https:' &&
+      hostUrl.hostname === originUrl.hostname &&
+      originUrl.port &&
+      !hostUrl.port &&
+      !explicitPortFromHostText(trimmed)
+    ) {
       hostUrl.port = originUrl.port;
       return hostUrl.host;
     }

--- a/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/homeServerInfo.ts
@@ -1,0 +1,74 @@
+import type { SwaggerDoc, SwaggerServer } from '../types/swagger';
+import { currentOrigin, normalizeRequestBaseUrl } from './api/requestBaseUrl';
+
+export function currentHomeOrigin(): string {
+  return currentOrigin();
+}
+
+function normalizeHomeServerUrl(url: string, origin: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) return url;
+  return normalizeRequestBaseUrl(trimmed, origin, {
+    preferHttpsOriginForSameHost: true,
+  });
+}
+
+export function normalizeHomeHost(host: string | undefined, origin: string): string | undefined {
+  const trimmed = host?.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const originUrl = new URL(`${origin.replace(/\/+$/, '')}/`);
+    const hostUrl = new URL(trimmed.includes('://') ? trimmed : `${originUrl.protocol}//${trimmed}`);
+    if (originUrl.protocol === 'https:' && hostUrl.hostname === originUrl.hostname && originUrl.port && !hostUrl.port) {
+      hostUrl.port = originUrl.port;
+      return hostUrl.host;
+    }
+  } catch {
+    // Keep the original host text when it is not URL-like.
+  }
+
+  return trimmed;
+}
+
+function legacySwaggerServers(swaggerDoc: SwaggerDoc): SwaggerServer[] {
+  if (!swaggerDoc.host) return [];
+  const schemes = swaggerDoc.schemes && swaggerDoc.schemes.length > 0 ? swaggerDoc.schemes : ['http'];
+  return schemes.map((scheme) => ({
+    url: `${scheme}://${swaggerDoc.host}${swaggerDoc.basePath ?? ''}`,
+  }));
+}
+
+export function resolveHomeServers(
+  swaggerDoc: SwaggerDoc | null | undefined,
+  origin: string = currentHomeOrigin(),
+): SwaggerServer[] {
+  if (!swaggerDoc) return [];
+
+  const sourceServers =
+    swaggerDoc.servers && swaggerDoc.servers.length > 0 ? swaggerDoc.servers : legacySwaggerServers(swaggerDoc);
+
+  return sourceServers.map((server) => ({
+    ...server,
+    url: normalizeHomeServerUrl(server.url, origin),
+  }));
+}
+
+export function resolveHomeHostLabel(
+  swaggerDoc: SwaggerDoc | null | undefined,
+  servers: SwaggerServer[],
+  origin: string = currentHomeOrigin(),
+): string {
+  const explicitHost = normalizeHomeHost(swaggerDoc?.host, origin);
+  if (explicitHost) return explicitHost;
+
+  const primaryServerUrl = servers[0]?.url;
+  if (!primaryServerUrl) return '-';
+
+  try {
+    const parsed = new URL(primaryServerUrl, origin);
+    return parsed.host || primaryServerUrl;
+  } catch {
+    return primaryServerUrl;
+  }
+}


### PR DESCRIPTION
## 关联 Issue

Closes #497

## 变更内容

- 抽出 Home 服务地址归一化逻辑，统一处理 Home 卡片 Host 与「服务地址」列表展示。
- HTTPS 页面访问同主机 server URL 时，保留页面 origin 的协议与非标准端口，避免 `https://mini.xxx.com:27000` 被显示为 `http://mini.xxx.com`。
- 同步补强调试请求 BaseURL 的同主机 HTTPS 端口保留逻辑；显式 Host override 仍保持原协议和优先级。
- 增加 `homeServerInfo` 与 `requestBaseUrl` 回归测试，覆盖同主机、显式端口、跨主机和 Host override 边界。

## Worker Handoff

- worker：实现 React UI Home 服务地址归一化和定向测试。
- 结果：`https://mini.xxx.com:27000` 访问时，`http://mini.xxx.com` 会归一化为 `https://mini.xxx.com:27000`；Home Host 显示 `mini.xxx.com:27000`。
- 风险：未做真实 HTTPS 反向代理浏览器复现；当前证据为纯函数回归测试和完整前端门禁。

## Reviewer Handoff

- reviewer：独立审查当前 diff。
- 结论：approve，未发现返工项。
- 覆盖：确认 #497 场景、显式端口、跨主机 server、相对 server URL、显式 Host override 均未见回归。

## 验证

- `bun --filter knife4j-ui-react test src/pages/homeServerInfo.test.ts src/pages/api/requestBaseUrl.test.ts --run`：通过，2 files / 18 tests。
- `./scripts/test-front-core.sh`：通过，`knife4j-core` 15 suites / 192 tests，`knife4j-ui-react` 20 files / 88 tests，format/build/lint 均通过。
- `git diff --cached --check`：通过。

说明：`./scripts/test-front-core.sh` 在 sandbox 内首次因 Bun tempdir `AccessDenied` 失败；使用提升权限重跑同一命令后通过，判断为本机 sandbox 临时目录权限问题。