### PR TITLE
docs: 本仓 bug issue 也强制先复现再修

### DIFF
--- a/.agent/KNOWN_PITFALLS.md
+++ b/.agent/KNOWN_PITFALLS.md
@@ -2,11 +2,12 @@
 
 只列「违反一次就很痛」的项目特有经验。通用工程常识不写。
 
-## 上游与复现
+## 复现
 
-- **先复现再修。** upstream 问题可能在本 fork 已不存在（依赖升级、历史 fix、默认配置不同）。未复现就写 try-catch / null-guard 等于噪音；#303 是反面教材（真实是 springdoc 内 `StackOverflowError`，外层 NPE catch 拦不到）。
-- **读完 upstream 正文 + 堆栈 + 评论再定本仓库范围。** 可以「受 upstream 启发做本仓增强」，但 issue 必须写明**不自认为修了 upstream #N**。
-- **一分支一任务。** 不要一个 commit 绑多个 upstream 编号；smoke 必须构造报告场景再断言。
+- **本仓 bug 与 upstream 关联 bug 都要先复现再修。** 未复现就写 try-catch / null-guard /「防御性」补丁等于噪音。证据写进 issue，再动修复代码。
+- **upstream 问题可能在本 fork 已不存在**（依赖升级、历史 fix、默认配置不同）。#303 是反面教材（真实是 springdoc 内 `StackOverflowError`，外层 NPE catch 拦不到）。
+- **读完正文 + 堆栈 + 评论再定范围。** 受 upstream 启发做本仓增强时，issue 必须写明**不自认为修了 upstream #N**。
+- **一分支一任务。** 不要一个 commit 绑多个 issue 编号；回归测试必须构造报告场景再断言。
 
 ## 审查
 

--- a/.agent/PLAYBOOK.md
+++ b/.agent/PLAYBOOK.md
@@ -14,11 +14,12 @@
 1. 读 `AGENTS.md`；按任务补读 `.agent/PROJECT.md` / `RUNBOOK.md` 等。
 2. 确认任务：维护者指定，或 `agent-task` + `status:ready` 的 issue。
 3. 可执行性检查（见下）；缺信息先补 issue 或问维护者。
-4. 开/切分支：`agent/<task-id>-<slug>`（无 issue：`agent/codex-<slug>`）。
-5. 最小改动；不夹带无关清理。
-6. 跑 `.agent/RUNBOOK.md` 中最窄验证。
-7. 开/更新 PR，`gh pr checks <N> --watch`。
-8. 本地验证 + 审查结论 + CI 全绿后，才把 issue 标 `status:review`。
+4. **Bug 类任务：先按 RUNBOOK 复现并贴证据，再写修复。**
+5. 开/切分支：`agent/<task-id>-<slug>`（无 issue：`agent/codex-<slug>`）。
+6. 最小改动；不夹带无关清理。
+7. 跑 `.agent/RUNBOOK.md` 中最窄验证。
+8. 开/更新 PR，`gh pr checks <N> --watch`。
+9. 本地验证 + 审查结论 + CI 全绿后，才把 issue 标 `status:review`。
 
 ## 可执行性检查
 
@@ -30,12 +31,15 @@
 - 完成条件
 - 风险与是否需要人工决策
 
-Upstream 相关还必须：
+**Bug / 回归 / 错误行为**（本仓 issue 与 upstream 关联均适用）还必须：
+
+- 在未打补丁基线上复现成功，证据已写进 issue（见 RUNBOOK「Bug 复现」）
+- 或已说明复现失败并 `blocked` / close——**不得**在未复现时直接写修复
+
+Upstream 关联额外：
 
 - 读完 upstream 原文、堆栈、截图与评论
-- 在本仓库能否复现（见 RUNBOOK）
 - 若只是衍生范围，issue 须写明**不自认为修了 upstream**
-
 ## 风险与审查
 
 | 级别 | 例子 | 做法 |

--- a/.agent/RUNBOOK.md
+++ b/.agent/RUNBOOK.md
@@ -25,15 +25,28 @@
 - Java 改动的 PR / issue 应能指向 smoke 证据：本地 `test-java.sh` 尾部 `Smoke-tests evidence OK`，或 CI 的 smoke summary。
 - 增删 smoke 模块时同步更新 `tools/test-java.sh` 的 `SMOKE_MODULES` 与 `.github/workflows/build.yml` 中的 summary 列表（若仓库已抽出 `tools/smoke-modules.txt` 则只改该文件）。
 
-## 上游 issue 复现（强制）
+## Bug 复现（强制）
 
-正文含 `Upstream: ...` 或标题带 `(upstream #N)` 时，**先复现再写修复**：
+凡 **bug / 回归 / 错误行为** 类任务（本仓 issue 或 upstream 关联），**先复现再写修复**。  
+不适用于：纯文档、流程文案、明确的新功能、无行为主张的格式化/重构。
 
-1. 读完 upstream 堆栈、触发条件、版本组合；缺信息 → 评论说明并 `status:blocked`。
-2. 在 `knife4j-smoke-tests/` 复用或新建最小工程，**显式 pin** 相关版本。
-3. 在未打补丁的 master 上复现，把证据贴 issue。
-4. 复现不到：写明尝试条件；已修复则 close 并链 commit；否则 blocked。**禁止**空想 try-catch / null-guard。
-5. 能复现：先写会失败的断言，再修，修后应变绿。
+### 通用步骤
+
+1. **读完问题描述**：堆栈、触发步骤、版本组合、期望 vs 实际；缺信息 → 评论说明并 `status:blocked`，不要猜。
+2. **在未打补丁的 master（或任务指定的基线）上复现**，留下可核对证据（命令输出、HTTP 响应、日志片段、失败测试）。证据贴 issue 评论。
+3. **复现手段按区域选择**（能自动化的优先自动化）：
+   - Java / starter / 兼容：优先 `knife4j-smoke-tests/` 复用或新建最小工程；相关版本**显式 pin**；登记 smoke 列表（见上）。
+   - `front/core`：失败单测或最小解析夹具。
+   - UI：最小复现步骤 + 能固定的测试/断言；纯视觉问题至少写清浏览器与操作路径及截图/描述。
+4. **复现不到**：写明已尝试条件；若历史已修则 close 并链 commit；否则 `status:blocked` 等补充信息。**禁止**空想 try-catch / null-guard /「防御性」补丁。
+5. **能复现**：先增加（或确认）在修复前会失败的断言/复现步骤，再修；修后同一证据应变绿或现象消失。
+
+### 额外：upstream 关联
+
+正文含 `Upstream: ...` 或标题带 `(upstream #N)` 时，在上述步骤之外还须：
+
+- 读完 upstream 原文、堆栈与评论，再定本仓范围。
+- 若本仓只做衍生增强，issue 须写明**不自认为修了 upstream #N**。
 
 ## PR 与 CI
 

--- a/.agent/prompts/coordinator.md
+++ b/.agent/prompts/coordinator.md
@@ -11,11 +11,12 @@
 
 硬规则：
 - 不 push master；不擅自发版/改坐标/secrets；不扩 scope
+- Bug/回归：先复现并贴证据到 issue，再写修复（本仓与 upstream 均适用）；见 RUNBOOK
 - 验证优先 ./tools/test-*.sh
 - 状态用 GitHub Issue label；进度写 issue/PR 评论
 - 中文写 commit / issue / PR
 
-循环：确认任务 → 分支 → 最小改动 → 验证 → PR → gh pr checks --watch → 审查与 CI 过后再标 status:review
+循环：确认任务 →（bug 则先复现）→ 分支 → 最小改动 → 验证 → PR → gh pr checks --watch → 审查与 CI 过后再标 status:review
 
 需要拆分时：
 - worker：.agent/prompts/worker.md + 当次 Allowed files / 验证命令

--- a/.agent/prompts/reviewer.md
+++ b/.agent/prompts/reviewer.md
@@ -8,7 +8,8 @@
 对照任务完成条件、PROJECT 边界、AUTONOMY_POLICY、RUNBOOK 审查 diff。
 只返回发现，不改代码。
 
-重点：回归、兼容、验证是否真跑过、范围漂移、不安全假设。
+重点：bug 是否先复现再修、回归、兼容、验证是否真跑过、范围漂移、不安全假设。
+Bug 修复若 issue/PR 无复现证据，视为 validation_gaps，倾向 revise/block。
 
 recommendation 规则：
 - 有 block/high → block

--- a/.agent/prompts/worker.md
+++ b/.agent/prompts/worker.md
@@ -7,6 +7,7 @@
 
 只改 Allowed files or modules 列出的路径。必须改范围外文件时停止并在 risks 说明。
 不改 issue label，不写最终 PR 叙事，不做无关清理。
+Bug/回归任务：确认主会话已完成复现（或按分配先复现）；禁止未复现就写防御性补丁。
 按分配的 Validation command 验证；前端相关优先仓库 ./tools/test-*.sh。
 
 返回 handoff：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@
 | 本文件 | 始终 |
 | `.agent/PROJECT.md` | 改产品行为、前端线、模块边界时 |
 | `.agent/AUTONOMY_POLICY.md` | 不确定能不能改某类东西时 |
-| `.agent/RUNBOOK.md` | 需要选验证命令、发版验收、复现 upstream 时 |
-| `.agent/KNOWN_PITFALLS.md` | 触碰 Java 兼容、upstream、审查结论时 |
+| `.agent/RUNBOOK.md` | 选验证命令、**bug 复现**、发版验收时 |
+| `.agent/KNOWN_PITFALLS.md` | 触碰 Java 兼容、bug/upstream、审查结论时 |
 | `.agent/PLAYBOOK.md` | 需要完整工作循环时 |
 | `.agent/COORDINATION.md` | 需要拆 worker / 独立 reviewer 时 |
 
@@ -27,6 +27,7 @@
 3. 不删除大模块或重要历史路径，除非维护者明确批准。
 4. OAS3 新功能只进 `front/ui-react`；`front/vue3` 仅 OAS2 兼容维护，不做功能扩张。
 5. 一个分支只做一件可独立验证的事；优先小而可回滚。
+6. **Bug / 回归类任务先复现再修**（本仓 issue 与 upstream 关联均适用）；证据写入 issue。细则见 `.agent/RUNBOOK.md`。
 
 ## 任务状态（Issue）
 
@@ -45,7 +46,7 @@
 
 ## 默认工作方式
 
-维护者在场时：**单 agent 端到端** 即可（实现 → `./tools/test-*` → PR → 等 CI）。  
+维护者在场时：**单 agent 端到端** 即可。Bug 类路径为：复现并贴证据 → 实现 → `./tools/test-*` → PR → 等 CI。  
 高风险改动需要第二意见（独立 agent 或维护者人工审），见 `.agent/COORDINATION.md` 与 `.agent/PLAYBOOK.md`。
 
 分支：`agent/<task-id>-<slug>`；无 issue 的现场小改可用 `agent/codex-<slug>` 并在 PR 说明原因。


### PR DESCRIPTION
## 变更

维护者要求：本仓 bug issue 与 upstream 关联任务一样，**先复现再修**。

- `RUNBOOK`：原「上游 issue 复现」改为通用「Bug 复现（强制）」+ upstream 附加条款
- `PLAYBOOK` / `AGENTS`：循环与硬约束写明
- `KNOWN_PITFALLS`、coordinator/worker/reviewer 提示词同步

不适用：纯文档、流程、明确新功能、无行为主张的重构。

## 验证

文档交叉引用自检；无运行时代码变更。