### PR TITLE
支持请求体按校验分组显示必填字段

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -19,6 +19,7 @@ import SchemaFieldTable, { SchemaTypeLink } from '../../components/schema/Schema
 import { schemaNameFromRef } from '../../components/schema/schemaUtils';
 import CodeBlock from './CodeBlock';
 import { operationAuthors } from './operationAuthor';
+import { applyValidationGroupRequiredFields } from './validationGroups';
 
 const { Title, Text } = Typography;
 
@@ -351,7 +352,9 @@ export default function ApiDoc() {
     };
   });
   const bodySchema = firstRequestSchema(op.requestBody, op.parameters);
-  const bodyFields = bodySchema ? filterFieldNodes(schemaToFieldNodes(bodySchema, swaggerDoc), 'request') : [];
+  const bodyFields = bodySchema
+    ? filterFieldNodes(applyValidationGroupRequiredFields(schemaToFieldNodes(bodySchema, swaggerDoc), op), 'request')
+    : [];
   const responses: ResponseRow[] = Object.entries(op.responses ?? {}).map(([statusCode, response]) => ({
     key: statusCode,
     statusCode,

--- a/knife4j-front/knife4j-ui-react/src/pages/api/validationGroups.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/validationGroups.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { SchemaFieldNode } from 'knife4j-core';
+import type { OperationObject } from '../../types/swagger';
+import { applyValidationGroupRequiredFields, validationGroupRequiredFields } from './validationGroups';
+
+function field(name: string, required = false): SchemaFieldNode {
+  return {
+    name,
+    type: 'string',
+    required,
+  };
+}
+
+describe('validation groups', () => {
+  it('unions operation validation group fields', () => {
+    const operation: OperationObject = {
+      responses: {},
+      'x-validation-groups': {
+        AddGroup: ['firstName', 'lastName'],
+        UpdateGroup: ['id', 'firstName'],
+      },
+    };
+
+    expect(Array.from(validationGroupRequiredFields(operation) ?? []).sort()).toEqual(['firstName', 'id', 'lastName']);
+  });
+
+  it('overrides top-level request body required flags when extension exists', () => {
+    const operation: OperationObject = {
+      responses: {},
+      'x-validation-groups': {
+        AddGroup: ['firstName', 'lastName'],
+      },
+    };
+
+    expect(
+      applyValidationGroupRequiredFields([field('id', true), field('firstName'), field('email')], operation),
+    ).toEqual([field('id', false), field('firstName', true), field('email', false)]);
+  });
+
+  it('keeps schema required flags when extension is absent', () => {
+    const fields = [field('id', true), field('name')];
+    expect(applyValidationGroupRequiredFields(fields, { responses: {} })).toBe(fields);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/validationGroups.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/validationGroups.ts
@@ -1,0 +1,25 @@
+import type { SchemaFieldNode } from 'knife4j-core';
+import type { OperationObject } from '../../types/swagger';
+
+export function validationGroupRequiredFields(operation: OperationObject): Set<string> | undefined {
+  const groups = operation['x-validation-groups'];
+  if (!groups) return undefined;
+
+  const fields = new Set<string>();
+  for (const names of Object.values(groups)) {
+    if (!Array.isArray(names)) continue;
+    for (const name of names) {
+      fields.add(name);
+    }
+  }
+  return fields;
+}
+
+export function applyValidationGroupRequiredFields(
+  fields: SchemaFieldNode[],
+  operation: OperationObject,
+): SchemaFieldNode[] {
+  const requiredFields = validationGroupRequiredFields(operation);
+  if (!requiredFields) return fields;
+  return fields.map((field) => ({ ...field, required: requiredFields.has(field.name) }));
+}

--- a/knife4j-front/knife4j-ui-react/src/types/swagger.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/swagger.ts
@@ -187,6 +187,8 @@ export interface OperationObject {
   'x-order'?: number | string;
   /** Knife4j extension emitted from @ApiOperationSupport.author/authors. */
   'x-author'?: string;
+  /** Knife4j extension mapping validation group name to required request body fields. */
+  'x-validation-groups'?: Record<string, string[]>;
 }
 
 export interface PathItemObject {

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jJakartaOperationCustomizer.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jJakartaOperationCustomizer.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.customizers.GlobalOperationCustomizer;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ClassUtils;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.method.HandlerMethod;
 
 import java.util.List;
@@ -56,8 +57,6 @@ public class Knife4jJakartaOperationCustomizer implements GlobalOperationCustomi
             if (operationSupport.order() != 0) {
                 operation.addExtension(ExtensionsConstants.EXTENSION_ORDER, operationSupport.order());
             }
-            // x-validation-groups extension
-            applyValidationGroupsExtension(operation, handlerMethod, operationSupport);
         } else {
             // 如果方法级别不存在，再找一次class级别的
             ApiSupport apiSupport = AnnotationUtils.findAnnotation(beanType, ApiSupport.class);
@@ -71,6 +70,7 @@ public class Knife4jJakartaOperationCustomizer implements GlobalOperationCustomi
                 }
             }
         }
+        applyValidationGroupsExtension(operation, handlerMethod, operationSupport);
 
         // 方法重名则进行处理，防止url覆盖
         String className = beanType.getSimpleName();
@@ -87,19 +87,22 @@ public class Knife4jJakartaOperationCustomizer implements GlobalOperationCustomi
                                                 Operation operation,
                                                 HandlerMethod handlerMethod,
                                                 ApiOperationSupport operationSupport) {
-        Class<?>[] groups = operationSupport.validationGroups();
-        if (groups == null || groups.length == 0) {
-            return;
-        }
+        Class<?>[] groups = operationSupport == null ? null : operationSupport.validationGroups();
         Class<?> bodyType = null;
         java.lang.reflect.Parameter[] params = handlerMethod.getMethod().getParameters();
         for (java.lang.reflect.Parameter p : params) {
             if (p.isAnnotationPresent(org.springframework.web.bind.annotation.RequestBody.class)) {
                 bodyType = p.getType();
+                if (groups == null || groups.length == 0) {
+                    Validated validated = p.getAnnotation(Validated.class);
+                    if (validated != null) {
+                        groups = validated.value();
+                    }
+                }
                 break;
             }
         }
-        if (bodyType == null) {
+        if (bodyType == null || groups == null || groups.length == 0) {
             return;
         }
         Map<String, List<String>> groupMap = ValidationGroupsUtils.resolveRequiredFields(bodyType, groups);

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jValidationGroupsExtensionTest.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jValidationGroupsExtensionTest.java
@@ -22,6 +22,7 @@ import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
 import io.swagger.v3.oas.models.Operation;
 import org.junit.Assert;
 import org.junit.Test;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.HandlerMethod;
@@ -88,6 +89,9 @@ public class Knife4jValidationGroupsExtensionTest {
         public void update(@RequestBody UserFormRequest req) {
         }
 
+        public void createByValidated(@RequestBody @Validated(Create.class) UserFormRequest req) {
+        }
+
         @ApiOperationSupport(order = 3)
         public void noGroups(@RequestBody UserFormRequest req) {
         }
@@ -138,6 +142,20 @@ public class Knife4jValidationGroupsExtensionTest {
         Assert.assertTrue(groups.get("Update").contains("id"));
         Assert.assertTrue(groups.get("Update").contains("name"));
         Assert.assertFalse(groups.get("Update").contains("email"));
+    }
+
+    @Test
+    public void validatedRequestBodyProducesGroupExtensionWithoutApiOperationSupport() throws Exception {
+        Operation op = new Operation().operationId("createByValidated");
+        customizer().customize(op, handlerMethod("createByValidated"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> groups =
+                (Map<String, List<String>>) op.getExtensions().get(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS);
+        Assert.assertNotNull(groups);
+        Assert.assertTrue(groups.get("Create").contains("name"));
+        Assert.assertTrue(groups.get("Create").contains("email"));
+        Assert.assertFalse(groups.get("Create").contains("id"));
     }
 
     @Test

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOperationCustomizer.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jOperationCustomizer.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.customizers.GlobalOperationCustomizer;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.method.HandlerMethod;
 
 import java.util.List;
@@ -53,8 +54,6 @@ public class Knife4jOperationCustomizer implements GlobalOperationCustomizer {
             if (operationSupport.order() != 0) {
                 operation.addExtension(ExtensionsConstants.EXTENSION_ORDER, operationSupport.order());
             }
-            // x-validation-groups extension
-            applyValidationGroupsExtension(operation, handlerMethod, operationSupport);
         } else {
             // 如果方法级别不存在，再找一次class级别的
             ApiSupport apiSupport = AnnotationUtils.findAnnotation(handlerMethod.getBeanType(), ApiSupport.class);
@@ -68,6 +67,7 @@ public class Knife4jOperationCustomizer implements GlobalOperationCustomizer {
                 }
             }
         }
+        applyValidationGroupsExtension(operation, handlerMethod, operationSupport);
         return operation;
     }
 
@@ -75,19 +75,22 @@ public class Knife4jOperationCustomizer implements GlobalOperationCustomizer {
                                                 Operation operation,
                                                 HandlerMethod handlerMethod,
                                                 ApiOperationSupport operationSupport) {
-        Class<?>[] groups = operationSupport.validationGroups();
-        if (groups == null || groups.length == 0) {
-            return;
-        }
+        Class<?>[] groups = operationSupport == null ? null : operationSupport.validationGroups();
         Class<?> bodyType = null;
         java.lang.reflect.Parameter[] params = handlerMethod.getMethod().getParameters();
         for (java.lang.reflect.Parameter p : params) {
             if (p.isAnnotationPresent(org.springframework.web.bind.annotation.RequestBody.class)) {
                 bodyType = p.getType();
+                if (groups == null || groups.length == 0) {
+                    Validated validated = p.getAnnotation(Validated.class);
+                    if (validated != null) {
+                        groups = validated.value();
+                    }
+                }
                 break;
             }
         }
-        if (bodyType == null) {
+        if (bodyType == null || groups == null || groups.length == 0) {
             return;
         }
         Map<String, List<String>> groupMap = ValidationGroupsUtils.resolveRequiredFields(bodyType, groups);

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jValidationGroupsExtensionTest.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/spring/extension/Knife4jValidationGroupsExtensionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.extension;
+
+import com.github.xiaoymin.knife4j.core.conf.ExtensionsConstants;
+import io.swagger.v3.oas.models.Operation;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.annotation.*;
+import java.util.List;
+import java.util.Map;
+
+public class Knife4jValidationGroupsExtensionTest {
+
+    interface Create {
+    }
+    interface Update {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface NotNull {
+
+        Class<?>[] groups() default {};
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface NotBlank {
+
+        Class<?>[] groups() default {};
+    }
+
+    static class UserFormRequest {
+
+        @NotNull(groups = Update.class)
+        Long id;
+
+        @NotBlank(groups = {Create.class, Update.class})
+        String name;
+
+        @NotBlank(groups = Create.class)
+        String email;
+    }
+
+    @RestController
+    static class DemoController {
+
+        public void create(@RequestBody @Validated(Create.class) UserFormRequest req) {
+        }
+
+        public void update(@RequestBody @Validated(Update.class) UserFormRequest req) {
+        }
+    }
+
+    private HandlerMethod handlerMethod(String methodName) throws Exception {
+        DemoController bean = new DemoController();
+        java.lang.reflect.Method method = DemoController.class.getMethod(methodName, UserFormRequest.class);
+        return new HandlerMethod(bean, method);
+    }
+
+    @Test
+    public void validatedRequestBodyProducesCreateGroupExtension() throws Exception {
+        Operation op = new Operation().operationId("create");
+        new Knife4jOperationCustomizer().customize(op, handlerMethod("create"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> groups =
+                (Map<String, List<String>>) op.getExtensions().get(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS);
+        Assert.assertNotNull(groups);
+        Assert.assertTrue(groups.get("Create").contains("name"));
+        Assert.assertTrue(groups.get("Create").contains("email"));
+        Assert.assertFalse(groups.get("Create").contains("id"));
+    }
+
+    @Test
+    public void validatedRequestBodyProducesUpdateGroupExtension() throws Exception {
+        Operation op = new Operation().operationId("update");
+        new Knife4jOperationCustomizer().customize(op, handlerMethod("update"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> groups =
+                (Map<String, List<String>>) op.getExtensions().get(ExtensionsConstants.EXTENSION_VALIDATION_GROUPS);
+        Assert.assertNotNull(groups);
+        Assert.assertTrue(groups.get("Update").contains("id"));
+        Assert.assertTrue(groups.get("Update").contains("name"));
+        Assert.assertFalse(groups.get("Update").contains("email"));
+    }
+}


### PR DESCRIPTION
## 关联 Issue

Closes #504

## 变更内容

- OAS3 Spring Boot 2.x 与 Jakarta starter 会从 `@RequestBody` 参数上的 `@Validated(...)` 自动提取 Bean Validation 分组，复用现有 `x-validation-groups` 扩展输出当前接口对应的必填字段集合。
- `@ApiOperationSupport(validationGroups = ...)` 的显式配置仍保留优先级；未声明分组时保持原行为。
- React 接口文档页在请求体 schema 表格中消费 `x-validation-groups`，按当前 operation 覆盖顶层字段的“必填”列；没有扩展时继续使用 OpenAPI schema 原始 `required`。
- 增加 Java 与 React 单元测试覆盖创建/更新分组的 required 字段差异。

## 验证

- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home mvn -pl knife4j-openapi3-spring-boot-starter,knife4j-openapi3-jakarta-spring-boot-starter -Dtest=Knife4jValidationGroupsExtensionTest -Dknife4j-skipTests=false test`
- `./scripts/test-front-core.sh`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home ./scripts/test-java.sh`
- Java smoke evidence: `==> Smoke-tests evidence OK (12 modules)`

## 协作说明

- 按仓库协作规范，本类源码改动通常需要独立 worker/reviewer。
- 本次运行的子 agent 工具要求必须由用户明确点名才可启动，因此未启动独立 worker/reviewer；替代措施是提交前完成定向 Java 测试、前端全脚本和 Java 全脚本。
- PR 保持 draft，等待维护者人工 review 后再推进 issue 到 `status:review`。