### PR TITLE
docs: 默认使用 Boot4 Maven 坐标

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 </dependency>
 ```
 
-如果你的使用场景不是 Spring Boot 4.x / Jakarta，将 `artifactId` 替换为上表对应的 starter。
+如果你的使用场景不是 Spring Boot 4.x，将 `artifactId` 替换为上表对应的 starter。
 
 启动应用后访问：
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@
 ```xml
 <dependency>
     <groupId>com.baizhukui</groupId>
-    <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
+    <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
     <version>5.0.14</version>
 </dependency>
 ```
 
-如果你的使用场景不是 Spring Boot 3.x / Jakarta，将 `artifactId` 替换为上表对应的 starter。
+如果你的使用场景不是 Spring Boot 4.x / Jakarta，将 `artifactId` 替换为上表对应的 starter。
 
 启动应用后访问：
 


### PR DESCRIPTION
## 关联 Issue
- Closes #516

## 变更内容
- 将 README 快速开始中的默认 Maven 示例从 Spring Boot 3 Jakarta starter 改为 Spring Boot 4 starter。
- 同步下方替换说明，默认场景改为 Spring Boot 4.x。

## 验证
- `git diff --check`
- `rg -n "artifactId>knife4j-openapi3-|如果你的使用场景不是" README.md`
- PR CI 未触发：`.github/workflows/build.yml` 的 `pull_request.paths` 不包含 `README.md`。

## 协作门禁
- worker：跳过。本次是 README 纯文档两行替换，当前 Codex 子 agent 工具策略要求用户显式授权后才能启动独立 agent。
- reviewer：跳过。同上，改动范围低风险；以 diff 检查和内容搜索作为替代验证，等待 PR 审查。

## 风险
- 未运行 Java、前端或文档站构建；本 PR 不触碰代码、依赖、站点构建源码或生成物。
