### PR TITLE
feat: 支持 Gateway Server Web MVC 聚合

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
             echo ""
             echo "| module | tests | failures | errors |"
             echo "| --- | ---: | ---: | ---: |"
-            for module in boot2-app boot2-openapi3-app boot2-webflux-app aggregation-boot2-app boot3-aggregation-jakarta-app boot4-aggregation-app boot3-app boot3-jakarta-app boot3-webflux-jakarta-app boot3-gateway-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
+            for module in boot2-app boot2-openapi3-app boot2-webflux-app aggregation-boot2-app boot3-aggregation-jakarta-app boot4-aggregation-app boot3-app boot3-jakarta-app boot3-webflux-jakarta-app boot3-gateway-app boot35-gateway-webmvc-app boot35-jakarta-app boot4-jakarta-app boot4-gateway-app; do
               dir="$root/$module/target/surefire-reports"
               if [ ! -d "$dir" ]; then
                 echo "| $module | (missing) | - | - |"

--- a/docs/guide/aggregation.md
+++ b/docs/guide/aggregation.md
@@ -8,7 +8,7 @@ title: Aggregation 聚合
 
 - 启动一个**专门用来聚合的 Servlet 应用**，读取若干下游服务的 OpenAPI 文档，合并成一套 `doc.html`。
 - 支持 **5 种数据源**：本地文件（Disk）、HTTP 直连（Cloud）、Nacos、Eureka、腾讯北极星（Polaris）。
-- 与 [Gateway starter](./gateway) 二选一：Gateway 跑在 WebFlux 技术栈内嵌；Aggregation 是独立 Servlet 应用。
+- 与 [Gateway starter](./gateway) 二选一：Gateway 聚合内嵌在 Gateway 进程中（WebFlux 或 Server Web MVC）；Aggregation 是独立 Servlet 应用。
 
 ## 何时选 aggregation 而不是 gateway
 
@@ -270,7 +270,7 @@ curl http://localhost:8080/swagger-resources
 | 对比项 | Gateway starter | Aggregation starter |
 | --- | --- | --- |
 | 运行形态 | 嵌入 Spring Cloud Gateway 进程 | 独立 Spring Boot 应用 |
-| 技术栈 | WebFlux | Servlet（spring-boot-starter-web） |
+| 技术栈 | WebFlux 或 Spring Cloud Gateway Server Web MVC | Servlet（spring-boot-starter-web） |
 | 数据源 | 服务发现 / 手动路由 | Disk / Cloud / Nacos / Eureka / Polaris |
 | 典型场景 | 已有 Gateway，顺带聚合 | 无 Gateway 或想独立部署聚合 |
 | 是否支持本地 JSON | ❌ | ✅（Disk 模式） |

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -4,7 +4,12 @@ title: Gateway 聚合
 
 # Gateway 聚合
 
-`knife4j-gateway-spring-boot-starter` 和 `knife4j-gateway-boot4-spring-boot-starter` 让 Spring Cloud Gateway 充当聚合入口：一次访问 `https://gateway/doc.html`，下面挂着所有下游微服务的 OpenAPI 分组。
+Knife4j 支持两种 Spring Cloud Gateway 聚合实现：
+
+- WebFlux Gateway：`knife4j-gateway-spring-boot-starter`（Boot 3.x）和 `knife4j-gateway-boot4-spring-boot-starter`（Boot 4.x）。
+- Gateway Server Web MVC：`knife4j-gateway-webmvc-spring-boot-starter`（Boot 3.5 / Spring Cloud 2025.0.x）。
+
+它们都让 Gateway 充当聚合入口：一次访问 `https://gateway/doc.html`，下面挂着所有下游微服务的 OpenAPI 分组。
 
 它解决三件事：
 
@@ -14,17 +19,17 @@ title: Gateway 聚合
 
 ## 适用场景
 
-- 项目使用 Spring Cloud Gateway（WebFlux 技术栈）。
+- 项目使用 Spring Cloud Gateway；WebFlux 与 Server Web MVC 要引入各自对应的 starter。
 - 下游服务已经用任一 knife4j starter 暴露 `/v2/api-docs` 或 `/v3/api-docs`。
 - 需要在 Gateway 层面合并、排序、打分组。
 
 ::: info 和 knife4j-aggregation-*-starter 的区别
-`knife4j-gateway-*-starter` 只跑在 Gateway 进程里（WebFlux）；`knife4j-aggregation-*-starter` 可以独立部署成聚合服务（Servlet）。二者不要在同一 Gateway 里同时启用。[Aggregation](./aggregation) 里有详细对比。
+`knife4j-gateway-*-starter` 只跑在 Gateway 进程里（WebFlux 或 Server Web MVC）；`knife4j-aggregation-*-starter` 可以独立部署成聚合服务（Servlet）。二者不要在同一 Gateway 里同时启用。[Aggregation](./aggregation) 里有详细对比。
 :::
 
 ## 最小依赖
 
-### Spring Boot 3.x / Spring Cloud Gateway 4.x
+### Spring Boot 3.x / Spring Cloud Gateway 4.x（WebFlux）
 
 Gateway 主工程 `pom.xml`：
 
@@ -60,6 +65,27 @@ Spring Cloud Gateway 5 使用新的 WebFlux starter 坐标：
 
 Boot 4.x 下 `knife4j.gateway.*` 配置保持不变；Spring Cloud Gateway 自身的 route / discovery 配置按 Gateway 5 文档使用。
 
+### Spring Boot 3.5 / Spring Cloud Gateway Server Web MVC
+
+Server Web MVC 使用 Servlet 技术栈，不能引入上面的 WebFlux Gateway starter：
+
+```xml
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-gateway-server-webmvc</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>com.baizhukui</groupId>
+    <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>
+    <version>5.0.17</version>
+</dependency>
+```
+
+::: warning Server Web MVC 的 DISCOVER 有意限定为配置路由发现
+它只聚合已经配置在 `spring.cloud.gateway.server.webmvc.routes` 中、同时满足 `uri: lb://<service>` 与 `Path` predicate 的路由。`DiscoveryClient` 仅用来确认服务仍在注册中心；它不会从注册中心自动创建 Gateway 路由，也不会读取运行时动态路由。
+:::
+
 ::: warning 不要把 knife4j 的 openapi starter 加到 Gateway
 `knife4j-gateway-starter` 不是 UI 生成器，而是路由+聚合。Gateway 本身**不生成** OpenAPI 文档，只**汇聚**下游的。
 :::
@@ -70,12 +96,12 @@ Starter 通过 `knife4j.gateway.strategy` 切换：
 
 | 策略 | 值 | 场景 |
 | --- | --- | --- |
-| 服务发现 | `DISCOVER` | 下游服务都注册到 Nacos/Eureka/Consul，自动聚合全部 |
+| 服务发现 | `DISCOVER` | WebFlux 自动聚合注册服务；Server Web MVC 聚合已配置的 `lb://` 路由 |
 | 手动路由 | `MANUAL`（默认） | 没接服务发现，或只想聚合一部分下游 |
 
 ## 策略 A：服务发现（DISCOVER）
 
-下面示例使用 Spring Cloud Gateway 4.x 常见配置前缀；Boot 4.x / Gateway 5.x 项目只需要把 `spring.cloud.gateway.*` 部分按 Gateway 5 迁移，`knife4j.gateway.*` 部分不变。
+下面示例适用于 WebFlux Gateway。Boot 4.x / Gateway 5.x 项目只需要把 `spring.cloud.gateway.*` 部分按 Gateway 5 迁移，`knife4j.gateway.*` 部分不变。
 
 ```yaml
 server:
@@ -134,6 +160,34 @@ knife4j:
 - `order`：排序权重，越小越靠前。
 - `group-names`：如果下游用 springdoc 的 `group-configs` 拆了多个 group，这里列出要聚合哪些 group。缺省只聚合 `default`。
 - `context-path`：下游挂在非根路径（比如 `/api`），在此填写让聚合 UI 调用下游时路径正确。
+
+### Server Web MVC 的配置路由 DISCOVER
+
+Server Web MVC 没有 WebFlux Gateway 的动态 `DiscoveryClientRouteDefinitionLocator`。因此先把真实业务路由写进 Gateway，再让 Knife4j 从这些路由生成文档入口：
+
+```yaml
+spring:
+  cloud:
+    gateway:
+      server:
+        webmvc:
+          routes:
+            - id: user-service
+              uri: lb://user-service
+              predicates:
+                - Path=/users/**
+
+knife4j:
+  gateway:
+    enabled: true
+    strategy: DISCOVER
+    discover:
+      version: OpenAPI3
+      oas3:
+        url: /v3/api-docs
+```
+
+上例会生成 `/users/v3/api-docs` 文档入口，调试接口的 `context-path` 也是 `/users`。要排除服务、改分组名、排序或为下游配置额外 group，继续使用上面的 `discover.excluded-services` 和 `discover.service-config`。没有 `lb://` + `Path` 的静态路由时，请改用 `MANUAL`。
 
 ## 策略 B：手动路由（MANUAL）
 
@@ -222,8 +276,8 @@ curl http://gateway:8080/v3/api-docs/swagger-config
 | `doc.html` 打不开 | 确认 `knife4j.gateway.enabled: true`，以及 Spring Cloud Gateway starter 和 knife4j gateway starter 版本兼容 |
 | UI 列出了服务但点进去 404 | 多半是 `context-path` 漏填；或 Gateway route 的 `StripPrefix` 与 `context-path` 不匹配 |
 | 聚合路径命中 Gateway 路由规则 | 确保 `knife4j.gateway.discover.oas3.url` 指向的路径能被 Gateway 透传到下游 |
-| 依然只看到一个服务 | 检查服务发现是否实际注册成功（`/actuator/gateway/routes`）；确认 `excluded-services` 没把目标服务排除掉 |
-| 某些配置不生效 | knife4j gateway starter 跑在 WebFlux 栈，不要混用 spring-boot-starter-web（会冲突） |
+| Server Web MVC 的 DISCOVER 未列出服务 | 确认服务已注册，并且 `spring.cloud.gateway.server.webmvc.routes` 中有对应的 `lb://服务名` 和 `Path` predicate |
+| 某些配置不生效 | 确认 starter 与 Gateway 实现匹配：WebFlux 用 `knife4j-gateway-*-starter`，Server Web MVC 用 `knife4j-gateway-webmvc-spring-boot-starter` |
 
 ## 相关
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -51,13 +51,14 @@ title: 兼容矩阵
 
 | Starter | Boot 2.7 | Boot 3.x | Boot 4.0 | 说明 | 验证状态 |
 | --- | --- | --- | --- | --- | --- |
-| `knife4j-gateway-spring-boot-starter` | ❌ | ✅ | ❌ | Spring Cloud Gateway 聚合 | [boot3-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-gateway-app) |
-| `knife4j-gateway-boot4-spring-boot-starter` | ❌ | ❌ | ✅ | Spring Cloud Gateway 5 聚合 | [boot4-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot4-gateway-app) |
+| `knife4j-gateway-spring-boot-starter` | ❌ | ✅ | ❌ | Spring Cloud Gateway WebFlux 聚合 | [boot3-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-gateway-app) |
+| `knife4j-gateway-webmvc-spring-boot-starter` | ❌ | ✅（3.5） | ❌ | Spring Cloud Gateway Server Web MVC 聚合；DISCOVER 仅读取已配置的 `lb://` + `Path` 路由 | [boot35-gateway-webmvc-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app) |
+| `knife4j-gateway-boot4-spring-boot-starter` | ❌ | ❌ | ✅ | Spring Cloud Gateway 5 WebFlux 聚合 | [boot4-gateway-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot4-gateway-app) |
 | `knife4j-aggregation-spring-boot-starter` | ✅ | ❌ | ❌ | 独立聚合（Boot 2.x） | [aggregation-boot2-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/aggregation-boot2-app) |
 | `knife4j-aggregation-jakarta-spring-boot-starter` | ❌ | ✅ | ❌ | 独立聚合（Boot 3.x） | [boot3-aggregation-jakarta-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app) |
 | `knife4j-aggregation-boot4-spring-boot-starter` | ❌ | ❌ | ✅ | 独立聚合（Boot 4.x） | [boot4-aggregation-app](https://github.com/songxychn/knife4j-next/tree/master/knife4j/knife4j-smoke-tests/boot4-aggregation-app) |
 
-- Gateway starter 仅用于 Spring Cloud Gateway（WebFlux），**不适用于普通 WebMvc 项目**。
+- Gateway starter 仅用于 Spring Cloud Gateway：WebFlux 与 Server Web MVC 是不同实现，必须使用各自对应的 starter；它们都**不适用于普通 WebMvc 业务应用**。
 - 聚合 starter 用于**非网关**的微服务聚合场景。
 - 详见 [Gateway 聚合](../guide/gateway) 和 [独立聚合](../guide/aggregation)。
 
@@ -94,10 +95,11 @@ WebFlux starter 是纯依赖编排，不声明 `/knife4j/config` 等 WebMvc star
 │   ├── WebMvc → knife4j-openapi3-jakarta-spring-boot-starter（React UI）
 │   ├── WebFlux → knife4j-openapi3-webflux-jakarta-spring-boot-starter（React UI）
 │   └── Spring Cloud Gateway？
-│       └── knife4j-gateway-spring-boot-starter
+│       ├── WebFlux → knife4j-gateway-spring-boot-starter
+│       └── Server Web MVC（Boot 3.5）→ knife4j-gateway-webmvc-spring-boot-starter
 └── 4.x
     ├── WebMvc → knife4j-openapi3-boot4-spring-boot-starter（React UI）
-    ├── Spring Cloud Gateway → knife4j-gateway-boot4-spring-boot-starter
+    ├── Spring Cloud Gateway WebFlux → knife4j-gateway-boot4-spring-boot-starter
     └── 非网关聚合 → knife4j-aggregation-boot4-spring-boot-starter
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -151,7 +151,9 @@ knife4j:
 
 ## Gateway Starter 配置
 
-适用于 `knife4j-gateway-spring-boot-starter` 和 `knife4j-gateway-boot4-spring-boot-starter`。
+适用于 `knife4j-gateway-spring-boot-starter`、`knife4j-gateway-webmvc-spring-boot-starter` 和 `knife4j-gateway-boot4-spring-boot-starter`。
+
+`knife4j-gateway-webmvc-spring-boot-starter` 仅适用于 Boot 3.5 的 Spring Cloud Gateway Server Web MVC。其 `DISCOVER` 只读取 `spring.cloud.gateway.server.webmvc.routes` 中已配置的 `lb://` + `Path` 路由，不会从注册中心创建或读取动态 Gateway 路由。
 
 ### `knife4j.gateway.*`
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -51,8 +51,9 @@ title: 模块说明
 
 | 模块 | 适用 Boot 版本 | 场景 |
 | --- | --- | --- |
-| `knife4j-gateway-spring-boot-starter` | 3.x | Spring Cloud Gateway 聚合 |
-| `knife4j-gateway-boot4-spring-boot-starter` | 4.x | Spring Cloud Gateway 5 聚合 |
+| `knife4j-gateway-spring-boot-starter` | 3.x | Spring Cloud Gateway WebFlux 聚合 |
+| `knife4j-gateway-webmvc-spring-boot-starter` | 3.5 | Spring Cloud Gateway Server Web MVC 聚合；DISCOVER 读取已配置的 `lb://` 路由 |
+| `knife4j-gateway-boot4-spring-boot-starter` | 4.x | Spring Cloud Gateway 5 WebFlux 聚合 |
 | `knife4j-aggregation-spring-boot-starter` | 2.x | 独立聚合（Disk/Cloud/Nacos/Eureka/Polaris） |
 | `knife4j-aggregation-jakarta-spring-boot-starter` | 3.x | 独立聚合（Jakarta 版） |
 | `knife4j-aggregation-boot4-spring-boot-starter` | 4.x | 独立聚合（springdoc-openapi 3.x） |
@@ -63,7 +64,7 @@ title: 模块说明
 | --- | --- |
 | `knife4j-demo-openapi3` | OpenAPI 3 在线演示应用（Boot 4.0.6 + Boot4 starter + React UI，部署到 `openapi3.demo.knife4jnext.com`） |
 | `knife4j-demo-openapi2` | OpenAPI 2 在线演示应用（Boot 2.7.18 + springfox 2.10.5 + Vue 3 UI，部署到 `openapi2.demo.knife4jnext.com`） |
-| `knife4j-smoke-tests` | 自动化冒烟测试（13 个子模块覆盖 Boot 2.x OAS2/OAS3/WebFlux/独立聚合、Boot 3.x Jakarta/Gateway/WebFlux/独立聚合、Boot 4.x WebMVC/Gateway/独立聚合） |
+| `knife4j-smoke-tests` | 自动化冒烟测试（14 个子模块覆盖 Boot 2.x OAS2/OAS3/WebFlux/独立聚合、Boot 3.x Jakarta/WebFlux/Gateway WebFlux/Gateway Server Web MVC/独立聚合、Boot 4.x WebMVC/Gateway/独立聚合） |
 
 ## 选型决策树
 
@@ -87,8 +88,9 @@ title: 模块说明
 │       └── knife4j-openapi3-webflux-jakarta-spring-boot-starter
 │
 ├── Spring Cloud Gateway 网关
-│   ├── Boot 3.x → knife4j-gateway-spring-boot-starter
-│   └── Boot 4.x → knife4j-gateway-boot4-spring-boot-starter
+│   ├── Boot 3.x WebFlux → knife4j-gateway-spring-boot-starter
+│   ├── Boot 3.5 Server Web MVC → knife4j-gateway-webmvc-spring-boot-starter
+│   └── Boot 4.x WebFlux → knife4j-gateway-boot4-spring-boot-starter
 │
 └── 非网关的微服务聚合
     ├── Boot 2.x

--- a/knife4j/knife4j-dependencies/pom.xml
+++ b/knife4j/knife4j-dependencies/pom.xml
@@ -140,6 +140,12 @@
 
             <dependency>
                 <groupId>com.baizhukui</groupId>
+                <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.baizhukui</groupId>
                 <artifactId>knife4j-gateway-boot4-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j</artifactId>
+        <version>5.0.17</version>
+    </parent>
+
+    <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>
+    <name>knife4j-gateway-webmvc-spring-boot-starter</name>
+    <description>Knife4j aggregation starter for Spring Cloud Gateway Server Web MVC</description>
+
+    <properties>
+        <knife4j-java.version>17</knife4j-java.version>
+        <knife4j-spring-boot3.version>3.5.14</knife4j-spring-boot3.version>
+        <knife4j-spring-cloud3.version>2025.0.3</knife4j-spring-cloud3.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${knife4j-spring-boot3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${knife4j-spring-cloud3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway-server-webmvc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-openapi3-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${knife4j-java.version}</source>
+                    <target>${knife4j-java.version}</target>
+                    <encoding>${knife4j-project.build.sourceEncoding}</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${knife4j-lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/Knife4jGatewayMvcAutoConfiguration.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/Knife4jGatewayMvcAutoConfiguration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.gateway.server.mvc.config.GatewayMvcProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+import org.springframework.web.servlet.DispatcherServlet;
+
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(name = "org.springframework.cloud.gateway.server.mvc.GatewayServerMvcAutoConfiguration")
+@EnableConfigurationProperties(Knife4jGatewayMvcProperties.class)
+@ConditionalOnClass({DispatcherServlet.class, GatewayMvcProperties.class})
+@ConditionalOnProperty(name = "knife4j.gateway.enabled", havingValue = "true")
+public class Knife4jGatewayMvcAutoConfiguration {
+
+    @Bean
+    public MvcSwaggerConfigController mvcSwaggerConfigController(Knife4jGatewayMvcProperties properties,
+                                                                 ObjectProvider<MvcGatewayDiscoveryService> discoveryService) {
+        return new MvcSwaggerConfigController(properties, discoveryService);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "knife4j.gateway.strategy", havingValue = "DISCOVER")
+    public MvcGatewayDiscoveryService mvcGatewayDiscoveryService(ObjectProvider<DiscoveryClient> discoveryClient,
+                                                                 GatewayMvcProperties gatewayProperties,
+                                                                 Knife4jGatewayMvcProperties knife4jProperties,
+                                                                 Environment environment) {
+        return new MvcGatewayDiscoveryService(discoveryClient.getIfAvailable(), gatewayProperties, knife4jProperties,
+                environment);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "knife4j.gateway.basic.enable", havingValue = "true")
+    public FilterRegistrationBean<MvcBasicAuthFilter> mvcBasicAuthFilter(Knife4jGatewayMvcProperties properties) {
+        FilterRegistrationBean<MvcBasicAuthFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new MvcBasicAuthFilter(properties.getBasic()));
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/Knife4jGatewayMvcProperties.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/Knife4jGatewayMvcProperties.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import com.github.xiaoymin.knife4j.core.extend.OpenApiExtendSetting;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * MVC Gateway aggregation properties. The public {@code knife4j.gateway.*}
+ * keys intentionally match the WebFlux Gateway starter where their meanings
+ * overlap.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "knife4j.gateway")
+public class Knife4jGatewayMvcProperties {
+
+    private boolean enabled;
+    private Strategy strategy = Strategy.MANUAL;
+    private Sorter tagsSorter = Sorter.alpha;
+    private Sorter operationsSorter = Sorter.alpha;
+    private OpenApiExtendSetting setting = new OpenApiExtendSetting();
+    private Basic basic = new Basic();
+    private final Discover discover = new Discover();
+    private final List<Router> routes = new ArrayList<>();
+
+    public enum Strategy {
+        DISCOVER,
+        MANUAL
+    }
+
+    public enum Sorter {
+        alpha,
+        order
+    }
+
+    public enum OpenApiVersion {
+        Swagger2,
+        OpenAPI3
+    }
+
+    @Getter
+    @Setter
+    public static class Basic {
+
+        private boolean enable;
+        private String username = "admin";
+        private String password = "123321";
+        private List<String> include = new ArrayList<>();
+    }
+
+    @Getter
+    @Setter
+    public static class Discover {
+
+        private Boolean enabled = Boolean.FALSE;
+        private Set<String> excludedServices = new HashSet<>();
+        private OpenApiVersion version = OpenApiVersion.OpenAPI3;
+        private final OpenApiV3 oas3 = new OpenApiV3();
+        private final OpenApiV2 swagger2 = new OpenApiV2();
+        private final Map<String, ServiceConfigInfo> serviceConfig = new HashMap<>();
+
+        public String getApiDocsPath() {
+            return version == OpenApiVersion.Swagger2 ? swagger2.getUrl() : oas3.getUrl();
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class ServiceConfigInfo {
+
+        private Integer order = 0;
+        private String groupName;
+        private List<String> groupNames = new ArrayList<>();
+        private String contextPath;
+    }
+
+    @Getter
+    @Setter
+    public static class Router {
+
+        private String name;
+        private String serviceName;
+        private String url = "/v2/api-docs?group=default";
+        private String contextPath = "/";
+        private Integer order = 0;
+    }
+
+    @Getter
+    @Setter
+    public static class OpenApiV2 {
+
+        private String url = "/v2/api-docs?group=default";
+    }
+
+    @Getter
+    @Setter
+    public static class OpenApiV3 {
+
+        private String url = "/v3/api-docs";
+        private String oauth2RedirectUrl = "";
+        private String validatorUrl = "";
+    }
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcBasicAuthFilter.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcBasicAuthFilter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.regex.Pattern;
+
+final class MvcBasicAuthFilter implements Filter {
+
+    private static final String SESSION_ATTRIBUTE = "KNIFE4J_GATEWAY_MVC_BASIC_AUTH";
+    private final Knife4jGatewayMvcProperties.Basic basic;
+    private final List<Pattern> protectedUrls = new ArrayList<>();
+
+    MvcBasicAuthFilter(Knife4jGatewayMvcProperties.Basic basic) {
+        this.basic = basic;
+        protectedUrls.add(Pattern.compile(".*/doc\\.html.*", Pattern.CASE_INSENSITIVE));
+        protectedUrls.add(Pattern.compile(".*/v2/api-docs.*", Pattern.CASE_INSENSITIVE));
+        protectedUrls.add(Pattern.compile(".*/v3/api-docs.*", Pattern.CASE_INSENSITIVE));
+        protectedUrls.add(Pattern.compile(".*/swagger-ui.*", Pattern.CASE_INSENSITIVE));
+        for (String include : basic.getInclude()) {
+            protectedUrls.add(Pattern.compile(include, Pattern.CASE_INSENSITIVE));
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        if (!matches(request.getRequestURI()) || authenticated(request)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        unauthorized(response);
+    }
+
+    private boolean authenticated(HttpServletRequest request) {
+        if (request.getSession().getAttribute(SESSION_ATTRIBUTE) != null) {
+            return true;
+        }
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null || !authorization.startsWith("Basic ")) {
+            return false;
+        }
+        try {
+            String decoded = new String(Base64.getDecoder().decode(authorization.substring(6)), StandardCharsets.UTF_8);
+            String[] credentials = decoded.split(":", 2);
+            if (credentials.length != 2 || !basic.getUsername().equals(credentials[0])
+                    || !basic.getPassword().equals(credentials[1])) {
+                return false;
+            }
+            request.getSession().setAttribute(SESSION_ATTRIBUTE, basic.getUsername());
+            return true;
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        }
+    }
+
+    private boolean matches(String requestUri) {
+        String normalized = requestUri.replaceAll("/+", "/");
+        int semicolon = normalized.indexOf(';');
+        if (semicolon >= 0) {
+            normalized = normalized.substring(0, semicolon);
+        }
+        for (Pattern protectedUrl : protectedUrls) {
+            if (protectedUrl.matcher(normalized).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void unauthorized(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader("WWW-Authenticate", "Basic realm=\"Knife4j Gateway\"");
+        response.getWriter().write("Unauthorized");
+    }
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcGatewayDiscoveryService.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcGatewayDiscoveryService.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.cloud.gateway.server.mvc.config.GatewayMvcProperties;
+import org.springframework.cloud.gateway.server.mvc.config.PredicateProperties;
+import org.springframework.cloud.gateway.server.mvc.config.RouteProperties;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Discovers documents only for explicitly configured MVC Gateway {@code lb://}
+ * routes. It never creates Gateway routes from registry entries.
+ */
+@Slf4j
+final class MvcGatewayDiscoveryService {
+
+    private final DiscoveryClient discoveryClient;
+    private final GatewayMvcProperties gatewayProperties;
+    private final Knife4jGatewayMvcProperties knife4jProperties;
+    private final Environment environment;
+    private volatile List<MvcOpenApiResource> resources = Collections.emptyList();
+
+    MvcGatewayDiscoveryService(DiscoveryClient discoveryClient, GatewayMvcProperties gatewayProperties,
+                               Knife4jGatewayMvcProperties knife4jProperties, Environment environment) {
+        this.discoveryClient = discoveryClient;
+        this.gatewayProperties = gatewayProperties;
+        this.knife4jProperties = knife4jProperties;
+        this.environment = environment;
+    }
+
+    boolean isAvailable() {
+        return discoveryClient != null;
+    }
+
+    @EventListener({ApplicationReadyEvent.class, HeartbeatEvent.class})
+    public void refresh() {
+        if (discoveryClient == null) {
+            resources = Collections.emptyList();
+            return;
+        }
+
+        List<String> services = discoveryClient.getServices();
+        Set<String> excluded = excludedServices();
+        List<MvcOpenApiResource> refreshed = new ArrayList<>();
+        for (RouteProperties route : configuredRoutes()) {
+            addRouteResources(refreshed, route, services, excluded);
+        }
+        for (Knife4jGatewayMvcProperties.Router route : knife4jProperties.getRoutes()) {
+            refreshed.add(MvcOpenApiResource.manual(route));
+        }
+        Collections.sort(refreshed);
+        resources = Collections.unmodifiableList(refreshed);
+        log.debug("Refreshed {} MVC Gateway OpenAPI resources", refreshed.size());
+    }
+
+    List<MvcOpenApiResource> resources(String basePath) {
+        List<MvcOpenApiResource> result = new ArrayList<>();
+        for (MvcOpenApiResource resource : resources) {
+            result.add(resource.withBasePath(basePath));
+        }
+        return result;
+    }
+
+    private Collection<RouteProperties> configuredRoutes() {
+        List<RouteProperties> routes = new ArrayList<>(gatewayProperties.getRoutes());
+        routes.addAll(gatewayProperties.getRoutesMap().values());
+        return routes;
+    }
+
+    private void addRouteResources(List<MvcOpenApiResource> target, RouteProperties route, List<String> services,
+                                   Set<String> excluded) {
+        URI uri = route.getUri();
+        if (uri == null || !"lb".equalsIgnoreCase(uri.getScheme()) || !StringUtils.hasText(uri.getHost())) {
+            return;
+        }
+        String serviceName = uri.getHost();
+        if (!containsIgnoreCase(services, serviceName) || excluded(serviceName, excluded)) {
+            return;
+        }
+        for (String prefix : pathPrefixes(route.getPredicates())) {
+            addResource(target, serviceName, prefix);
+        }
+    }
+
+    private void addResource(List<MvcOpenApiResource> target, String serviceName, String prefix) {
+        Knife4jGatewayMvcProperties.ServiceConfigInfo config = findServiceConfig(serviceName);
+        String name = StringUtils.hasText(config.getGroupName()) ? config.getGroupName() : serviceName;
+        String contextPath = StringUtils.hasText(config.getContextPath()) ? config.getContextPath() : prefix;
+        String url = MvcPathUtils.append(prefix, knife4jProperties.getDiscover().getApiDocsPath());
+        List<String> groups = config.getGroupNames();
+        if (groups == null || groups.isEmpty()) {
+            target.add(MvcOpenApiResource.discovered(name, serviceName, url, contextPath, config.getOrder()));
+            return;
+        }
+        for (String group : groups) {
+            String groupUrl = url + (url.contains("?") ? "&" : "?") + "group=" + group;
+            target.add(MvcOpenApiResource.discovered(name + " (" + group + ")", serviceName, groupUrl,
+                    contextPath, config.getOrder()));
+        }
+    }
+
+    private Knife4jGatewayMvcProperties.ServiceConfigInfo findServiceConfig(String serviceName) {
+        for (Map.Entry<String, Knife4jGatewayMvcProperties.ServiceConfigInfo> entry : knife4jProperties.getDiscover().getServiceConfig().entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(serviceName)) {
+                return entry.getValue();
+            }
+        }
+        return new Knife4jGatewayMvcProperties.ServiceConfigInfo();
+    }
+
+    private List<String> pathPrefixes(List<PredicateProperties> predicates) {
+        List<String> prefixes = new ArrayList<>();
+        for (PredicateProperties predicate : predicates) {
+            if (!"Path".equalsIgnoreCase(predicate.getName())) {
+                continue;
+            }
+            for (String pattern : predicate.getArgs().values()) {
+                prefixes.add(MvcPathUtils.routePrefix(pattern));
+            }
+        }
+        return prefixes;
+    }
+
+    private Set<String> excludedServices() {
+        Set<String> excluded = new LinkedHashSet<>(knife4jProperties.getDiscover().getExcludedServices());
+        String applicationName = environment.getProperty("spring.application.name");
+        if (StringUtils.hasText(applicationName)) {
+            excluded.add(applicationName);
+        }
+        return excluded;
+    }
+
+    private boolean excluded(String serviceName, Set<String> excluded) {
+        for (String rule : excluded) {
+            if (rule.equalsIgnoreCase(serviceName)
+                    || Pattern.compile(rule, Pattern.CASE_INSENSITIVE).matcher(serviceName).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean containsIgnoreCase(List<String> values, String expected) {
+        String normalizedExpected = expected.toLowerCase(Locale.ROOT);
+        return values.stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalizedExpected::equals);
+    }
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcOpenApiResource.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcOpenApiResource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Getter
+final class MvcOpenApiResource implements Comparable<MvcOpenApiResource> {
+
+    @JsonIgnore
+    private final Integer order;
+    @JsonIgnore
+    private final String serviceName;
+    private final String name;
+    private final String url;
+    private final String contextPath;
+    private final String id;
+
+    private MvcOpenApiResource(String name, String serviceName, String url, String contextPath, Integer order) {
+        this.name = name;
+        this.serviceName = serviceName;
+        this.url = url;
+        this.contextPath = MvcPathUtils.normalizeContextPath(contextPath);
+        this.order = order == null ? 0 : order;
+        this.id = Base64.getEncoder().encodeToString((name + url + this.contextPath).getBytes(StandardCharsets.UTF_8));
+    }
+
+    static MvcOpenApiResource manual(Knife4jGatewayMvcProperties.Router router) {
+        return new MvcOpenApiResource(router.getName(), router.getServiceName(), router.getUrl(), router.getContextPath(), router.getOrder());
+    }
+
+    static MvcOpenApiResource discovered(String name, String serviceName, String url, String contextPath, Integer order) {
+        return new MvcOpenApiResource(name, serviceName, url, contextPath, order);
+    }
+
+    MvcOpenApiResource withBasePath(String basePath) {
+        return new MvcOpenApiResource(name, serviceName, MvcPathUtils.append(basePath, url),
+                MvcPathUtils.append(basePath, contextPath), order);
+    }
+
+    @Override
+    public int compareTo(MvcOpenApiResource other) {
+        int orderComparison = order.compareTo(other.order);
+        return orderComparison != 0 ? orderComparison : name.compareTo(other.name);
+    }
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcPathUtils.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcPathUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class MvcPathUtils {
+
+    private static final Pattern DOC_HTML = Pattern.compile("(.*?)/doc\\.html", Pattern.CASE_INSENSITIVE);
+
+    private MvcPathUtils() {
+    }
+
+    static String getDefaultContextPath(HttpServletRequest request) {
+        String contextPath = request.getContextPath();
+        if (StringUtils.hasText(contextPath)) {
+            return contextPath;
+        }
+        String referer = request.getHeader("Referer");
+        if (!StringUtils.hasText(referer)) {
+            return "/";
+        }
+        try {
+            Matcher matcher = DOC_HTML.matcher(URI.create(referer).getPath());
+            return matcher.find() ? matcher.group(1) : "/";
+        } catch (IllegalArgumentException ignored) {
+            return "/";
+        }
+    }
+
+    static String append(String first, String second) {
+        String left = trim(first);
+        String right = trim(second);
+        if (left.isEmpty() && right.isEmpty()) {
+            return "/";
+        }
+        if (left.isEmpty()) {
+            return "/" + right;
+        }
+        if (right.isEmpty()) {
+            return "/" + left;
+        }
+        return "/" + left + "/" + right;
+    }
+
+    static String normalizeContextPath(String path) {
+        String normalized = trim(path);
+        return normalized.isEmpty() ? "" : "/" + normalized;
+    }
+
+    static String routePrefix(String pattern) {
+        return normalizeContextPath(pattern == null ? "" : pattern.replace("**", ""));
+    }
+
+    private static String trim(String path) {
+        if (!StringUtils.hasText(path) || "/".equals(path)) {
+            return "";
+        }
+        String result = path.trim().replaceAll("/+", "/");
+        result = result.replaceFirst("^/+", "");
+        return result.replaceFirst("/+$", "");
+    }
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcSwaggerConfigController.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcSwaggerConfigController.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+
+@RestController
+final class MvcSwaggerConfigController {
+
+    private final Knife4jGatewayMvcProperties properties;
+    private final ObjectProvider<MvcGatewayDiscoveryService> discoveryService;
+
+    MvcSwaggerConfigController(Knife4jGatewayMvcProperties properties,
+                               ObjectProvider<MvcGatewayDiscoveryService> discoveryService) {
+        this.properties = properties;
+        this.discoveryService = discoveryService;
+    }
+
+    @GetMapping("/v3/api-docs/swagger-config")
+    ResponseEntity<MvcSwaggerConfigResponse> swaggerConfig(HttpServletRequest request) {
+        String basePath = MvcPathUtils.getDefaultContextPath(request);
+        MvcSwaggerConfigResponse response = new MvcSwaggerConfigResponse();
+        response.setConfigUrl(MvcPathUtils.append(basePath, "/v3/api-docs/swagger-config"));
+        response.setOauth2RedirectUrl(properties.getDiscover().getOas3().getOauth2RedirectUrl());
+        response.setValidatorUrl(properties.getDiscover().getOas3().getValidatorUrl());
+        response.setTagsSorter(properties.getTagsSorter().name());
+        response.setOperationsSorter(properties.getOperationsSorter().name());
+        response.setSetting(properties.getSetting());
+        response.setUrls(resources(basePath));
+        return ResponseEntity.ok(response);
+    }
+
+    private List<MvcOpenApiResource> resources(String basePath) {
+        if (properties.getStrategy() == Knife4jGatewayMvcProperties.Strategy.MANUAL) {
+            List<MvcOpenApiResource> resources = new ArrayList<>();
+            for (Knife4jGatewayMvcProperties.Router route : properties.getRoutes()) {
+                resources.add(MvcOpenApiResource.manual(route).withBasePath(basePath));
+            }
+            Collections.sort(resources);
+            return resources;
+        }
+        MvcGatewayDiscoveryService service = discoveryService.getIfAvailable();
+        if (service == null || !service.isAvailable()) {
+            throw new ResponseStatusException(SERVICE_UNAVAILABLE,
+                    "DISCOVER requires a configured Spring Cloud DiscoveryClient");
+        }
+        return service.resources(basePath);
+    }
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcSwaggerConfigResponse.java
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/spring/gateway/mvc/MvcSwaggerConfigResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.spring.gateway.mvc;
+
+import com.github.xiaoymin.knife4j.core.extend.OpenApiExtendSetting;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+final class MvcSwaggerConfigResponse {
+
+    private String configUrl;
+    private String oauth2RedirectUrl;
+    private String operationsSorter = "alpha";
+    private String tagsSorter = "alpha";
+    private List<MvcOpenApiResource> urls;
+    private String validatorUrl;
+    private OpenApiExtendSetting setting;
+}

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.github.xiaoymin.knife4j.spring.gateway.mvc.Knife4jGatewayMvcAutoConfiguration

--- a/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.baizhukui</groupId>
+        <artifactId>knife4j-smoke-tests</artifactId>
+        <version>5.0.17</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>knife4j-smoke-boot35-gateway-webmvc-app</artifactId>
+    <name>knife4j-smoke-boot35-gateway-webmvc-app</name>
+
+    <properties>
+        <knife4j-java.version>17</knife4j-java.version>
+        <knife4j-spring-boot3.version>3.5.14</knife4j-spring-boot3.version>
+        <knife4j-spring-cloud3.version>2025.0.3</knife4j-spring-cloud3.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${knife4j-spring-boot3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${knife4j-spring-cloud3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.baizhukui</groupId>
+            <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway-server-webmvc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot35gatewaymvc/Boot35GatewayWebMvcDocHttpSmokeTest.java
+++ b/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/src/test/java/com/github/xiaoymin/knife4j/smoke/boot35gatewaymvc/Boot35GatewayWebMvcDocHttpSmokeTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.smoke.boot35gatewaymvc;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+public class Boot35GatewayWebMvcDocHttpSmokeTest {
+
+    private ConfigurableApplicationContext context;
+
+    @After
+    public void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    public void shouldServeManualSwaggerConfigAndBasicAuthOnBoot35GatewayMvc() throws IOException {
+        context = application(
+                "knife4j.gateway.strategy=MANUAL",
+                "knife4j.gateway.basic.enable=true",
+                "knife4j.gateway.basic.username=admin",
+                "knife4j.gateway.basic.password=change-me",
+                "knife4j.gateway.routes[0].name=用户中心",
+                "knife4j.gateway.routes[0].service-name=user-service",
+                "knife4j.gateway.routes[0].url=/users/v3/api-docs",
+                "knife4j.gateway.routes[0].context-path=/users",
+                "knife4j.gateway.routes[0].order=1");
+
+        int port = port();
+        Assert.assertEquals(401, get(port, "/doc.html", null).statusCode);
+        Assert.assertEquals(200, get(port, "/doc.html", "Basic YWRtaW46Y2hhbmdlLW1l").statusCode);
+
+        HttpResponse swaggerConfig = get(port, "/v3/api-docs/swagger-config", "Basic YWRtaW46Y2hhbmdlLW1l");
+        Assert.assertEquals(200, swaggerConfig.statusCode);
+        Assert.assertTrue(swaggerConfig.body.contains("用户中心"));
+        Assert.assertTrue(swaggerConfig.body.contains("/users/v3/api-docs"));
+        Assert.assertTrue(swaggerConfig.body.contains("\"contextPath\":\"/users\""));
+    }
+
+    @Test
+    public void shouldDiscoverConfiguredLoadBalancedMvcRouteOnBoot35() throws IOException {
+        context = application(
+                "knife4j.gateway.strategy=DISCOVER",
+                "spring.cloud.gateway.server.webmvc.routes[0].id=user-service",
+                "spring.cloud.gateway.server.webmvc.routes[0].uri=lb://user-service",
+                "spring.cloud.gateway.server.webmvc.routes[0].predicates[0].name=Path",
+                "spring.cloud.gateway.server.webmvc.routes[0].predicates[0].args._genkey_0=/users/**");
+
+        HttpResponse swaggerConfig = get(port(), "/v3/api-docs/swagger-config", null);
+        Assert.assertEquals(200, swaggerConfig.statusCode);
+        Assert.assertTrue(swaggerConfig.body.contains("user-service"));
+        Assert.assertTrue(swaggerConfig.body.contains("/users/v3/api-docs"));
+        Assert.assertTrue(swaggerConfig.body.contains("\"contextPath\":\"/users\""));
+    }
+
+    private ConfigurableApplicationContext application(String... properties) {
+        String[] defaults = {
+                "server.port=0",
+                "spring.main.banner-mode=off",
+                "knife4j.gateway.enabled=true",
+                "logging.level.root=ERROR"
+        };
+        String[] merged = new String[defaults.length + properties.length];
+        System.arraycopy(defaults, 0, merged, 0, defaults.length);
+        System.arraycopy(properties, 0, merged, defaults.length, properties.length);
+        return new SpringApplicationBuilder(TestGatewayApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .properties(merged)
+                .run();
+    }
+
+    private int port() {
+        return context.getEnvironment().getRequiredProperty("local.server.port", Integer.class);
+    }
+
+    private HttpResponse get(int port, String path, String authorization) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL("http://localhost:" + port + path).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+        if (authorization != null) {
+            connection.setRequestProperty("Authorization", authorization);
+        }
+        int statusCode = connection.getResponseCode();
+        InputStream input = statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+        return new HttpResponse(statusCode, read(input));
+    }
+
+    private String read(InputStream input) throws IOException {
+        if (input == null) {
+            return "";
+        }
+        try (InputStream body = input; ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = body.read(buffer)) != -1) {
+                output.write(buffer, 0, length);
+            }
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static class HttpResponse {
+
+        private final int statusCode;
+        private final String body;
+
+        private HttpResponse(int statusCode, String body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+    }
+
+    @SpringBootApplication
+    public static class TestGatewayApplication {
+
+        @Bean
+        DiscoveryClient discoveryClient() {
+            return new DiscoveryClient() {
+
+                @Override
+                public String description() {
+                    return "smoke";
+                }
+
+                @Override
+                public List<ServiceInstance> getInstances(String serviceId) {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public List<String> getServices() {
+                    return Collections.singletonList("user-service");
+                }
+            };
+        }
+    }
+}

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -31,6 +31,7 @@
         <module>boot3-webflux-jakarta-app</module>
         <module>boot3-app</module>
         <module>boot3-gateway-app</module>
+        <module>boot35-gateway-webmvc-app</module>
         <module>boot35-jakarta-app</module>
         <module>boot4-jakarta-app</module>
         <module>boot4-gateway-app</module>

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -19,6 +19,7 @@
         <module>knife4j-openapi3-jakarta-spring-boot-starter</module>
         <module>knife4j-openapi3-boot4-spring-boot-starter</module>
         <module>knife4j-gateway-spring-boot-starter</module>
+        <module>knife4j-gateway-webmvc-spring-boot-starter</module>
         <module>knife4j-gateway-boot4-spring-boot-starter</module>
         <module>knife4j-openapi3-webflux-spring-boot-starter</module>
         <module>knife4j-openapi3-webflux-jakarta-spring-boot-starter</module>

--- a/tools/release-modules.txt
+++ b/tools/release-modules.txt
@@ -10,6 +10,7 @@ knife4j-aggregation-boot4-spring-boot-starter
 knife4j-openapi3-jakarta-spring-boot-starter
 knife4j-openapi3-boot4-spring-boot-starter
 knife4j-gateway-spring-boot-starter
+knife4j-gateway-webmvc-spring-boot-starter
 knife4j-gateway-boot4-spring-boot-starter
 knife4j-openapi3-webflux-spring-boot-starter
 knife4j-openapi3-webflux-jakarta-spring-boot-starter

--- a/tools/test-java.sh
+++ b/tools/test-java.sh
@@ -37,6 +37,7 @@ SMOKE_MODULES=(
   "boot3-jakarta-app"
   "boot3-webflux-jakarta-app"
   "boot3-gateway-app"
+  "boot35-gateway-webmvc-app"
   "boot35-jakarta-app"
   "boot4-jakarta-app"
   "boot4-gateway-app"


### PR DESCRIPTION
## 变更内容

- 新增 `knife4j-gateway-webmvc-spring-boot-starter`，面向 Spring Boot 3.5 / Spring Cloud 2025.0.x 的 Gateway Server Web MVC。
- 支持 `MANUAL` 路由聚合、Basic 认证，以及受限的 `DISCOVER`：只从已配置的 `spring.cloud.gateway.server.webmvc.routes` 中读取 `lb://` + `Path` 路由。
- 新增 Boot 3.5 MVC Gateway HTTP smoke，覆盖 MANUAL、DISCOVER、`/doc.html` 和 Basic 认证。
- 将新模块纳入 BOM、发布模块清单、Java smoke 证据门、CI 汇总及兼容性文档。

## 根因与边界

现有 Gateway starter 依赖 WebFlux 的 GatewayProperties、路由仓库与 reactive endpoint，放入 `spring-cloud-starter-gateway-server-webmvc` 会触发 reactive 类型缺失。Server Web MVC 没有 WebFlux 的动态 DiscoveryClientRouteDefinitionLocator，因此 DISCOVER 不创建路由，只为已存在的静态 `lb://` 路由生成文档入口。

## 验证

- `mvn -B -ntp -Dmaven.repo.local=<tmp> -pl :knife4j-smoke-boot35-gateway-webmvc-app -am -Dknife4j-skipTests=false test`
- `./tools/test-java.sh`（14 个 smoke 模块全部通过）
- `./tools/test-docs.sh`

Closes #540
