### PR TITLE
ci: 仅在 v* tag 部署在线 Demo

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,17 +1,10 @@
 name: Build and Deploy Demo
 
+# Demo 只跟已发布版本对齐：master 合并不自动部署，避免线上 demo 跑到
+# 用户尚未能通过 Maven Central 拿到的未发版 master 代码。
+# 紧急手动部署仍可用 workflow_dispatch。
 on:
   push:
-    branches:
-      - master
-    paths:
-      - 'knife4j/**'
-      - 'front/core/**'
-      - 'front/ui-react/**'
-      - 'front/package.json'
-      - 'front/bun.lock'
-      - 'front/vue3/**'
-      - '.github/workflows/deploy-demo.yml'
     tags:
       - 'v*'
   workflow_dispatch:

--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -155,7 +155,7 @@ docker run --rm -p 8081:8081 \
 
 ## 镜像发布
 
-两个 demo 镜像都由 `.github/workflows/deploy-demo.yml` 在 `master` 推送时通过 matrix 构建并推送到 GitHub Container Registry：
+两个 demo 镜像都由 `.github/workflows/deploy-demo.yml` 在推送 `v*` 发布 tag 时通过 matrix 构建并推送到 GitHub Container Registry（`master` 合并不自动部署，保证在线 demo 与已发布版本一致；紧急情况可 `workflow_dispatch` 手动跑）：
 
 - `ghcr.io/songxychn/knife4j-next/knife4j-next-demo-openapi3:latest`
 - `ghcr.io/songxychn/knife4j-next/knife4j-next-demo-openapi2:latest`

--- a/knife4j/RELEASE.md
+++ b/knife4j/RELEASE.md
@@ -18,6 +18,7 @@
 
 - `.github/workflows/build.yml` 在 PR 和 `master` push 时运行 `mvn verify` 等验证。
 - `.github/workflows/release.yml` 在推送 `v*` tag 时发布 Maven Central 构件，并创建 GitHub Release。
+- `.github/workflows/deploy-demo.yml` 仅在推送 `v*` tag（或 `workflow_dispatch`）时构建并部署在线 demo，**不在** `master` 合并时自动部署，避免 demo 超前于已发布版本。
 
 ## Release flow
 
@@ -26,11 +27,11 @@
 3. 提交并合并 release prep PR，等待 PR CI 和 `master` push CI 通过。
 4. 创建并推送 tag，例如 `v5.0.8`。
 5. 等待 GitHub Actions `Release` workflow 完成发布。
-6. 等待 `Build and Deploy Demo` workflow 完成 demo 镜像发布。
+6. 等待同一次 tag 触发的 `Build and Deploy Demo` workflow 完成 demo 镜像发布。
 7. 验收发布完成条件：
    - `vX.Y.Z` tag 已推送。
    - `Release` workflow 成功。
-   - `Build and Deploy Demo` workflow 成功。
+   - `Build and Deploy Demo` workflow 成功（与 tag 对齐，非 master 合并触发）。
    - Maven Central 目标构件可访问。
    - GitHub Release `vX.Y.Z` 存在。
    - GitHub Release body 与 `docs/release-notes/index.md` 中对应版本小节一致。


### PR DESCRIPTION
## 背景

合并到 `master` 时会自动跑 `Build and Deploy Demo`，而 Maven 新版本要等 `v*` tag 才对用户可见。线上 demo 因此常会“超前”于 Central 上的稳定版，造成误解。

## 变更

- `.github/workflows/deploy-demo.yml`：去掉 `push.branches: master`（及 paths 过滤）；**仅**在 `v*` tag 与 `workflow_dispatch` 时部署。
- 同步 `docs/guide/demo.md`、`knife4j/RELEASE.md` 说明。

## 影响

- 日常 master 合并：只跑 `Build`，不再部署 demo。
- 正式发版打 tag：仍会跑 `Release` + `Deploy Demo`（与已发布版本对齐）。
- 紧急需要可手动 `workflow_dispatch`。

## 验证

- 工作流 YAML 语法与触发条件人工核对。
- 文档与 RELEASE 流程描述一致。