### PR TITLE
修复：顶栏使用 OpenAPI 文档标题

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/App.tsx
+++ b/knife4j-front/knife4j-ui-react/src/App.tsx
@@ -352,6 +352,8 @@ const AppInner: React.FC = () => {
     closable: item.key !== HOME_KEY,
     children: item.key === activeKey ? <Outlet /> : item.children,
   }));
+  const rawHeaderTitle = swaggerDoc?.info?.title?.trim();
+  const headerTitle = rawHeaderTitle && rawHeaderTitle !== 'API Docs' ? rawHeaderTitle : t('app.header.title');
   const footerContent = resolveFooterContent(settings, t('app.footer'));
 
   return (
@@ -426,7 +428,7 @@ const AppInner: React.FC = () => {
             onClick={() => setCollapsed(!collapsed)}
             style={{ fontSize: 16, width: 64, height: 64 }}
           />
-          {t('app.header.title')}
+          {headerTitle}
           <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
             <Dropdown
               menu={{


### PR DESCRIPTION
## 关联 Issue
- Closes #505

## 变更内容
- React OpenAPI3 UI 顶栏优先显示当前文档的 `info.title`。
- 当文档标题缺失并被前端规范化为内置 `API Docs` 时，顶栏回退默认文案“OpenAPI 接口文档聚合中心”。
- 左上角品牌 `Knife4j Next` 和首页大标题逻辑不变。

## 验证
- `./scripts/test-front-core.sh`：通过。
- 本地 mock OpenAPI + Vite 预览：`info.title = 商品采购接口文档` 时，顶栏显示“商品采购接口文档”。
- 本地 mock OpenAPI + Vite 预览：缺失 `info.title` 时，顶栏回退显示“OpenAPI 接口文档聚合中心”。

## 协作记录
- Worker：完成 `App.tsx` 最小实现并运行前端验证。
- Reviewer：首次指出缺失标题会被规范化为 `API Docs` 的回退问题；修复后复审通过。

## 已知风险
- 如果用户真实自定义标题恰好为 `API Docs`，顶栏会按内置兜底处理并回退默认文案；该边界很窄，本次不新增额外配置或元数据标记。