### PR TITLE
fix: 恢复发布包 Spring Boot 配置元数据 （541）

### DIFF
--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
@@ -107,11 +107,16 @@
                     <source>${knife4j-java.version}</source>
                     <target>${knife4j-java.version}</target>
                     <encoding>${knife4j-project.build.sourceEncoding}</encoding>
-                    <annotationProcessorPaths>
+                    <annotationProcessorPaths combine.self="override">
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>${knife4j-lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${knife4j-spring-boot3.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
@@ -72,4 +72,27 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths combine.self="override">
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${knife4j-lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${knife4j-spring-boot.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
@@ -55,5 +55,27 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths combine.self="override">
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${knife4j-lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${knife4j-spring-boot.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
@@ -114,5 +114,27 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths combine.self="override">
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${knife4j-lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${knife4j-spring-boot.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
@@ -79,11 +79,16 @@
                     <source>${knife4j-java.version}</source>
                     <target>${knife4j-java.version}</target>
                     <encoding>${knife4j-project.build.sourceEncoding}</encoding>
-                    <annotationProcessorPaths>
+                    <annotationProcessorPaths combine.self="override">
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>${knife4j-lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${knife4j-spring-boot3.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
@@ -98,5 +98,27 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths combine.self="override">
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${knife4j-lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${knife4j-spring-boot.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/tools/ci-changes.sh
+++ b/tools/ci-changes.sh
@@ -14,7 +14,7 @@ while IFS= read -r path || [ -n "$path" ]; do
     docs/*|tools/test-docs.sh)
       docs=true
       ;;
-    knife4j/*|tools/test-java.sh|tools/verify-release-modules.sh|tools/release-modules.txt|.java-version)
+    knife4j/*|tools/test-java.sh|tools/verify-configuration-metadata.sh|tools/verify-release-modules.sh|tools/release-modules.txt|.java-version)
       java=true
       ;;
     front/core/*|front/ui-react/*|front/package.json|front/bun.lock|tools/test-front-core.sh)

--- a/tools/test-ci-changes.sh
+++ b/tools/test-ci-changes.sh
@@ -34,7 +34,7 @@ vue3_and_java="$(outputs true false true false)"
 all="$(outputs true true true true)"
 
 assert_case "docs" "$docs_only" $'docs/guide/index.md\ntools/test-docs.sh'
-assert_case "java" "$java_only" $'knife4j/knife4j-core/pom.xml\ntools/test-java.sh\ntools/verify-release-modules.sh\ntools/release-modules.txt\n.java-version'
+assert_case "java" "$java_only" $'knife4j/knife4j-core/pom.xml\ntools/test-java.sh\ntools/verify-configuration-metadata.sh\ntools/verify-release-modules.sh\ntools/release-modules.txt\n.java-version'
 assert_case "react" "$react_and_java" $'front/core/src/index.ts\nfront/ui-react/src/App.tsx\nfront/package.json\nfront/bun.lock\ntools/test-front-core.sh'
 assert_case "vue3" "$vue3_and_java" $'front/vue3/src/App.vue\ntools/test-vue3.sh'
 assert_case "shared configuration" "$all" $'.github/workflows/build.yml\n.editorconfig\n.gitattributes\n.nvmrc\ntools/ci-changes.sh\ntools/test-ci-changes.sh'

--- a/tools/test-java.sh
+++ b/tools/test-java.sh
@@ -12,6 +12,8 @@ cd "$REPO_ROOT/knife4j"
 mvn -B -ntp spotless:check
 mvn -B -ntp -Dknife4j-skipTests=false verify
 
+"$REPO_ROOT/tools/verify-configuration-metadata.sh"
+
 # ---------------------------------------------------------------------------
 # Smoke-tests evidence gate (issue #241 / #198 FU-3)
 #

--- a/tools/verify-configuration-metadata.sh
+++ b/tools/verify-configuration-metadata.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+specs=(
+  "knife4j-openapi2-spring-boot-starter|knife4j.enable|knife4j.production"
+  "knife4j-openapi3-spring-boot-starter|knife4j.enable|knife4j.production"
+  "knife4j-openapi3-jakarta-spring-boot-starter|knife4j.enable|knife4j.production"
+  "knife4j-aggregation-spring-boot-starter|knife4j.enable-aggregation"
+  "knife4j-aggregation-jakarta-spring-boot-starter|knife4j.enable-aggregation"
+  "knife4j-gateway-spring-boot-starter|knife4j.gateway.enabled"
+)
+
+tmp_metadata="$(mktemp)"
+trap 'rm -f "$tmp_metadata"' EXIT
+
+failures=()
+
+echo "==> Verifying Spring Boot configuration metadata"
+for spec in "${specs[@]}"; do
+  IFS='|' read -r module key1 key2 <<< "$spec"
+  target_dir="$repo_root/knife4j/$module/target"
+  jars=()
+
+  for candidate in "$target_dir"/"$module"-*.jar; do
+    if [ ! -e "$candidate" ]; then
+      continue
+    fi
+    case "$(basename "$candidate")" in
+      *-sources.jar|*-javadoc.jar|*-tests.jar)
+        continue
+        ;;
+    esac
+    jars+=("$candidate")
+  done
+
+  if [ "${#jars[@]}" -ne 1 ]; then
+    echo "   [MISSING] $module: expected one binary JAR under $target_dir, found ${#jars[@]}"
+    failures+=("$module")
+    continue
+  fi
+
+  jar_file="${jars[0]}"
+  if ! unzip -p "$jar_file" META-INF/spring-configuration-metadata.json > "$tmp_metadata" 2>/dev/null; then
+    echo "   [MISSING] $module: META-INF/spring-configuration-metadata.json"
+    failures+=("$module")
+    continue
+  fi
+
+  normalized="$(tr -d '[:space:]' < "$tmp_metadata")"
+  missing_keys=()
+  for key in "$key1" "${key2:-}"; do
+    if [ -z "$key" ]; then
+      continue
+    fi
+    case "$normalized" in
+      *"\"name\":\"$key\""*)
+        ;;
+      *)
+        missing_keys+=("$key")
+        ;;
+    esac
+  done
+
+  if [ "${#missing_keys[@]}" -ne 0 ]; then
+    echo "   [INVALID] $module: missing properties ${missing_keys[*]}"
+    failures+=("$module")
+    continue
+  fi
+
+  echo "   [OK]      $module: $(basename "$jar_file")"
+done
+
+if [ "${#failures[@]}" -ne 0 ]; then
+  echo "" >&2
+  echo "Configuration metadata verification failed for: ${failures[*]}" >&2
+  exit 1
+fi
+
+echo "==> Configuration metadata OK (${#specs[@]} modules)"


### PR DESCRIPTION
## 关联 issue

- Closes #541 
- upstream 灵感来源：N/A，本 PR 不涉及 upstream issue

## 变更摘要

修复 starter 发布包缺少 `META-INF/spring-configuration-metadata.json` 的问题，使 IDE 能够识别 `knife4j.enable`、`knife4j.production` 等配置项。

为 6 个包含本地 `@ConfigurationProperties` 的 starter 显式配置与模块 Spring Boot 版本对齐的 configuration processor，并增加最终二进制 JAR 元数据门禁。

本 PR 不修改运行时配置行为、Maven 坐标、依赖 scope、版本号或兼容性承诺。

## Upstream issue 处理自检

> 本 PR 不涉及 upstream issue，以下各项均为 N/A。

- [x] N/A：本 PR 未关联 upstream issue
- [x] N/A：本 PR 未引用 upstream 问题作为修复目标
- [x] N/A：复现目标为本仓库 `5.0.17` 发布 JAR 缺少配置元数据
- [x] N/A：本 PR 使用发布二进制 JAR 元数据门禁区分修复前后的行为
- [x] N/A：不存在与 upstream 诉求范围不同的问题

## 影响面自检

- [x] 本 PR未修改发布流程、项目坐标或兼容性承诺；仅调整编译期注解处理器配置和 Java CI 产物检查
- [x] 本 PR 修改了 Java starter 的构建配置，具体影响如下：
  - [x] `knife4j-openapi2-spring-boot-starter`：增加 Boot 2 configuration processor
  - [x] `knife4j-openapi3-spring-boot-starter`：增加 Boot 2 configuration processor
  - [x] `knife4j-openapi3-jakarta-spring-boot-starter`：增加与模块版本对齐的 Boot 3 configuration processor
  - [x] `knife4j-gateway-spring-boot-starter`：增加 Boot 2 configuration processor
  - [x] `knife4j-aggregation-*-starter`：为 Boot 2 和 Jakarta starter 增加对应版本的 configuration processor
  - [x] N/A：未修改 `knife4j-core` 的 filter、security 或 config 逻辑

上述修改仅影响编译期配置元数据生成，不改变 starter 的运行时自动配置行为。

## 验证

- [x] 使用 JDK 17.0.17、Bun 1.3.13 完整运行 `./tools/test-java.sh`
- [x] Maven reactor 全部 32 个模块构建成功
- [x] 13 个 smoke-tests 模块全部通过，`failures=0 errors=0`
- [x] 6 个目标 starter 的最终二进制 JAR 均包含 `META-INF/spring-configuration-metadata.json`
- [x] OpenAPI2、OpenAPI3、OpenAPI3 Jakarta starter 均包含 `knife4j.enable` 和 `knife4j.production`
- [x] Aggregation starter 包含 `knife4j.enable-aggregation`
- [x] Gateway starter 包含 `knife4j.gateway.enabled`
- [x] `tools/test-ci-changes.sh` 通过
- [x] 所有变更脚本通过 `bash -n` 语法检查
- [x] N/A：未修改前端源码；`tools/test-java.sh` 中集成的 Vue3、React UI 构建均成功
- [x] N/A：未修改文档站

```text
$ bun --version
1.3.13

$ java -version
openjdk version "17.0.17"

$ ./tools/test-java.sh
[INFO] Reactor Summary for knife4j 5.0.17:
[INFO] knife4j ............................................ SUCCESS
[INFO] knife4j-core ....................................... SUCCESS
[INFO] knife4j-openapi2-ui ................................ SUCCESS
[INFO] knife4j-openapi3-ui ................................ SUCCESS
[INFO] knife4j-openapi2-spring-boot-starter ............... SUCCESS
[INFO] knife4j-openapi3-spring-boot-starter ............... SUCCESS
[INFO] knife4j-aggregation-spring-boot-starter ............ SUCCESS
[INFO] knife4j-aggregation-jakarta-spring-boot-starter .... SUCCESS
[INFO] knife4j-openapi3-jakarta-spring-boot-starter ....... SUCCESS
[INFO] knife4j-gateway-spring-boot-starter ................ SUCCESS
[INFO] BUILD SUCCESS
[INFO] Total time: 04:37 min

==> Verifying Spring Boot configuration metadata
[OK] knife4j-openapi2-spring-boot-starter
[OK] knife4j-openapi3-spring-boot-starter
[OK] knife4j-openapi3-jakarta-spring-boot-starter
[OK] knife4j-aggregation-spring-boot-starter
[OK] knife4j-aggregation-jakarta-spring-boot-starter
[OK] knife4j-gateway-spring-boot-starter
==> Configuration metadata OK (6 modules)

==> Verifying smoke-tests evidence (issue #241)
[OK] boot2-app: tests=3 failures=0 errors=0
[OK] boot2-openapi3-app: tests=3 failures=0 errors=0
[OK] boot2-webflux-app: tests=1 failures=0 errors=0
[OK] aggregation-boot2-app: tests=1 failures=0 errors=0
[OK] boot3-aggregation-jakarta-app: tests=1 failures=0 errors=0
[OK] boot4-aggregation-app: tests=1 failures=0 errors=0
[OK] boot3-app: tests=1 failures=0 errors=0
[OK] boot3-jakarta-app: tests=7 failures=0 errors=0
[OK] boot3-webflux-jakarta-app: tests=1 failures=0 errors=0
[OK] boot3-gateway-app: tests=1 failures=0 errors=0
[OK] boot35-jakarta-app: tests=2 failures=0 errors=0
[OK] boot4-jakarta-app: tests=6 failures=0 errors=0
[OK] boot4-gateway-app: tests=1 failures=0 errors=0
==> Smoke-tests evidence OK (13 modules)

$ tools/test-ci-changes.sh
ci change classification tests passed

流程自检

已按现行 AGENTS.md、.agent/RUNBOOK.md、.agent/KNOWN_PITFALLS.md 和 .agent/PLAYBOOK.md 判断风险及验证门禁；模板中的旧 Playbook 路径不适用于当前仓库

commit message 仅关联 issue #541，分支未混入无关修复

未修改 Java 运行时核心逻辑；本 PR 标题和内容均明确为 starter 构建及发布产物修复

未绕过 PR 直推 master，未 force push 到 master

已附 worker handoff 摘要；按维护者在场模式由当前单 agent 端到端完成

已附 reviewer handoff 摘要；独立 reviewer 由维护者人工审查替代

N/A：当前没有 reviewer 的 block、high 或 medium 发现；仍需等待维护者 PR review 和远端 CI
Agent 交接
Worker：当前 Codex 单 agent。完成根因核对、6 个 starter POM 修改、配置元数据门禁脚本、CI 变更分类更新及本地全量验证。
Reviewer：由维护者进行 PR 人工审查；本地已检查真实 git diff、effective POM、最终二进制 JAR 和完整测试结果。
跳过角色与原因：未拆分独立 worker/reviewer。按照维护者在场的单 agent 工作模式执行；本改动的第二意见由维护者 PR review 和远端 CI 提供。
剩余风险：本地 JDK 17.0.17 + Bun 1.3.13 下全量验证通过，但远端 PR CI 尚未执行。后续若调整根 POM 的注解处理器列表或新增带本地 @ConfigurationProperties 的 Boot 4 starter，需要同步维护模块级 processor 配置和元数据门禁。