### PR TITLE
docs: 首页默认 Maven 坐标改为 Spring Boot 4

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -15,7 +15,7 @@ title: 快速开始
 如果不确定哪个版本合适，先看 [版本参考表](../reference/version-ref)。
 :::
 
-## 路径一：Spring Boot 4.x + OpenAPI3 Boot4
+## 路径一：Spring Boot 4.x + OpenAPI3 Boot4（默认推荐）
 
 ### 环境要求
 
@@ -65,7 +65,7 @@ Controller 写法与 Boot 3.x Jakarta 版一致，annotation 使用 `io.swagger.
 
 ---
 
-## 路径二：Spring Boot 3.x + OpenAPI3 Jakarta（推荐）
+## 路径二：Spring Boot 3.x + OpenAPI3 Jakarta
 
 ### 环境要求
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,17 @@ features:
 
 ## 60 秒上手
 
-Spring Boot 3.x（Jakarta）：
+默认推荐 **Spring Boot 4.x**：
+
+```xml
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
+    <version>5.0.15</version>
+</dependency>
+```
+
+仍在 **Spring Boot 3.x** 时：
 
 ```xml
 <dependency>
@@ -58,6 +68,8 @@ Spring Boot 3.x（Jakarta）：
     <version>5.0.15</version>
 </dependency>
 ```
+
+Spring Boot 2.x / Gateway / 独立聚合等场景，将 `artifactId` 换成对应 starter，见 [快速开始](/guide/getting-started)。
 
 最小配置（使用 springdoc 默认 `/v3/api-docs` 和 `/swagger-ui.html`）：
 


### PR DESCRIPTION
## 摘要

- 文档站首页「60 秒上手」默认 Maven 示例改为 `knife4j-openapi3-boot4-spring-boot-starter`，与 README（#516 / PR #517）一致。
- 首页同时保留 Spring Boot 3.x（`knife4j-openapi3-jakarta-spring-boot-starter`）示例，并指向完整 starter 列表。
- 快速开始中将「默认推荐」标注从 Boot 3 路径移到 Boot 4 路径。

## 关联

- 跟进 #516：README 已改，文档站首页此前仍展示 Boot 3 坐标。

## 验证

- `./tools/test-docs.sh`：通过（VitePress build 成功）。
- `git diff --check`：通过。

## 协作门禁

- 跳过 worker / reviewer：纯文档两处文案对齐，无运行时行为变化。
- 替代验证：本地 docs build + 与 README 默认坐标对照。
- 剩余风险：低；仅影响文档展示，不涉及发布构件。