### PR TITLE
fix(ui-react): 限制 Tab 右键菜单作用域

### DIFF
--- a/front/ui-react/src/App.tsx
+++ b/front/ui-react/src/App.tsx
@@ -349,6 +349,11 @@ const AppInner: React.FC = () => {
   const groupOptions = groups.map((g) => ({ value: g.value, label: g.label }));
   const tabItems = items.map((item) => ({
     ...item,
+    label: (
+      <Dropdown menu={{ items: contextMenuItems }} trigger={['contextMenu']}>
+        <span onContextMenu={() => setContextMenuKey(item.key)}>{item.label}</span>
+      </Dropdown>
+    ),
     closable: item.key !== HOME_KEY,
     children: item.key === activeKey ? <Outlet /> : item.children,
   }));
@@ -471,20 +476,16 @@ const AppInner: React.FC = () => {
                 style={{ margin: '2px 2px 8px' }}
               />
             )}
-            <Dropdown menu={{ items: contextMenuItems }} trigger={['contextMenu']}>
-              <div>
-                <Tabs
-                  hideAdd
-                  onChange={onChange}
-                  activeKey={activeKey}
-                  type="editable-card"
-                  onEdit={onEdit}
-                  items={tabItems}
-                  style={{ flex: 1, margin: '2px 2px' }}
-                  onTabClick={(key) => setContextMenuKey(key)}
-                />
-              </div>
-            </Dropdown>
+            <Tabs
+              hideAdd
+              onChange={onChange}
+              activeKey={activeKey}
+              type="editable-card"
+              onEdit={onEdit}
+              items={tabItems}
+              style={{ flex: 1, margin: '2px 2px' }}
+              onTabClick={(key) => setContextMenuKey(key)}
+            />
           </div>
         </Content>
 


### PR DESCRIPTION
Closes #536

## 变更

- 将 Tab 右键菜单从整个 Tabs 容器收窄到各 Tab 标签。
- 文档内容区不再被菜单触发区域覆盖。

## 原因

外层 Dropdown 包裹整个 Tabs，导致内容区的 contextmenu 也会触发 Tab 菜单。

## 验证

- `./tools/test-front-core.sh`
- 本地 demo（27 个接口）：内容区右键无 Tab 菜单；Tab 标签右键保留关闭菜单。

## 影响

仅调整 ui-react 的右键触发范围；未改 Tab 关闭逻辑。