### PR TITLE
feat(ui-react): 支持 Knife4x Embed Bootstrap

### DIFF
--- a/front/ui-react/src/api/knife4jClient.test.ts
+++ b/front/ui-react/src/api/knife4jClient.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SwaggerDoc } from '../types/swagger';
-import { fetchSwaggerDocResult, fetchSwaggerUiConfig, parseGroupsFromConfig, parseMenuTags } from './knife4jClient';
+import {
+  fetchSwaggerDocResult,
+  fetchSwaggerUiConfig,
+  isOpenApi3Document,
+  parseGroupsFromConfig,
+  parseMenuTags,
+} from './knife4jClient';
 
 function jsonResponse(body: unknown, ok = true): Response {
   return {
@@ -47,6 +53,12 @@ describe('knife4jClient', () => {
 
   it('uses the single springdoc url when swagger-config has no urls array', () => {
     expect(parseGroupsFromConfig({ url: '/api/openapi' })).toEqual([{ name: 'default', url: '/api/openapi' }]);
+  });
+
+  it('distinguishes OpenAPI 3 from Swagger 2 documents', () => {
+    expect(isOpenApi3Document({ openapi: '3.1.0', info: { title: 'demo', version: '1' }, paths: {} })).toBe(true);
+    expect(isOpenApi3Document({ openapi: '3.bad', info: { title: 'demo', version: '1' }, paths: {} })).toBe(false);
+    expect(isOpenApi3Document({ swagger: '2.0', info: { title: 'demo', version: '1' }, paths: {} })).toBe(false);
   });
 
   it('preserves gateway route contextPath from swagger-config urls', () => {

--- a/front/ui-react/src/api/knife4jClient.ts
+++ b/front/ui-react/src/api/knife4jClient.ts
@@ -107,6 +107,10 @@ export function parseGroupsFromConfig(config: SwaggerUiConfig): SwaggerGroup[] {
   return [{ name: 'default', url: 'v3/api-docs' }];
 }
 
+export function isOpenApi3Document(doc: SwaggerDoc): boolean {
+  return typeof doc.openapi === 'string' && /^3\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?$/.test(doc.openapi);
+}
+
 /** 拉取 group 列表（兼容 springfox / springdoc） */
 export async function fetchGroups(options: LanguageAwareRequestOptions = {}): Promise<SwaggerGroup[]> {
   // 优先尝试 springdoc: v3/api-docs/swagger-config

--- a/front/ui-react/src/config/knife4xConfig.test.ts
+++ b/front/ui-react/src/config/knife4xConfig.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { readKnife4xBootstrap } from './knife4xConfig';
+
+function host(config: unknown, origin = 'https://example.com') {
+  return {
+    location: { origin },
+    __KNIFE4X_CONFIG__: config,
+  };
+}
+
+describe('readKnife4xBootstrap', () => {
+  it('keeps Java discovery when the global config is absent', () => {
+    expect(readKnife4xBootstrap({ location: { origin: 'https://example.com' } })).toEqual({ mode: 'java' });
+  });
+
+  it('ignores a config inherited from the prototype', () => {
+    const inherited = Object.create({
+      __KNIFE4X_CONFIG__: { specUrl: '/openapi.json', basePath: '/docs' },
+    }) as { location: { origin: string } };
+    inherited.location = { origin: 'https://example.com' };
+
+    expect(readKnife4xBootstrap(inherited)).toEqual({ mode: 'java' });
+  });
+
+  it('resolves root-relative spec URLs against the current origin', () => {
+    expect(readKnife4xBootstrap(host({ specUrl: '/openapi.json', basePath: '/docs/' }))).toEqual({
+      mode: 'embed',
+      config: {
+        specUrl: 'https://example.com/openapi.json',
+        basePath: '/docs',
+      },
+    });
+  });
+
+  it('resolves path-relative spec URLs under the normalized basePath', () => {
+    expect(readKnife4xBootstrap(host({ specUrl: 'openapi.json', basePath: 'nested/docs/' }))).toEqual({
+      mode: 'embed',
+      config: {
+        specUrl: 'https://example.com/nested/docs/openapi.json',
+        basePath: '/nested/docs',
+      },
+    });
+  });
+
+  it('keeps complete HTTP URLs and supports a root basePath', () => {
+    expect(
+      readKnife4xBootstrap(
+        host({
+          specUrl: 'https://api.example.net/openapi.json',
+          basePath: '/',
+        }),
+      ),
+    ).toEqual({
+      mode: 'embed',
+      config: {
+        specUrl: 'https://api.example.net/openapi.json',
+        basePath: '/',
+      },
+    });
+  });
+
+  it.each([
+    ['undefined config', undefined],
+    ['null config', null],
+    ['missing fields', {}],
+    ['empty specUrl', { specUrl: '', basePath: '/docs' }],
+    ['empty basePath', { specUrl: '/openapi.json', basePath: '' }],
+    ['absolute basePath', { specUrl: '/openapi.json', basePath: 'https://example.com/docs' }],
+    ['protocol-relative specUrl', { specUrl: '//api.example.net/openapi.json', basePath: '/docs' }],
+    ['non-HTTP specUrl', { specUrl: 'data:application/json,{}', basePath: '/docs' }],
+  ])('fails closed for $0', (_name, config) => {
+    const result = readKnife4xBootstrap(host(config));
+
+    expect(result.mode).toBe('error');
+    if (result.mode === 'error') {
+      expect(result.error).toContain('Knife4x 启动配置错误');
+    }
+  });
+});

--- a/front/ui-react/src/config/knife4xConfig.ts
+++ b/front/ui-react/src/config/knife4xConfig.ts
@@ -1,0 +1,105 @@
+const CONFIG_KEY = '__KNIFE4X_CONFIG__';
+
+export interface Knife4xConfig {
+  specUrl: string;
+  basePath: string;
+}
+
+export type Knife4xBootstrap =
+  | { mode: 'java' }
+  | { mode: 'embed'; config: Knife4xConfig }
+  | { mode: 'error'; error: string };
+
+interface Knife4xWindow {
+  location: {
+    origin: string;
+  };
+  __KNIFE4X_CONFIG__?: unknown;
+}
+
+export function readKnife4xBootstrap(host: Knife4xWindow = window): Knife4xBootstrap {
+  if (!Object.prototype.hasOwnProperty.call(host, CONFIG_KEY)) {
+    return { mode: 'java' };
+  }
+
+  const raw = host.__KNIFE4X_CONFIG__;
+  if (!isRecord(raw)) {
+    return configError('必须是对象');
+  }
+
+  const specUrl = readNonEmptyString(raw.specUrl);
+  if (!specUrl) {
+    return configError('specUrl 必须是非空字符串');
+  }
+
+  const basePathValue = readNonEmptyString(raw.basePath);
+  if (!basePathValue) {
+    return configError('basePath 必须是非空字符串');
+  }
+
+  const basePath = normalizeBasePath(basePathValue);
+  if (!basePath) {
+    return configError('basePath 必须是 URL 路径');
+  }
+
+  try {
+    const origin = new URL(host.location.origin);
+    if (!isHttpProtocol(origin.protocol)) {
+      return configError('页面必须通过 HTTP(S) 提供');
+    }
+
+    if (specUrl.startsWith('//')) {
+      return configError('specUrl 不支持省略协议的跨域地址');
+    }
+
+    const baseUrl = new URL(basePath === '/' ? '/' : `${basePath}/`, origin);
+    const resolvedSpecUrl = new URL(specUrl, baseUrl);
+    if (!isHttpProtocol(resolvedSpecUrl.protocol)) {
+      return configError('specUrl 只支持 HTTP(S) URL');
+    }
+
+    return {
+      mode: 'embed',
+      config: {
+        specUrl: resolvedSpecUrl.href,
+        basePath,
+      },
+    };
+  } catch {
+    return configError('specUrl 或页面 origin 不是有效 URL');
+  }
+}
+
+function normalizeBasePath(value: string): string | null {
+  if (
+    value.includes('?') ||
+    value.includes('#') ||
+    value.includes('\\') ||
+    value.startsWith('//') ||
+    /^[A-Za-z][A-Za-z\d+.-]*:/.test(value)
+  ) {
+    return null;
+  }
+
+  const withLeadingSlash = value.startsWith('/') ? value : `/${value}`;
+  const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/, '');
+  return withoutTrailingSlash || '/';
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function isHttpProtocol(protocol: string): boolean {
+  return protocol === 'http:' || protocol === 'https:';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function configError(message: string): Knife4xBootstrap {
+  return { mode: 'error', error: `Knife4x 启动配置错误：${message}。` };
+}

--- a/front/ui-react/src/config/knife4xStartup.test.ts
+++ b/front/ui-react/src/config/knife4xStartup.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchSwaggerDocForMode, loadInitialGroups } from './knife4xStartup';
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function documentResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('Knife4x startup', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps Java discovery when the global config is absent', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ url: '/v3/api-docs' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadInitialGroups({ mode: 'java' }, 'zh-CN')).resolves.toEqual({
+      mode: 'ready',
+      groups: [{ name: 'default', url: '/v3/api-docs' }],
+      swaggerUiConfig: { url: '/v3/api-docs' },
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'v3/api-docs/swagger-config',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'Accept-Language': expect.stringMatching(/^zh-CN(?:,|$)/) }),
+      }),
+    );
+  });
+
+  it('creates one default group in Embed mode without Java discovery', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      loadInitialGroups(
+        {
+          mode: 'embed',
+          config: { specUrl: 'https://example.com/docs/openapi.json', basePath: '/docs' },
+        },
+        'zh-CN',
+      ),
+    ).resolves.toEqual({
+      mode: 'ready',
+      groups: [{ name: 'default', url: 'https://example.com/docs/openapi.json' }],
+      swaggerUiConfig: null,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for an invalid Embed config without Java discovery', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(loadInitialGroups({ mode: 'error', error: 'bad config' }, 'zh-CN')).resolves.toEqual({
+      mode: 'error',
+      error: 'bad config',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts OpenAPI 3 documents in Embed mode', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          documentResponse({ openapi: '3.1.0', info: { title: 'demo', version: '1' }, paths: {} }),
+        ),
+    );
+
+    const result = await fetchSwaggerDocForMode('/openapi.json', 'embed');
+
+    expect(result.doc?.openapi).toBe('3.1.0');
+    expect(result.error).toBeNull();
+  });
+
+  it('rejects Swagger 2 documents in Embed mode', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(documentResponse({ swagger: '2.0', info: { title: 'demo', version: '1' }, paths: {} })),
+    );
+
+    await expect(fetchSwaggerDocForMode('/swagger.json', 'embed')).resolves.toEqual({
+      doc: null,
+      error: 'Knife4x 仅支持 OpenAPI 3.x 文档。',
+    });
+  });
+});

--- a/front/ui-react/src/config/knife4xStartup.ts
+++ b/front/ui-react/src/config/knife4xStartup.ts
@@ -1,0 +1,77 @@
+import {
+  fetchSwaggerDocResult,
+  fetchSwaggerUiConfig,
+  isOpenApi3Document,
+  parseGroupsFromConfig,
+  type LanguageAwareRequestOptions,
+  type SwaggerDocFetchResult,
+} from '../api/knife4jClient';
+import { fetchWithAcceptLanguage } from '../api/acceptLanguage';
+import type { SwaggerGroup, SwaggerUiConfig } from '../types/swagger';
+import type { Knife4xBootstrap } from './knife4xConfig';
+
+export type InitialGroupsResult =
+  | { mode: 'ready'; groups: SwaggerGroup[]; swaggerUiConfig: SwaggerUiConfig | null }
+  | { mode: 'error'; error: string }
+  | { mode: 'mock' };
+
+export async function loadInitialGroups(
+  bootstrap: Knife4xBootstrap,
+  preferredLanguage?: string,
+): Promise<InitialGroupsResult> {
+  if (bootstrap.mode === 'error') {
+    return bootstrap;
+  }
+
+  if (bootstrap.mode === 'embed') {
+    return {
+      mode: 'ready',
+      groups: [{ name: 'default', url: bootstrap.config.specUrl }],
+      swaggerUiConfig: null,
+    };
+  }
+
+  const swaggerUiConfig = await fetchSwaggerUiConfig({ preferredLanguage });
+  if (swaggerUiConfig) {
+    return {
+      mode: 'ready',
+      groups: parseGroupsFromConfig(swaggerUiConfig),
+      swaggerUiConfig,
+    };
+  }
+
+  try {
+    const response = await fetchWithAcceptLanguage('swagger-resources', preferredLanguage);
+    if (response.ok) {
+      const resources: Array<{ name: string; location: string; swaggerVersion?: string }> = await response.json();
+      if (resources.length > 0) {
+        return {
+          mode: 'ready',
+          groups: resources.map((group) => ({
+            name: group.name,
+            url: group.location,
+            location: group.location,
+            swaggerVersion: group.swaggerVersion,
+          })),
+          swaggerUiConfig: null,
+        };
+      }
+    }
+  } catch {
+    // Java discovery 失败时保持现有 mock fallback。
+  }
+
+  return { mode: 'mock' };
+}
+
+export async function fetchSwaggerDocForMode(
+  url: string,
+  mode: 'java' | 'embed',
+  options: LanguageAwareRequestOptions = {},
+): Promise<SwaggerDocFetchResult> {
+  const result = await fetchSwaggerDocResult(url, options);
+  if (mode === 'embed' && result.doc && !isOpenApi3Document(result.doc)) {
+    return { doc: null, error: 'Knife4x 仅支持 OpenAPI 3.x 文档。' };
+  }
+  return result;
+}

--- a/front/ui-react/src/context/GroupContext.tsx
+++ b/front/ui-react/src/context/GroupContext.tsx
@@ -1,17 +1,15 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import {
-  fetchSwaggerDocResult,
-  fetchSwaggerUiConfig,
   getSchemas,
   normalizeOperationsSorter,
   normalizeTagsSorter,
-  parseGroupsFromConfig,
   parseMenuTags,
   type OperationsSorter,
   type TagsSorter,
 } from '../api/knife4jClient';
-import { fetchWithAcceptLanguage } from '../api/acceptLanguage';
+import { readKnife4xBootstrap } from '../config/knife4xConfig';
+import { fetchSwaggerDocForMode, loadInitialGroups } from '../config/knife4xStartup';
 import type { MenuTag, SchemaObject, SwaggerDoc, SwaggerGroup, SwaggerUiConfig } from '../types/swagger';
 import { extractKnife4jSettings, extractMarkdownFiles } from '../utils/knife4jSettings';
 import { groupNameFromPathname, selectInitialGroupName } from '../utils/groupRoute';
@@ -80,44 +78,27 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [loading, setLoading] = useState(true);
   const [usingMock, setUsingMock] = useState(false);
   const [groupError, setGroupError] = useState<string | null>(null);
+  const knife4xBootstrap = useMemo(() => readKnife4xBootstrap(), []);
 
-  // 初始化：优先拉取 swagger-config（拿到 tagsSorter / operationsSorter），失败回退到 swagger-resources
+  // Knife4x 直接加载宿主注入的 spec；Java 模式保留现有 discovery 顺序。
   useEffect(() => {
     let cancelled = false;
     (async () => {
       const preferredLanguage = initialLanguageRef.current;
-      const config = await fetchSwaggerUiConfig({ preferredLanguage });
+      const result = await loadInitialGroups(knife4xBootstrap, preferredLanguage);
       if (cancelled) return;
 
-      if (config) {
-        setSwaggerUiConfig(config);
-        const groups = parseGroupsFromConfig(config);
-        if (groups.length > 0) {
-          setRawGroups(groups);
-          setActiveGroupValue(selectInitialGroupName(groups, initialPathnameRef.current));
-          return;
-        }
+      if (result.mode === 'error') {
+        setGroupError(result.error);
+        setLoading(false);
+        return;
       }
 
-      // swagger-config 不可用 → 回退 springfox swagger-resources
-      try {
-        const res = await fetchWithAcceptLanguage('swagger-resources', preferredLanguage);
-        if (res.ok) {
-          const data: Array<{ name: string; location: string; swaggerVersion?: string }> = await res.json();
-          const groups: SwaggerGroup[] = data.map((g) => ({
-            name: g.name,
-            url: g.location,
-            location: g.location,
-            swaggerVersion: g.swaggerVersion,
-          }));
-          if (groups.length > 0) {
-            setRawGroups(groups);
-            setActiveGroupValue(selectInitialGroupName(groups, initialPathnameRef.current));
-            return;
-          }
-        }
-      } catch {
-        /* ignore */
+      if (result.mode === 'ready') {
+        setSwaggerUiConfig(result.swaggerUiConfig);
+        setRawGroups(result.groups);
+        setActiveGroupValue(selectInitialGroupName(result.groups, initialPathnameRef.current));
+        return;
       }
 
       // 完全拿不到 → mock
@@ -128,7 +109,7 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [knife4xBootstrap]);
 
   const routeGroupName = useMemo(() => groupNameFromPathname(location.pathname), [location.pathname]);
 
@@ -149,7 +130,8 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     let cancelled = false;
     setLoading(true);
     setGroupError(null);
-    fetchSwaggerDocResult(group.url, { preferredLanguage }).then((result) => {
+    const mode = knife4xBootstrap.mode === 'embed' ? 'embed' : 'java';
+    fetchSwaggerDocForMode(group.url, mode, { preferredLanguage }).then((result) => {
       if (cancelled) return;
       if (result.doc) {
         setSwaggerDoc(result.doc);
@@ -163,7 +145,7 @@ export const GroupProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     return () => {
       cancelled = true;
     };
-  }, [activeGroupValue, rawGroups, userSettings.language, usingMock]);
+  }, [activeGroupValue, knife4xBootstrap.mode, rawGroups, userSettings.language, usingMock]);
 
   useEffect(() => {
     setServerSettings(extractKnife4jSettings(swaggerDoc));

--- a/front/ui-react/src/vite-env.d.ts
+++ b/front/ui-react/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  __KNIFE4X_CONFIG__?: unknown;
+}


### PR DESCRIPTION
## 关联

Closes #548
Related #524

## 变更

- 通过 `window` 自有 `__KNIFE4X_CONFIG__` 属性区分 Java 与 Knife4x Embed 启动模式。
- 校验并解析必填的 `specUrl` / `basePath`；相对规范地址按规范化后的挂载路径解析。
- Embed 模式直接创建单一 `default` group，不请求 Java discovery；非法配置 fail closed。
- Embed 模式只接受 OpenAPI 3.x，Swagger 2 返回明确错误。
- 保持 Java 的 swagger-config → `/knife4j/config` → swagger-resources → mock 行为，以及现有 Try-it URL 规则。

## 范围

- 未加入 `enabled`、`persistAuth`、`title`、`tryIt` 或 Go 侧实现。
- 未修改 Java starter、`doc.html`、`createHashRouter`、Vite base，也未提交构建产物。

## 验证

- `./tools/test-front-core.sh`：通过（core 192 tests；ui-react 139 tests；format/build/lint 全绿）。
- 浏览器 fixture：`/nested/docs/` 正确加载相对 spec，Network 无 Java discovery 请求；Java discovery、自定义错误、OAS2 拒绝与 Try-it 地址均验证通过。
- 独立 reviewer 复审通过，无阻断 findings。