### PR TITLE
fix: Markdown 超长连续英文不再撑开文档页 (#528)

### DIFF
--- a/front/ui-react/src/components/Markdown.tsx
+++ b/front/ui-react/src/components/Markdown.tsx
@@ -13,7 +13,7 @@ const Markdown = memo(({ source, preserveLineBreaks = false }: MarkdownProps) =>
     return DOMPurify.sanitize(rawHtml);
   }, [preserveLineBreaks, source]);
 
-  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+  return <div className="knife4j-markdown" dangerouslySetInnerHTML={{ __html: html }} />;
 });
 
 Markdown.displayName = 'Markdown';

--- a/front/ui-react/src/index.css
+++ b/front/ui-react/src/index.css
@@ -148,6 +148,39 @@ body {
   margin: 0;
 }
 
+/*
+ * Markdown long-token overflow (#528):
+ * Unbreakable English/API-key strings and <pre> blocks must not stretch the page.
+ */
+.knife4j-markdown {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.knife4j-markdown pre {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.knife4j-markdown pre code {
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+}
+
+.knife4j-markdown :not(pre) > code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.knife4j-markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 @media (max-width: 800px) {
   .knife4j-operation-tabs.ant-tabs-left > .ant-tabs-nav {
     min-width: 88px;

--- a/front/ui-react/src/pages/document/MarkdownDocument.tsx
+++ b/front/ui-react/src/pages/document/MarkdownDocument.tsx
@@ -27,7 +27,7 @@ const MarkdownDocument: React.FC = () => {
   }
 
   return (
-    <div style={{ padding: '16px 24px', maxWidth: 900, minWidth: 0, width: '100%', boxSizing: 'border-box' }}>
+    <div style={{ padding: '16px 24px', minWidth: 0, width: '100%', maxWidth: '100%', boxSizing: 'border-box' }}>
       <h2 style={{ marginBottom: 16, overflowWrap: 'anywhere' }}>{doc.title}</h2>
       <Markdown source={doc.content} />
     </div>

--- a/front/ui-react/src/pages/document/MarkdownDocument.tsx
+++ b/front/ui-react/src/pages/document/MarkdownDocument.tsx
@@ -27,8 +27,8 @@ const MarkdownDocument: React.FC = () => {
   }
 
   return (
-    <div style={{ padding: '16px 24px', maxWidth: 900 }}>
-      <h2 style={{ marginBottom: 16 }}>{doc.title}</h2>
+    <div style={{ padding: '16px 24px', maxWidth: 900, minWidth: 0, width: '100%', boxSizing: 'border-box' }}>
+      <h2 style={{ marginBottom: 16, overflowWrap: 'anywhere' }}>{doc.title}</h2>
       <Markdown source={doc.content} />
     </div>
   );

--- a/front/vue3/src/assets/css/markdown-preview.css
+++ b/front/vue3/src/assets/css/markdown-preview.css
@@ -1,6 +1,7 @@
 .markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
+  box-sizing: border-box;
   color: #333;
   overflow: hidden;
   font-family:
@@ -9,7 +10,12 @@
     sans-serif;
   font-size: 16px;
   line-height: 1.6;
+  /* #528: contain long unbroken tokens inside flex/layout parents */
+  min-width: 0;
+  max-width: 100%;
   word-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .markdown-body * {
@@ -203,6 +209,8 @@
   font-size: 85%;
   background-color: rgba(0, 0, 0, 0.04);
   border-radius: 3px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .markdown-body code:before,
@@ -213,7 +221,10 @@
 
 .markdown-body pre {
   padding: 16px;
-  overflow: auto;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: auto;
   font-size: 85%;
   line-height: 1.45;
   word-wrap: normal;
@@ -231,6 +242,7 @@
   line-height: inherit;
   word-break: normal;
   word-wrap: normal;
+  overflow-wrap: normal;
   white-space: pre;
   background: transparent;
   border: 0;
@@ -397,7 +409,10 @@
 
 .editormd-preview-container,
 .editormd-html-preview {
+  box-sizing: border-box;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
   padding: 20px;
   overflow: auto;
   font-size: 14px;

--- a/front/vue3/src/components/Markdown/index.vue
+++ b/front/vue3/src/components/Markdown/index.vue
@@ -52,3 +52,13 @@ export default {
   }
 }
 </script>
+
+<style>
+/* #528: flex parents (e.g. a-row.markdown-body) must not grow with long tokens / pre */
+.knife4j-markdown {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+</style>


### PR DESCRIPTION
## 摘要

修复自定义 Markdown 文档中超长连续英文字符（如 API key）把页面横向撑开的问题（#528）。

- **React（OAS3 主线）**：`Markdown` 增加 `knife4j-markdown` 容器样式（`overflow-wrap: anywhere`、`pre` 横向滚动）；`MarkdownDocument` 约束 `minWidth`/`width`
- **Vue3（OAS2 兼容）**：`markdown-preview.css` 与 `.knife4j-markdown` 补齐 `min-width:0` / `box-sizing` / 换行与 `pre` 溢出，避免 `a-row` flex 子项被拉宽

## 关联

Closes #528

## 复现与验证

### 复现（修前 master）

Chrome headless 布局测量：长 token（600+ 无空格）+ 真实结构

| 路径 | 结果 |
|---|---|
| Vue3 `othermarkdown`（`a-row.markdown-body`） | container `904 → 5343`，页面撑开 |
| React `MarkdownDocument` 裸渲染 | content `856 → 6048`，页面撑开 |

证据见 issue 评论。

### 修后

同脚本：Vue3 / React 均 `pageStretched=false`；段落换行；`pre` 仅内部横向滚动。

### 脚本

- `./tools/test-front-core.sh` ✅
- `./tools/test-vue3.sh` ✅

## 风险

- 仅 CSS / 容器 class，不改 Markdown 解析语义
- 长单词可能在段落内被断行；代码块保持 `pre` + 横向滚动