### PR TITLE
支持默认隐藏响应状态码栏

### DIFF
--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -89,7 +89,7 @@ public OpenAPI customOpenAPI() {
 | `knife4j.setting.enableHomeCustom` | `boolean` | `false` | 启用首页自定义 | ✅ |
 | `knife4j.setting.homeCustomLocation` | `String` | — | 首页自定义 Markdown 内容（通常由后端根据 `homeCustomPath` 读取后注入） | ✅ |
 | `knife4j.setting.enableGroup` | `boolean` | `true` | 显示分组下拉框 | ✅ |
-| `knife4j.setting.enableResponseCode` | `boolean` | `true` | 显示响应状态码栏 | ⚠️ |
+| `knife4j.setting.enableResponseCode` | `boolean` | openapi2: `true` / openapi3: `false` | 显示响应状态码栏；React 默认隐藏，设为 `true` 时按 HTTP 状态码分组展示响应结构 | ✅ |
 | `knife4j.setting.customCode` | `Integer` | `200` | 生产环境屏蔽时的自定义 HTTP 状态码 | ✅ |
 
 > React 新前端会读取后端注入到 OpenAPI JSON 的 `x-openapi.x-setting`，但只消费表中标 ✅ 的 UI 字段；用户在前端设置面板中的本地选择会覆盖后端默认值。标 ⚠️ 的配置仍会由后端写入 extension，但 React 暂不消费。详见 [FAQ](../guide/faq#react-setting-not-effective)。

--- a/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/en-US.ts
@@ -335,6 +335,7 @@ const enUS = {
   'settings.tip': 'After enabling personalized settings, API tabs need to be closed and reopened or refresh the page',
   'settings.enableRequestCache': 'Enable request parameter cache (Debug panel auto-caches last filled values)',
   'settings.enableDynamicParameter': 'Enable dynamic parameters (Support dynamic injection in debug mode)',
+  'settings.enableResponseCode': 'Show response status-code section',
   'settings.enableFilterMultipartApis':
     'Filter API types (For RequestMapping without specified type, show only selected type)',
   'settings.filterMethodType': 'Filter method type',

--- a/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/ja-JP.ts
@@ -342,6 +342,7 @@ const jaJP = {
   'settings.enableRequestCache':
     'リクエストパラメータのキャッシュを有効化（デバッグ画面で前回入力したパラメータ値を自動保存）',
   'settings.enableDynamicParameter': '動的パラメータを有効化（デバッグ時にリクエストパラメータへ動的に値を注入）',
+  'settings.enableResponseCode': 'レスポンスのステータスコード欄を表示',
   'settings.enableFilterMultipartApis':
     'API タイプをフィルタ（タイプ未指定の RequestMapping について、指定したタイプのみ表示）',
   'settings.filterMethodType': '保持するメソッドタイプ',

--- a/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
+++ b/knife4j-front/knife4j-ui-react/src/locales/zh-CN.ts
@@ -333,6 +333,7 @@ const zhCN = {
   'settings.tip': '启用个性化配置后，接口 Tab 标签需关闭后重新打开或者刷新当前页面',
   'settings.enableRequestCache': '开启请求参数缓存（Debug 调试栏自动缓存上次填写的参数值）',
   'settings.enableDynamicParameter': '开启动态参数（调试时请求参数支持动态注入）',
+  'settings.enableResponseCode': '显示响应状态码栏',
   'settings.enableFilterMultipartApis': '过滤接口类型（针对 RequestMapping 未指定类型的接口，只展示指定类型）',
   'settings.filterMethodType': '过滤保留的方法类型',
   'settings.enableHost': '覆盖 Host（调试时使用指定 Host 替换接口 BaseURL）',

--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDoc.tsx
@@ -20,6 +20,8 @@ import { schemaNameFromRef } from '../../components/schema/schemaUtils';
 import CodeBlock from './CodeBlock';
 import { operationAuthors } from './operationAuthor';
 import { applyValidationGroupRequiredFields } from './validationGroups';
+import { useSettings } from '../../context/SettingsContext';
+import { responseExamplesForDisplay, responseRowsForDisplay } from './responseCodeDisplay';
 
 const { Title, Text } = Typography;
 
@@ -242,6 +244,7 @@ const METHOD_COLOR: Record<string, string> = {
 export default function ApiDoc() {
   const { t } = useTranslation();
   const { loading, swaggerDoc, operation } = useCurrentOperation();
+  const { settings } = useSettings();
 
   if (loading) {
     return (
@@ -375,6 +378,8 @@ export default function ApiDoc() {
 
   const requestExample = buildRequestBodyExample(op.requestBody, bodySchema, swaggerDoc);
   const respExamples = responseExamples(op.responses, swaggerDoc);
+  const visibleResponses = responseRowsForDisplay(responses, settings.enableResponseCode);
+  const visibleRespExamples = responseExamplesForDisplay(respExamples, settings.enableResponseCode);
   const authors = operationAuthors(op);
 
   return (
@@ -519,10 +524,10 @@ export default function ApiDoc() {
             label: t('apiDoc.tab.schema'),
             children: (
               <div>
-                {responses.length === 0 ? (
+                {visibleResponses.length === 0 ? (
                   <SchemaFieldTable fields={[]} emptyText={t('apiDoc.noResponse')} />
                 ) : (
-                  responses.map((row) => {
+                  visibleResponses.map((row) => {
                     const color = row.statusCode.startsWith('2')
                       ? 'success'
                       : row.statusCode.startsWith('4')
@@ -534,7 +539,7 @@ export default function ApiDoc() {
                     return (
                       <div key={row.key} style={{ marginBottom: 16 }}>
                         <Space size={8} style={{ marginBottom: 6 }}>
-                          <Tag color={color}>{row.statusCode}</Tag>
+                          {settings.enableResponseCode && <Tag color={color}>{row.statusCode}</Tag>}
                           {row.description && (
                             <DescriptionText type="secondary" style={{ fontSize: 13 }}>
                               {row.description}
@@ -550,9 +555,11 @@ export default function ApiDoc() {
               </div>
             ),
           },
-          ...respExamples.map(({ statusCode, example }) => ({
+          ...visibleRespExamples.map(({ statusCode, example }) => ({
             key: `resp-${statusCode}`,
-            label: `${t('apiDoc.tab.responseExample')} ${statusCode}`,
+            label: settings.enableResponseCode
+              ? `${t('apiDoc.tab.responseExample')} ${statusCode}`
+              : t('apiDoc.tab.responseExample'),
             children: (
               <CodeBlock
                 code={example}

--- a/knife4j-front/knife4j-ui-react/src/pages/api/responseCodeDisplay.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/responseCodeDisplay.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { responseExamplesForDisplay, responseRowsForDisplay } from './responseCodeDisplay';
+
+const rows = [
+  { key: '400', statusCode: '400', description: 'Bad request' },
+  { key: '200', statusCode: '200', description: 'OK' },
+  { key: '500', statusCode: '500', description: 'Server error' },
+];
+
+describe('response code display', () => {
+  it('keeps all status-code groups when enabled', () => {
+    expect(responseRowsForDisplay(rows, true).map((row) => row.statusCode)).toEqual(['400', '200', '500']);
+  });
+
+  it('uses the success response by default', () => {
+    expect(responseRowsForDisplay(rows, false).map((row) => row.statusCode)).toEqual(['200']);
+  });
+
+  it('uses default then first response when no success response exists', () => {
+    expect(
+      responseRowsForDisplay(
+        [
+          { key: '400', statusCode: '400', description: 'Bad request' },
+          { key: 'default', statusCode: 'default', description: 'Default' },
+        ],
+        false,
+      ).map((row) => row.statusCode),
+    ).toEqual(['default']);
+
+    expect(responseRowsForDisplay([{ key: '400', statusCode: '400', description: 'Bad request' }], false)).toEqual([
+      { key: '400', statusCode: '400', description: 'Bad request' },
+    ]);
+  });
+
+  it('uses the same status-code preference for examples', () => {
+    expect(
+      responseExamplesForDisplay(
+        [
+          { statusCode: '400', example: '{}' },
+          { statusCode: '201', example: '{"id":1}' },
+        ],
+        false,
+      ),
+    ).toEqual([{ statusCode: '201', example: '{"id":1}' }]);
+  });
+});

--- a/knife4j-front/knife4j-ui-react/src/pages/api/responseCodeDisplay.ts
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/responseCodeDisplay.ts
@@ -1,0 +1,29 @@
+export interface ResponseDisplayItem {
+  statusCode: string;
+}
+
+function preferredStatusEntry<T extends ResponseDisplayItem>(items: T[]): T | undefined {
+  return (
+    items.find((item) => item.statusCode.startsWith('2')) ??
+    items.find((item) => item.statusCode === 'default') ??
+    items[0]
+  );
+}
+
+export function responseRowsForDisplay<T extends ResponseDisplayItem>(
+  responses: T[],
+  enableResponseCode: boolean,
+): T[] {
+  if (enableResponseCode) return responses;
+  const preferred = preferredStatusEntry(responses);
+  return preferred ? [preferred] : [];
+}
+
+export function responseExamplesForDisplay<T extends ResponseDisplayItem>(
+  examples: T[],
+  enableResponseCode: boolean,
+): T[] {
+  if (enableResponseCode) return examples;
+  const preferred = preferredStatusEntry(examples);
+  return preferred ? [preferred] : [];
+}

--- a/knife4j-front/knife4j-ui-react/src/pages/document/Settings.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/document/Settings.tsx
@@ -47,6 +47,17 @@ export default function Settings() {
       </div>
       <Divider style={{ margin: '4px 0' }} />
 
+      {/* 响应状态码栏 */}
+      <div style={{ height: 50, lineHeight: '50px' }}>
+        <Checkbox
+          checked={settings.enableResponseCode}
+          onChange={(e) => setSetting('enableResponseCode', e.target.checked)}
+        >
+          {t('settings.enableResponseCode')}
+        </Checkbox>
+      </div>
+      <Divider style={{ margin: '4px 0' }} />
+
       {/* 过滤 multipart 接口 */}
       <div style={{ minHeight: 50, lineHeight: '50px' }}>
         <Space align="center" wrap>

--- a/knife4j-front/knife4j-ui-react/src/types/settings.ts
+++ b/knife4j-front/knife4j-ui-react/src/types/settings.ts
@@ -41,6 +41,8 @@ export interface AppSettings {
   enableRequestCache: boolean;
   /** Whether dynamic parameters are enabled. Reserved until dynamic parameter behavior is wired. */
   enableDynamicParameter: boolean;
+  /** Whether response schemas are grouped by HTTP status code. */
+  enableResponseCode: boolean;
   /** Whether same-path multi-method RequestMapping APIs are collapsed to one configured method. */
   enableFilterMultipartApis: boolean;
   /** Preferred HTTP method kept when same-path multi-method APIs are filtered. */
@@ -73,6 +75,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   enableHostText: '',
   enableRequestCache: true,
   enableDynamicParameter: false,
+  enableResponseCode: false,
   enableFilterMultipartApis: false,
   enableFilterMultipartApiMethodType: 'POST',
   tagsSorter: 'auto',

--- a/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.test.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.test.ts
@@ -33,6 +33,7 @@ describe('knife4j setting extraction', () => {
           enableHost: true,
           enableHostText: 'http://localhost:9000',
           enableRequestCache: false,
+          enableResponseCode: true,
           enableFilterMultipartApis: true,
           enableFilterMultipartApiMethodType: 'put',
           enableAfterScript: true,
@@ -57,6 +58,7 @@ describe('knife4j setting extraction', () => {
       enableHost: true,
       enableHostText: 'http://localhost:9000',
       enableRequestCache: false,
+      enableResponseCode: true,
       enableFilterMultipartApis: true,
       enableFilterMultipartApiMethodType: 'PUT',
     });
@@ -67,6 +69,7 @@ describe('knife4j setting extraction', () => {
       'x-openapi': {
         'x-setting': {
           enableRequestCache: 'false',
+          enableResponseCode: 'true',
           enableHomeCustom: 'true',
           homeCustomLocation: 123,
           enableFilterMultipartApis: 'true',

--- a/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.ts
+++ b/knife4j-front/knife4j-ui-react/src/utils/knife4jSettings.ts
@@ -111,6 +111,9 @@ export function extractKnife4jSettings(doc: SwaggerDoc | null | undefined): Part
   const enableRequestCache = readBoolean(setting, 'enableRequestCache');
   if (enableRequestCache !== undefined) next.enableRequestCache = enableRequestCache;
 
+  const enableResponseCode = readBoolean(setting, 'enableResponseCode');
+  if (enableResponseCode !== undefined) next.enableResponseCode = enableResponseCode;
+
   const enableFilterMultipartApis = readBoolean(setting, 'enableFilterMultipartApis');
   if (enableFilterMultipartApis !== undefined) next.enableFilterMultipartApis = enableFilterMultipartApis;
 

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
@@ -150,6 +150,6 @@ public class Knife4jSetting {
      * https://gitee.com/xiaoym/knife4j/issues/I3TE0V
      * @since v4.0.0
      */
-    private boolean enableResponseCode = true;
+    private boolean enableResponseCode = false;
 
 }

--- a/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/configuration/Knife4jSetting.java
@@ -149,6 +149,6 @@ public class Knife4jSetting {
      * https://gitee.com/xiaoym/knife4j/issues/I3TE0V
      * @since v4.0.0
      */
-    private boolean enableResponseCode = true;
+    private boolean enableResponseCode = false;
 
 }


### PR DESCRIPTION
## 变更内容

- React 前端接入 `enableResponseCode`，默认隐藏响应状态码栏。
- 关闭时只展示一个优先响应结构：优先 2xx，其次 `default`，最后回退到第一个响应。
- 开启时保留原有按 HTTP 状态码分组展示响应结构和响应示例的行为。
- 设置页新增“显示响应状态码栏”开关，并补齐中英日文案。
- OpenAPI3 两个 starter 的 `enableResponseCode` 默认值改为 `false`，OpenAPI2 默认值保持不变。
- 同步配置文档和 React 设置解析测试。

## 背景

多数业务接口会用 HTTP 200 包装响应，并在响应体内放业务错误码。把 HTTP 状态码分组作为默认返回结构展示容易干扰阅读，所以本次默认隐藏；需要按 HTTP 状态码区分响应结构的项目仍可显式开启。

## 验证

- `bun test src/utils/knife4jSettings.test.ts src/pages/api/responseCodeDisplay.test.ts`
- `./scripts/test-front-core.sh`
- `./scripts/test-docs.sh`
- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home ./scripts/test-java.sh`

Java 全量验证通过，并包含 12 个 smoke 模块证据检查。

## 协作说明

本次是维护者现场指令，无对应 issue。当前运行未启动独立 reviewer，PR 保持 draft；合并前仍需 CI 和 review 通过。