### PR TITLE
fix: 保留调试数值参数输入精度

### DIFF
--- a/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
+++ b/knife4j-front/knife4j-ui-react/src/pages/api/ApiDebug.tsx
@@ -591,18 +591,17 @@ function ParamInput({ param, value, onChange, hasError }: ParamInputProps) {
     );
   }
 
-  // integer / number → InputNumber
+  // integer / number → Input; snowflake IDs can exceed JS safe integer precision.
   if (param.type === 'integer' || param.type === 'number') {
-    const numValue = value === '' ? undefined : Number(value);
     return (
-      <InputNumber
+      <Input
         size="small"
         status={status}
-        value={Number.isFinite(numValue) ? numValue : undefined}
-        onChange={(next) => onChange(next === null || next === undefined ? '' : String(next))}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
         placeholder={param.required ? t('apiDebug.inputNumber.required') : param.description}
+        inputMode={param.type === 'integer' ? 'numeric' : 'decimal'}
         style={{ width: '100%' }}
-        step={param.type === 'integer' ? 1 : undefined}
       />
     );
   }


### PR DESCRIPTION
## 关联 Issue
- Closes #515

## 变更内容
- 将 OpenAPI 3 React UI 调试面板中 `integer` / `number` 类型的 Path、Query、Header、Cookie 参数输入从 `InputNumber` 改为字符串 `Input`。
- 保留 `inputMode` 数字键盘提示，避免雪花 ID 等超出 JavaScript 安全整数范围的值被浏览器或组件转成 `Number` 后丢失精度。

## 协作门禁
- Worker：本轮未启动。原因：当前 Codex subagent 工具策略要求用户显式授权后才能启动子 agent；本任务为单文件低风险前端修复，由 coordinator 直接处理。
- Reviewer：本轮未启动。原因同上；未声称独立审查，等待 PR CI 与维护者 review。

## 验证
- `./scripts/test-front-core.sh`：通过。
- `git diff --check`：通过。

## 风险
- 仅影响调试参数输入控件，提交给 `knife4j-core` 的请求构建值仍为字符串。
- 表单 body 字段输入未纳入本次范围，issue 指向的是 Path / Query 调试参数。