### PR TITLE
fix(ui-react): 保留响应媒体示例值

### DIFF
--- a/front/ui-react/src/pages/api/ApiDoc.tsx
+++ b/front/ui-react/src/pages/api/ApiDoc.tsx
@@ -3,7 +3,6 @@ import { CopyOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import {
   buildMediaTypeExampleValue,
-  buildSchemaExample,
   buildSchemaFieldTree,
   generateApiMarkdown,
   resolveRefMeta,
@@ -20,6 +19,7 @@ import { schemaNameFromRef } from '../../components/schema/schemaUtils';
 import CodeBlock from './CodeBlock';
 import { operationAuthors } from './operationAuthor';
 import { applyValidationGroupRequiredFields } from './validationGroups';
+import { buildJsonExample, responseExamples } from './apiDocExamples';
 
 const { Title, Text } = Typography;
 
@@ -174,20 +174,6 @@ function collectSchemaRefs(
   }
 }
 
-/** Build a pretty-printed JSON example string from a schema, or return null. */
-function buildJsonExample(schema: SchemaObject | undefined, doc: SwaggerDoc): string | null {
-  if (!schema) return null;
-  try {
-    const example = buildSchemaExample(schema as Record<string, unknown>, {
-      doc: doc as unknown as Record<string, unknown>,
-    });
-    if (example === null || example === undefined) return null;
-    return JSON.stringify(example, null, 2);
-  } catch {
-    return null;
-  }
-}
-
 function buildRequestBodyExample(
   requestBody: RequestBodyObject | undefined,
   bodySchema: SchemaObject | undefined,
@@ -211,22 +197,6 @@ function buildRequestBodyExample(
   }
 
   return buildJsonExample(mediaEntry.mediaObj.schema ?? bodySchema, doc);
-}
-
-/** Extract per-status-code response schemas for example generation. */
-function responseExamples(
-  responses: Record<string, ResponseObject> | undefined,
-  doc: SwaggerDoc,
-): Array<{ statusCode: string; example: string }> {
-  if (!responses) return [];
-  return Object.entries(responses)
-    .map(([statusCode, resp]) => {
-      const schema =
-        resp.content?.['application/json']?.schema ?? resp.schema ?? Object.values(resp.content ?? {})[0]?.schema;
-      const example = buildJsonExample(schema, doc);
-      return example ? { statusCode, example } : null;
-    })
-    .filter((x): x is { statusCode: string; example: string } => x !== null);
 }
 
 const METHOD_COLOR: Record<string, string> = {

--- a/front/ui-react/src/pages/api/apiDocExamples.test.ts
+++ b/front/ui-react/src/pages/api/apiDocExamples.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import type { ResponseObject, SwaggerDoc } from '../../types/swagger';
+import { responseExamples } from './apiDocExamples';
+
+describe('API document examples', () => {
+  it('uses an OAS3 response examples.value JSON string before the schema example', () => {
+    const value = JSON.stringify(
+      {
+        success: true,
+        status: '200',
+        message: '',
+        data: 'SUCCESS',
+        timestamp: '',
+      },
+      null,
+      2,
+    );
+    const responses = {
+      '200': {
+        description: 'OK',
+        content: {
+          '*/*': {
+            schema: { $ref: '#/components/schemas/ResponseResultHttpCodeEnum' },
+            examples: {
+              json: {
+                summary: 'test data',
+                value,
+              },
+            },
+          },
+        },
+      },
+    } satisfies Record<string, ResponseObject>;
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'Issue 550', version: '1.0.0' },
+      paths: {},
+      components: {
+        schemas: {
+          ResponseResultHttpCodeEnum: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean' },
+              status: { type: 'string' },
+              message: { type: 'string' },
+              data: { type: 'string' },
+              timestamp: { type: 'string' },
+            },
+          },
+        },
+      },
+    } as SwaggerDoc;
+
+    expect(responseExamples(responses, doc)).toEqual([{ statusCode: '200', example: value }]);
+  });
+
+  it('keeps an explicitly empty response example', () => {
+    const responses = {
+      '204': {
+        description: 'No content',
+        content: {
+          '*/*': {
+            example: '',
+          },
+        },
+      },
+    } satisfies Record<string, ResponseObject>;
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'Empty example', version: '1.0.0' },
+      paths: {},
+    } as SwaggerDoc;
+
+    expect(responseExamples(responses, doc)).toEqual([{ statusCode: '204', example: '' }]);
+  });
+
+  it('keeps the schema fallback when no media example is declared', () => {
+    const responses = {
+      '200': {
+        description: 'OK',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                message: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      '500': {
+        description: 'Unknown schema',
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/Missing' },
+          },
+        },
+      },
+    } satisfies Record<string, ResponseObject>;
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'Schema fallback', version: '1.0.0' },
+      paths: {},
+    } as SwaggerDoc;
+
+    expect(responseExamples(responses, doc)).toEqual([
+      {
+        statusCode: '200',
+        example: JSON.stringify({ message: 'string' }, null, 2),
+      },
+    ]);
+  });
+
+  it('preserves the legacy response schema fallback priority', () => {
+    const responses = {
+      '206': {
+        description: 'Other media schema',
+        content: {
+          'text/plain': {
+            schema: { type: 'string' },
+          },
+          'application/json': {},
+        },
+      },
+      '207': {
+        description: 'OAS2 schema before media schema',
+        schema: { type: 'integer' },
+        content: {
+          'text/plain': {
+            schema: { type: 'string' },
+          },
+        },
+      },
+    } satisfies Record<string, ResponseObject>;
+    const doc = {
+      openapi: '3.0.1',
+      info: { title: 'Schema priority', version: '1.0.0' },
+      paths: {},
+    } as SwaggerDoc;
+
+    expect(responseExamples(responses, doc)).toEqual([
+      { statusCode: '206', example: JSON.stringify('string', null, 2) },
+      { statusCode: '207', example: JSON.stringify(0, null, 2) },
+    ]);
+  });
+});

--- a/front/ui-react/src/pages/api/apiDocExamples.ts
+++ b/front/ui-react/src/pages/api/apiDocExamples.ts
@@ -1,0 +1,54 @@
+import { buildMediaTypeExampleValue, buildSchemaExample } from 'knife4j-core';
+import type { ResponseObject, SchemaObject, SwaggerDoc } from '../../types/swagger';
+
+/** Build a pretty-printed JSON example string from a schema, or return null. */
+export function buildJsonExample(schema: SchemaObject | undefined, doc: SwaggerDoc): string | null {
+  if (!schema) return null;
+  try {
+    const example = buildSchemaExample(schema as Record<string, unknown>, {
+      doc: doc as unknown as Record<string, unknown>,
+    });
+    if (example === null || example === undefined) return null;
+    return JSON.stringify(example, null, 2);
+  } catch {
+    return null;
+  }
+}
+
+/** Extract per-status-code response examples, preferring explicit media examples over generated schema values. */
+export function responseExamples(
+  responses: Record<string, ResponseObject> | undefined,
+  doc: SwaggerDoc,
+): Array<{ statusCode: string; example: string }> {
+  if (!responses) return [];
+  return Object.entries(responses)
+    .map(([statusCode, resp]) => {
+      const mediaEntry = resp.content
+        ? resp.content['application/json']
+          ? (['application/json', resp.content['application/json']] as const)
+          : Object.entries(resp.content)[0]
+        : undefined;
+      const schema =
+        resp.content?.['application/json']?.schema ?? resp.schema ?? Object.values(resp.content ?? {})[0]?.schema;
+      let example: string | null | undefined;
+
+      if (mediaEntry) {
+        try {
+          example = buildMediaTypeExampleValue(
+            mediaEntry[1],
+            undefined,
+            { doc: doc as unknown as Record<string, unknown> },
+            { mediaType: mediaEntry[0] },
+          );
+        } catch {
+          example = undefined;
+        }
+      }
+      if (example === undefined) {
+        example = buildJsonExample(schema, doc);
+      }
+
+      return example !== null && example !== undefined ? { statusCode, example } : null;
+    })
+    .filter((x): x is { statusCode: string; example: string } => x !== null);
+}

--- a/front/ui-react/src/types/swagger.ts
+++ b/front/ui-react/src/types/swagger.ts
@@ -137,7 +137,14 @@ export interface RequestBodyObject {
 
 export interface ResponseObject {
   description?: string;
-  content?: Record<string, { schema?: SchemaObject }>;
+  content?: Record<
+    string,
+    {
+      schema?: SchemaObject;
+      example?: unknown;
+      examples?: Record<string, ExampleObject>;
+    }
+  >;
   schema?: SchemaObject; // OAS2
 }
 


### PR DESCRIPTION
## 问题

Closes #550

OpenAPI 3 响应在 `content.<mediaType>.examples.*.value` 中声明显式示例时，文档页仍只按 response schema 生成占位值，导致空字符串、枚举式文本等内容被显示为 `"string"`。

## 根因

`ApiDoc` 的请求示例与调试模型已经复用 `buildMediaTypeExampleValue`，但响应示例路径只读取 schema，完全忽略 media type 层的 `example` / `examples`。

## 修改

- 响应文档示例优先使用 media type 的 `example` / `examples.*.value`
- 没有显式示例时保持原有 schema fallback 顺序
- 补齐 `ResponseObject.content` 的 example 类型声明
- 增加 #550 JSON 字符串、顶层空字符串、schema fallback 与旧优先级回归测试

## 验证

- 未修复基线：`bun run test --run src/pages/api/apiDocExamples.test.ts` 按预期失败，`status/message/data/timestamp` 被生成成 `"string"`
- 修复后定向测试：4/4 通过
- `./tools/test-front-core.sh`
  - `knife4j-core`: 192 tests passed
  - `knife4j-ui-react`: 143 tests passed
  - format / lint / build 均通过
- 独立 reviewer：`approve`，无 validation gap、无 scope drift

## 风险

保持每个状态码一个示例，并沿用现有 helper 只取所选 media type 的第一个 named example；不扩展多示例 Tabs、`externalValue` 或 OAS2 response examples。