### PR TITLE
ci: 按改动范围运行构建门禁

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,44 +5,45 @@ env:
 
 on:
   pull_request:
-    paths:
-      - "knife4j/**"
-      - "front/core/**"
-      - "front/ui-react/**"
-      - "front/package.json"
-      - "front/bun.lock"
-      - "front/vue3/**"
-      - "docs/**"
-      - "tools/**"
-      - ".github/workflows/build.yml"
-      - ".github/workflows/release.yml"
-      - ".java-version"
-      - ".nvmrc"
-      - ".editorconfig"
-      - ".gitattributes"
-      - "CONTRIBUTING.md"
   push:
     branches:
       - master
-    paths:
-      - "knife4j/**"
-      - "front/core/**"
-      - "front/ui-react/**"
-      - "front/package.json"
-      - "front/bun.lock"
-      - "front/vue3/**"
-      - "docs/**"
-      - "tools/**"
-      - ".github/workflows/build.yml"
-      - ".github/workflows/release.yml"
-      - ".java-version"
-      - ".nvmrc"
-      - ".editorconfig"
-      - ".gitattributes"
-      - "CONTRIBUTING.md"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      java: ${{ steps.classify.outputs.java }}
+      react: ${{ steps.classify.outputs.react }}
+      vue3: ${{ steps.classify.outputs.vue3 }}
+      docs: ${{ steps.classify.outputs.docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          changed_paths="$(mktemp)"
+          trap 'rm -f "$changed_paths"' EXIT
+          if [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA" >/dev/null 2>&1 || true
+          fi
+          if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null || ! git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null || ! git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$changed_paths"; then
+            tools/ci-changes.sh </dev/null >> "$GITHUB_OUTPUT"
+          else
+            tools/ci-changes.sh < "$changed_paths" >> "$GITHUB_OUTPUT"
+          fi
+
   java-build-test:
+    needs: changes
+    if: needs.changes.outputs.java == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -68,14 +69,6 @@ jobs:
 
       - name: Set up bun
         uses: oven-sh/setup-bun@v2
-
-      - name: Install front workspace dependencies
-        run: bun install --frozen-lockfile
-        working-directory: front
-
-      - name: Install front/vue3 dependencies (bun)
-        run: bun install --frozen-lockfile
-        working-directory: front/vue3
 
       - name: Verify Java modules
         run: tools/test-java.sh
@@ -122,6 +115,8 @@ jobs:
           if-no-files-found: ignore
 
   front-core-test:
+    needs: changes
+    if: needs.changes.outputs.react == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -141,7 +136,31 @@ jobs:
       - name: Test front core
         run: tools/test-front-core.sh
 
+  vue3-test:
+    needs: changes
+    if: needs.changes.outputs.vue3 == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Test Vue3 UI
+        run: tools/test-vue3.sh
+
   docs-build:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/tools/ci-changes.sh
+++ b/tools/ci-changes.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+java=false
+react=false
+vue3=false
+docs=false
+saw_path=false
+full=false
+
+while IFS= read -r path || [ -n "$path" ]; do
+  saw_path=true
+  case "$path" in
+    docs/*|tools/test-docs.sh)
+      docs=true
+      ;;
+    knife4j/*|tools/test-java.sh|tools/verify-release-modules.sh|tools/release-modules.txt|.java-version)
+      java=true
+      ;;
+    front/core/*|front/ui-react/*|front/package.json|front/bun.lock|tools/test-front-core.sh)
+      java=true
+      react=true
+      ;;
+    front/vue3/*|tools/test-vue3.sh)
+      java=true
+      vue3=true
+      ;;
+    .github/workflows/*|.editorconfig|.gitattributes|.nvmrc|tools/ci-changes.sh|tools/test-ci-changes.sh)
+      full=true
+      ;;
+    README.md|CONTRIBUTING.md|AGENTS.md|.agent/*|.gitignore|tools/README.md|tools/agent-status.sh|tools/claude/*|tools/test-all.sh|tools/extract-release-note.sh|tools/verify-github-release.sh)
+      ;;
+    *)
+      full=true
+      ;;
+  esac
+done
+
+if [ "$saw_path" = false ] || [ "$full" = true ]; then
+  java=true
+  react=true
+  vue3=true
+  docs=true
+fi
+
+printf 'java=%s\nreact=%s\nvue3=%s\ndocs=%s\n' "$java" "$react" "$vue3" "$docs"

--- a/tools/test-ci-changes.sh
+++ b/tools/test-ci-changes.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+classifier="$repo_root/tools/ci-changes.sh"
+
+outputs() {
+  printf 'java=%s\nreact=%s\nvue3=%s\ndocs=%s\n' "$1" "$2" "$3" "$4"
+}
+
+assert_case() {
+  local name=$1
+  local expected=$2
+  local input=$3
+  local actual
+
+  if [ "$input" = "__EMPTY__" ]; then
+    actual="$("$classifier" </dev/null)"
+  else
+    actual="$(printf '%s\n' "$input" | "$classifier")"
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s\nexpected:\n%s\nactual:\n%s\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+none="$(outputs false false false false)"
+docs_only="$(outputs false false false true)"
+java_only="$(outputs true false false false)"
+react_and_java="$(outputs true true false false)"
+vue3_and_java="$(outputs true false true false)"
+all="$(outputs true true true true)"
+
+assert_case "docs" "$docs_only" $'docs/guide/index.md\ntools/test-docs.sh'
+assert_case "java" "$java_only" $'knife4j/knife4j-core/pom.xml\ntools/test-java.sh\ntools/verify-release-modules.sh\ntools/release-modules.txt\n.java-version'
+assert_case "react" "$react_and_java" $'front/core/src/index.ts\nfront/ui-react/src/App.tsx\nfront/package.json\nfront/bun.lock\ntools/test-front-core.sh'
+assert_case "vue3" "$vue3_and_java" $'front/vue3/src/App.vue\ntools/test-vue3.sh'
+assert_case "shared configuration" "$all" $'.github/workflows/build.yml\n.editorconfig\n.gitattributes\n.nvmrc\ntools/ci-changes.sh\ntools/test-ci-changes.sh'
+assert_case "unknown path" "$all" "new-area/example.txt"
+assert_case "maintenance files" "$none" $'README.md\nCONTRIBUTING.md\nAGENTS.md\n.agent/PROJECT.md\n.gitignore\ntools/README.md\ntools/agent-status.sh\ntools/claude/run.sh\ntools/test-all.sh\ntools/extract-release-note.sh\ntools/verify-github-release.sh'
+assert_case "empty input" "$all" "__EMPTY__"
+
+printf 'ci change classification tests passed\n'


### PR DESCRIPTION
## 关联任务

- 维护者现场指定的 CI 优化，无对应 Issue。

## 变更内容

- Build 始终先执行轻量变更分类，再按 Java、React、Vue3、文档的实际依赖条件运行对应 job。
- Vue3 改动仅运行 vue3-test 与 java-build-test，不再误跑 front-core-test；React/Vue3 仍保留 Java webjar 打包验证。
- Java job 移除两次与 Maven reactor 重复的 Bun 预安装；Maven 内的 UI 构建仍保留。
- 未识别路径和 CI 共享配置回退为全量验证，并新增无依赖分类回归测试。

## 验证

- 通过：bash tools/test-ci-changes.sh
- 通过：./tools/test-vue3.sh
- 通过：./tools/test-front-core.sh（受限环境 Bun 临时目录不可写后，在可写临时目录环境重跑）
- 通过：./tools/test-docs.sh
- 本地 Java 门禁未进入 Maven reactor 即卡在本机 java -version，已停止；以本 PR 的 java-build-test 作为最终验证。

## 协作门禁

- Worker：完成限定在 Build workflow 与 CI 分类脚本的实现。
- Reviewer：独立审查通过，无发现；待真实 PR 事件确认分类 job 的 SHA 获取和 job 跳过状态。

## 风险与范围外

- 未改 Release 或 Build and Deploy Demo；分类器无法获取完整 diff 时会回退全量，不会漏测。