### PR TITLE
升级 OpenAPI3 demo 到 Spring Boot 4

### DIFF
--- a/docs-site/guide/demo.md
+++ b/docs-site/guide/demo.md
@@ -10,7 +10,7 @@ knife4j-next 提供两个并列的 demo 工程，分别覆盖两条独立的 UI 
 
 | Demo | 后端 | UI 产物 | 在线地址 |
 | --- | --- | --- | --- |
-| `knife4j-demo-openapi3` | Spring Boot 3.4 + springdoc + `knife4j-openapi3-jakarta-spring-boot-starter` | React（`knife4j-openapi3-ui`） | [https://openapi3.demo.knife4jnext.com/doc.html](https://openapi3.demo.knife4jnext.com/doc.html) |
+| `knife4j-demo-openapi3` | Spring Boot 4.0 + springdoc + `knife4j-openapi3-boot4-spring-boot-starter` | React（`knife4j-openapi3-ui`） | [https://openapi3.demo.knife4jnext.com/doc.html](https://openapi3.demo.knife4jnext.com/doc.html) |
 | `knife4j-demo-openapi2` | Spring Boot 2.7 + springfox 2.10.5 + `knife4j-openapi2-spring-boot-starter` | Vue 3（`knife4j-openapi2-ui`） | [https://openapi2.demo.knife4jnext.com/doc.html](https://openapi2.demo.knife4jnext.com/doc.html) |
 
 两个站点都跟随 `master` 分支自动构建与刷新，建议直接打开比对，看看 OpenAPI 3 主线和 OpenAPI 2 兼容维护线在 UI 上的差异。
@@ -30,10 +30,10 @@ knife4j-next 提供两个并列的 demo 工程，分别覆盖两条独立的 UI 
 
 | 组件 | 版本 | 说明 |
 | --- | --- | --- |
-| Spring Boot | `3.4.5` | demo `pom.xml` 显式声明 |
-| knife4j starter | `knife4j-openapi3-jakarta-spring-boot-starter` | 本仓库 `5.0.13` |
+| Spring Boot | `4.0.6` | demo `pom.xml` 通过 Boot BOM 显式声明 |
+| knife4j starter | `knife4j-openapi3-boot4-spring-boot-starter` | 本仓库 `5.0.13` |
 | JDK | 17 | Dockerfile base image `eclipse-temurin:17-jre-alpine` |
-| springdoc-openapi-jakarta | `2.8.9` | 由 starter 管理 |
+| springdoc-openapi | `3.0.3` | 由 starter 管理 |
 
 ### 展示了什么
 
@@ -166,7 +166,7 @@ docker run --rm -p 8081:8081 \
 
 如果你想拷贝某个 demo 做自己的工程：
 
-1. 选择和你后端栈匹配的目录：`knife4j/knife4j-demo-openapi3`（OpenAPI 3 + Boot 3）或 `knife4j/knife4j-demo-openapi2`（OpenAPI 2 + Boot 2）。
+1. 选择和你后端栈匹配的目录：`knife4j/knife4j-demo-openapi3`（OpenAPI 3 + Boot 4）或 `knife4j/knife4j-demo-openapi2`（OpenAPI 2 + Boot 2）。
 2. 改 `pom.xml` 的 `groupId`/`artifactId`/`name`。
 3. 替换 package 命名空间为你的项目命名空间。
 4. 按需调整 `application.yml`（OpenAPI 3 调 `springdoc.group-configs.packages-to-scan`，OpenAPI 2 调 `Docket` 中的 `basePackage`）。

--- a/docs-site/guide/introduction.md
+++ b/docs-site/guide/introduction.md
@@ -27,7 +27,7 @@ title: 产品介绍
 1. **兼容性修复**。upstream 对 Spring Boot 3.4 / 3.5 的适配步伐变慢，fork 已经升级 `springdoc-openapi-jakarta` 到 `2.8.9`，并通过 smoke-tests 覆盖 Boot 2.7.18 的 OAS2/OAS3、Boot 3.4.x/3.5.0 Jakarta 与 Boot 4.0.6 Jakarta 组合。
 2. **安全修复**。修复了 `/v2/api-docs;xxx` 分号绕过 Basic 认证的漏洞（[#886](https://github.com/xiaoymin/knife4j/issues/886)），以及 gateway `context-path` 下聚合 host 少斜杠的问题（[#954](https://github.com/xiaoymin/knife4j/issues/954)）。
 3. **可重复发布流程**。`.github/workflows/release.yml` 通过 Central Publishing Plugin 直接推送 Maven Central，不依赖人工临场操作。
-4. **可试用的 Demo**。`knife4j-demo-openapi3`（Spring Boot 3.4 + OpenAPI 3 + React UI）和 `knife4j-demo-openapi2`（Spring Boot 2.7 + OpenAPI 2 + Vue 3 UI）两个示例工程都附带 Dockerfile，可分别本地运行或在线预览。
+4. **可试用的 Demo**。`knife4j-demo-openapi3`（Spring Boot 4.0 + OpenAPI 3 + React UI）和 `knife4j-demo-openapi2`（Spring Boot 2.7 + OpenAPI 2 + Vue 3 UI）两个示例工程都附带 Dockerfile，可分别本地运行或在线预览。
 
 ## 哪些是 **已经** 做了的
 

--- a/docs-site/reference/modules.md
+++ b/docs-site/reference/modules.md
@@ -60,7 +60,7 @@ title: 模块说明
 
 | 模块 | 说明 |
 | --- | --- |
-| `knife4j-demo-openapi3` | OpenAPI 3 在线演示应用（Boot 3.4.5 + Jakarta starter + React UI，部署到 `openapi3.demo.knife4jnext.com`） |
+| `knife4j-demo-openapi3` | OpenAPI 3 在线演示应用（Boot 4.0.6 + Boot4 starter + React UI，部署到 `openapi3.demo.knife4jnext.com`） |
 | `knife4j-demo-openapi2` | OpenAPI 2 在线演示应用（Boot 2.7.18 + springfox 2.10.5 + Vue 3 UI，部署到 `openapi2.demo.knife4jnext.com`） |
 | `knife4j-smoke-tests` | 自动化冒烟测试（7 个子模块覆盖 Boot 2.x OAS2/OAS3、Boot 3.4.x/3.5.x Jakarta、Boot 4.x WebMVC 与 Boot 4.x Gateway） |
 

--- a/knife4j/knife4j-demo-openapi3/pom.xml
+++ b/knife4j/knife4j-demo-openapi3/pom.xml
@@ -13,26 +13,37 @@
 
     <artifactId>knife4j-demo-openapi3</artifactId>
     <name>knife4j-demo-openapi3</name>
-    <description>knife4j-next OpenAPI 3 online demo application (Spring Boot 3 + React UI)</description>
+    <description>knife4j-next OpenAPI 3 online demo application (Spring Boot 4 + React UI)</description>
 
     <properties>
         <knife4j-java.version>17</knife4j-java.version>
-        <knife4j-spring-boot3.version>3.4.5</knife4j-spring-boot3.version>
         <start-class>com.baizhukui.knife4j.demo.openapi3.DemoApplication</start-class>
         <maven.deploy.skip>true</maven.deploy.skip>
         <skipPublishing>true</skipPublishing>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${knife4j-spring-boot4.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.baizhukui</groupId>
-            <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+            <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${knife4j-spring-boot3.version}</version>
+            <version>${knife4j-spring-boot4.version}</version>
         </dependency>
     </dependencies>
 
@@ -41,7 +52,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${knife4j-spring-boot3.version}</version>
+                <version>${knife4j-spring-boot4.version}</version>
                 <configuration>
                     <mainClass>${start-class}</mainClass>
                 </configuration>


### PR DESCRIPTION
## 关联 Issue

无对应 issue：维护者现场要求将 `knife4j-demo-openapi3` 升级到 Spring Boot 4。

## 变更内容

- 将 `knife4j-demo-openapi3` 从 Spring Boot 3.4.5 / `knife4j-openapi3-jakarta-spring-boot-starter` 切到 Spring Boot 4.0.6 / `knife4j-openapi3-boot4-spring-boot-starter`。
- 在 demo POM 中导入现有 `${knife4j-spring-boot4.version}` 对应的 Spring Boot BOM，保持与 Boot4 smoke test 基线一致。
- 同步更新 demo 页面、介绍页和模块清单中的 OpenAPI3 demo 技术栈说明。

## 验证

- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH TMPDIR=/private/tmp mvn -pl knife4j-demo-openapi3 -am package -DskipTests`：通过，`spring-boot:4.0.6:repackage` 成功。
- `TMPDIR=/private/tmp ./scripts/test-docs.sh`：通过。
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home PATH=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home/bin:$PATH TMPDIR=/private/tmp ./scripts/test-java.sh`：通过，`Smoke-tests evidence OK (12 modules)`。
- 临时启动 `knife4j-demo-openapi3-5.0.13.jar --server.port=18080`：Boot 4.0.6 / Tomcat 11 正常启动；`/v3/api-docs` 返回 `200 application/json`，`/doc.html` 返回 `200 text/html`；验证后已关闭进程。

## 协作说明

- worker：未派发。原因是当前可用的 sub-agent 工具要求用户显式授权 delegation，本次由 Codex 直接完成小范围改动。
- reviewer：未派发。原因同上；本 PR 保持 draft，等待维护者人工 review 与 CI。

## 风险与范围外

- 未升级仓库全局 Boot4 基线，继续复用现有 `4.0.6`。
- 未调整 OpenAPI `info.title` / `info.version` 的配置方式；runtime smoke 中 `/v3/api-docs` 正常返回，标题仍由 springdoc 默认值给出，该行为不在本次升级范围内。