### PR TITLE
支持 React 过滤多方法接口配置

### DIFF
--- a/docs-site/guide/faq.md
+++ b/docs-site/guide/faq.md
@@ -175,6 +175,7 @@ connect-src 'self';
 - `knife4j.setting.enable-footer-custom` / `footer-custom-content`
 - `knife4j.setting.enable-request-cache`
 - `knife4j.setting.enable-home-custom` / `home-custom-location`
+- `knife4j.setting.enable-filter-multipart-apis` / `enable-filter-multipart-api-method-type`
 
 用户在 React 设置面板里的本地选择会覆盖后端默认值。自定义首页只消费后端注入到 `homeCustomLocation` 的 Markdown 内容；React 不会读取 `homeCustomPath` 文件路径。注意：`enable-debug=false` 只是隐藏调试入口，不是安全控制；线上屏蔽请使用 `knife4j.production`、`knife4j.basic` 或外层安全框架。
 
@@ -184,7 +185,6 @@ connect-src 'self';
 - `knife4j.setting.enable-after-script`
 - `knife4j.setting.enable-reload-cache-parameter`
 - `knife4j.setting.enable-dynamic-parameter`
-- `knife4j.setting.enable-filter-multipart-apis`
 - `knife4j.setting.enable-response-code`
 
 原因：这些字段对应的 Vue 版能力尚未在 React 新前端里实现，或还没有接到实际行为上。后端 `ProductionSecurityFilter`、`knife4j.basic`、`knife4j.documents` 等服务端侧能力不受影响。

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -75,8 +75,8 @@ public OpenAPI customOpenAPI() {
 | `knife4j.setting.enableAfterScript` | `boolean` | `true` | 显示 afterScript 功能 | ⚠️ |
 | `knife4j.setting.enableVersion` | `boolean` | `false` | 启用接口版本控制 | ⚠️ |
 | `knife4j.setting.enableRequestCache` | `boolean` | `true` | 启用请求参数缓存 | ✅ |
-| `knife4j.setting.enableFilterMultipartApis` | `boolean` | `false` | 过滤 RequestMapping 多方法显示 | ⚠️ |
-| `knife4j.setting.enableFilterMultipartApiMethodType` | `String` | `"POST"` | 过滤方法类型 | ⚠️ |
+| `knife4j.setting.enableFilterMultipartApis` | `boolean` | `false` | 过滤 RequestMapping 多方法显示 | ✅ |
+| `knife4j.setting.enableFilterMultipartApiMethodType` | `String` | `"POST"` | 过滤方法类型 | ✅ |
 | `knife4j.setting.enableHost` | `boolean` | `false` | 启用 Host | ✅ |
 | `knife4j.setting.enableHostText` | `String` | `""` | Host 地址 | ✅ |
 | `knife4j.setting.enableDynamicParameter` | `boolean` | `false` | 启用动态请求参数 | ⚠️ |

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.test.ts
@@ -237,6 +237,78 @@ describe('knife4jClient', () => {
     expect(menuTags[0].operations.map((operation) => operation.operationId)).toEqual(['listUsers', 'createUser']);
   });
 
+  it('filters same-path multi-method operations to the configured method', () => {
+    const doc: SwaggerDoc = {
+      openapi: '3.0.1',
+      info: { title: 'demo', version: '1.0.0' },
+      tags: [{ name: 'files' }],
+      paths: {
+        '/files/upload': {
+          get: {
+            tags: ['files'],
+            summary: 'Read upload endpoint',
+            operationId: 'readUpload',
+          },
+          post: {
+            tags: ['files'],
+            summary: 'Upload file',
+            operationId: 'uploadFile',
+          },
+          put: {
+            tags: ['files'],
+            summary: 'Replace upload',
+            operationId: 'replaceUpload',
+          },
+        },
+        '/files/status': {
+          get: {
+            tags: ['files'],
+            summary: 'Upload status',
+            operationId: 'uploadStatus',
+          },
+        },
+      },
+    };
+
+    const menuTags = parseMenuTags(doc, {
+      filterMultipartApis: true,
+      filterMultipartApiMethodType: 'POST',
+    });
+
+    expect(menuTags[0].operations.map((operation) => operation.operationId)).toEqual(['uploadFile', 'uploadStatus']);
+    expect(menuTags[0].operations.map((operation) => operation.method)).toEqual(['post', 'get']);
+  });
+
+  it('falls back to the first same-path operation when the configured filter method is absent', () => {
+    const doc: SwaggerDoc = {
+      openapi: '3.0.1',
+      info: { title: 'demo', version: '1.0.0' },
+      tags: [{ name: 'files' }],
+      paths: {
+        '/files/upload': {
+          get: {
+            tags: ['files'],
+            summary: 'Read upload endpoint',
+            operationId: 'readUpload',
+          },
+          put: {
+            tags: ['files'],
+            summary: 'Replace upload',
+            operationId: 'replaceUpload',
+          },
+        },
+      },
+    };
+
+    const menuTags = parseMenuTags(doc, {
+      filterMultipartApis: true,
+      filterMultipartApiMethodType: 'POST',
+    });
+
+    expect(menuTags[0].operations.map((operation) => operation.operationId)).toEqual(['readUpload']);
+    expect(menuTags[0].operations.map((operation) => operation.method)).toEqual(['get']);
+  });
+
   it('falls back to configured sorters when Knife4j x-order is absent', () => {
     const doc: SwaggerDoc = {
       openapi: '3.0.1',

--- a/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
+++ b/knife4j-front/knife4j-ui-react/src/api/knife4jClient.ts
@@ -11,10 +11,12 @@ import type {
   MenuOperation,
   SwaggerUiConfig,
   Knife4jRuntimeConfig,
+  OperationObject,
 } from '../types/swagger';
 import { fetchWithAcceptLanguage } from './acceptLanguage';
 
 const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
 const KNIFE4J_ORDER_EXTENSION = 'x-order';
 const DEFAULT_SWAGGER_INFO: SwaggerInfo = { title: 'API Docs', version: '' };
 
@@ -244,6 +246,15 @@ export function normalizeOperationsSorter(value: unknown): OperationsSorter {
 export interface MenuSortOptions {
   tagsSorter?: TagsSorter;
   operationsSorter?: OperationsSorter;
+  filterMultipartApis?: boolean;
+  filterMultipartApiMethodType?: string;
+}
+
+interface ParsedOperation {
+  path: string;
+  method: HttpMethod;
+  operation: OperationObject;
+  tags: string[];
 }
 
 function sortOperations(ops: MenuOperation[], sorter: OperationsSorter): MenuOperation[] {
@@ -296,13 +307,40 @@ function sortByKnife4jOrder<T>(items: T[], getOrder: (item: T) => unknown): T[] 
     .map((entry) => entry.item);
 }
 
+function normalizeHttpMethod(value: unknown): HttpMethod | null {
+  if (typeof value !== 'string') return null;
+  const method = value.trim().toLowerCase();
+  return (HTTP_METHODS as readonly string[]).includes(method) ? (method as HttpMethod) : null;
+}
+
+function filterMultipartOperations(operations: ParsedOperation[], methodType: string | undefined): ParsedOperation[] {
+  const preferredMethod = normalizeHttpMethod(methodType) ?? 'post';
+  const operationsByPath = new Map<string, ParsedOperation[]>();
+
+  operations.forEach((operation) => {
+    const samePathOperations = operationsByPath.get(operation.path);
+    if (samePathOperations) {
+      samePathOperations.push(operation);
+    } else {
+      operationsByPath.set(operation.path, [operation]);
+    }
+  });
+
+  return Array.from(operationsByPath.values()).flatMap((samePathOperations) => {
+    if (samePathOperations.length <= 1) return samePathOperations;
+    return [samePathOperations.find((operation) => operation.method === preferredMethod) ?? samePathOperations[0]];
+  });
+}
+
 /** 将 SwaggerDoc 解析为侧边栏菜单结构 */
 export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): MenuTag[] {
   const tagsSorter = options.tagsSorter ?? 'preserve';
   const operationsSorter = options.operationsSorter ?? 'preserve';
+  const filterMultipartApis = options.filterMultipartApis ?? false;
 
   const tagMap = new Map<string, MenuTag>();
   const tagOrders = new Map<string, unknown>();
+  const parsedOperations: ParsedOperation[] = [];
 
   // 初始化 tag 列表（保持 doc.tags 原始顺序）
   (doc.tags ?? []).forEach((t) => {
@@ -316,21 +354,29 @@ export function parseMenuTags(doc: SwaggerDoc, options: MenuSortOptions = {}): M
       if (!op) return;
 
       const tags = op.tags?.length ? op.tags : ['default'];
-      tags.forEach((tag) => {
-        if (!tagMap.has(tag)) {
-          tagMap.set(tag, { tag, operations: [] });
-        }
-        const menuOp: MenuOperation = {
-          key: `${encodeURIComponent(tag)}/${encodeURIComponent(op.operationId ?? path)}`,
-          path,
-          method,
-          summary: op.summary ?? path,
-          operationId: op.operationId,
-          deprecated: op.deprecated,
-          operation: op,
-        };
-        tagMap.get(tag)!.operations.push(menuOp);
-      });
+      parsedOperations.push({ path, method, operation: op, tags });
+    });
+  });
+
+  const visibleOperations = filterMultipartApis
+    ? filterMultipartOperations(parsedOperations, options.filterMultipartApiMethodType)
+    : parsedOperations;
+
+  visibleOperations.forEach(({ path, method, operation, tags }) => {
+    tags.forEach((tag) => {
+      if (!tagMap.has(tag)) {
+        tagMap.set(tag, { tag, operations: [] });
+      }
+      const menuOp: MenuOperation = {
+        key: `${encodeURIComponent(tag)}/${encodeURIComponent(operation.operationId ?? path)}`,
+        path,
+        method,
+        summary: operation.summary ?? path,
+        operationId: operation.operationId,
+        deprecated: operation.deprecated,
+        operation,
+      };
+      tagMap.get(tag)!.operations.push(menuOp);
     });
   });
 

--- a/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
+++ b/knife4j-front/knife4j-ui-react/src/context/GroupContext.tsx
@@ -192,9 +192,17 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         ? parseMenuTags(swaggerDoc, {
             tagsSorter: effectiveTagsSorter,
             operationsSorter: effectiveOperationsSorter,
+            filterMultipartApis: settings.enableFilterMultipartApis,
+            filterMultipartApiMethodType: settings.enableFilterMultipartApiMethodType,
           })
         : [],
-    [swaggerDoc, effectiveTagsSorter, effectiveOperationsSorter],
+    [
+      swaggerDoc,
+      effectiveTagsSorter,
+      effectiveOperationsSorter,
+      settings.enableFilterMultipartApis,
+      settings.enableFilterMultipartApiMethodType,
+    ],
   );
   const schemas: Record<string, SchemaObject> = swaggerDoc ? getSchemas(swaggerDoc) : {};
 

--- a/knife4j-front/knife4j-ui-react/src/types/settings.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/settings.ts
@@ -39,9 +39,9 @@ export interface AppSettings {
   enableRequestCache: boolean;
   /** Whether dynamic parameters are enabled. Reserved until dynamic parameter behavior is wired. */
   enableDynamicParameter: boolean;
-  /** Whether multipart/RequestMapping APIs are filtered. Reserved until filtering behavior is wired. */
+  /** Whether same-path multi-method RequestMapping APIs are collapsed to one configured method. */
   enableFilterMultipartApis: boolean;
-  /** Filtered method type for multipart/RequestMapping APIs. */
+  /** Preferred HTTP method kept when same-path multi-method APIs are filtered. */
   enableFilterMultipartApiMethodType: string;
   /** tag sorting override (default 'auto': follow springdoc.swagger-ui.tags-sorter). */
   tagsSorter: TagsSorterOverride;

--- a/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.test.ts
@@ -32,6 +32,8 @@ describe('knife4j setting extraction', () => {
           enableHost: true,
           enableHostText: 'http://localhost:9000',
           enableRequestCache: false,
+          enableFilterMultipartApis: true,
+          enableFilterMultipartApiMethodType: 'put',
           enableAfterScript: true,
         },
       },
@@ -53,6 +55,8 @@ describe('knife4j setting extraction', () => {
       enableHost: true,
       enableHostText: 'http://localhost:9000',
       enableRequestCache: false,
+      enableFilterMultipartApis: true,
+      enableFilterMultipartApiMethodType: 'PUT',
     });
   });
 
@@ -63,6 +67,8 @@ describe('knife4j setting extraction', () => {
           enableRequestCache: 'false',
           enableHomeCustom: 'true',
           homeCustomLocation: 123,
+          enableFilterMultipartApis: 'true',
+          enableFilterMultipartApiMethodType: 'TRACE',
         },
       },
     });

--- a/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.ts
@@ -3,6 +3,7 @@ import { SUPPORTED_LANGS } from '../types/settings';
 import type { MarkdownFileGroup, SwaggerDoc } from '../types/swagger';
 
 type UnknownRecord = Record<string, unknown>;
+const FILTER_MULTIPART_METHOD_TYPES = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD'] as const;
 
 function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -25,6 +26,12 @@ function readBoolean(source: UnknownRecord, key: string): boolean | undefined {
 
 function readString(source: UnknownRecord, key: string): string | undefined {
   return typeof source[key] === 'string' ? source[key] : undefined;
+}
+
+function normalizeFilterMultipartMethodType(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const methodType = value.trim().toUpperCase();
+  return (FILTER_MULTIPART_METHOD_TYPES as readonly string[]).includes(methodType) ? methodType : undefined;
 }
 
 function readOpenApiExtension(doc: SwaggerDoc | null | undefined): UnknownRecord | undefined {
@@ -100,6 +107,16 @@ export function extractKnife4jSettings(doc: SwaggerDoc | null | undefined): Part
 
   const enableRequestCache = readBoolean(setting, 'enableRequestCache');
   if (enableRequestCache !== undefined) next.enableRequestCache = enableRequestCache;
+
+  const enableFilterMultipartApis = readBoolean(setting, 'enableFilterMultipartApis');
+  if (enableFilterMultipartApis !== undefined) next.enableFilterMultipartApis = enableFilterMultipartApis;
+
+  const enableFilterMultipartApiMethodType = normalizeFilterMultipartMethodType(
+    setting.enableFilterMultipartApiMethodType,
+  );
+  if (enableFilterMultipartApiMethodType !== undefined) {
+    next.enableFilterMultipartApiMethodType = enableFilterMultipartApiMethodType;
+  }
 
   return next;
 }


### PR DESCRIPTION
## 变更

- React 菜单解析支持 `enableFilterMultipartApis` / `enableFilterMultipartApiMethodType`。
- 从 OpenAPI `x-openapi.x-setting` 读取后端注入的过滤配置。
- 更新 React 配置支持文档，并补充单测覆盖多方法过滤和设置抽取。

## 验证

- `bun --filter knife4j-ui-react test src/api/knife4jClient.test.ts src/utils/knife4jSettings.test.ts --run`
- `./scripts/test-front-core.sh`
- `git diff --check`
- 远端 CI `Build` #551 通过：`docs-build`、`front-core-test`、`java-build-test`

## 协作说明

- 本次为维护者现场指令下的小范围 React 配置接入，未单独启动 worker/reviewer；风险由目标单测、前端核心门禁和远端 CI 覆盖。