### PR TITLE
feat(knife4x): 实现 Go 嵌入式 HTTP Handler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: knife4x/go/go.mod
+          cache: false
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -157,6 +163,9 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: front/package.json
+
+      - name: Test Knife4x Go
+        run: ./tools/test-knife4x-go.sh
 
       - name: Verify Knife4x Go UI assets
         run: ./tools/sync-knife4x-ui.sh --check

--- a/knife4x/go/LICENSE
+++ b/knife4x/go/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "{}" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright 2017 小明
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -1,6 +1,9 @@
 # knife4x / go
 
-未来提供 Go module，将 `front/ui-react` 构建产物嵌入 Go Handler。
+Go module：`github.com/songxychn/knife4j-next/knife4x/go`。
+
+核心只依赖标准库 `net/http`。`NewHandler` 接收 `SpecURL` 与可选的 `BasePath`，默认在 `/doc.html`
+提供嵌入式 OpenAPI 3 控制台；未命中的请求原样交给宿主 Handler。
 
 ## UI 资产
 
@@ -16,5 +19,11 @@
 ./tools/sync-knife4x-ui.sh --check
 ```
 
-`static/index.html` 是 Vite 构建入口。后续 Handler 默认将它暴露为 `/doc.html`；`BasePath` 只表示挂载前缀，例如
+`static/index.html` 是 Vite 构建入口。Handler 将它暴露为 `/doc.html`；`BasePath` 只表示挂载前缀，例如
 `BasePath=/internal` 对应 `/internal/doc.html`。
+
+## 验证
+
+```bash
+./tools/test-knife4x-go.sh
+```

--- a/knife4x/go/go.mod
+++ b/knife4x/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/songxychn/knife4j-next/knife4x/go
+
+go 1.22.0

--- a/knife4x/go/handler.go
+++ b/knife4x/go/handler.go
@@ -1,0 +1,178 @@
+// Package knife4x serves the embedded Knife4x OpenAPI console.
+package knife4x
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+const (
+	staticRoot       = "internal/ui/static"
+	indexFile        = "index.html"
+	moduleScriptMark = `<script type="module"`
+	configAssignment = "window.__KNIFE4X_CONFIG__="
+)
+
+//go:embed internal/ui/static
+var embeddedUI embed.FS
+
+// Config controls how the embedded console starts.
+type Config struct {
+	SpecURL  string
+	BasePath string
+}
+
+type browserConfig struct {
+	SpecURL  string `json:"specUrl"`
+	BasePath string `json:"basePath"`
+}
+
+type handler struct {
+	basePath string
+	index    []byte
+	files    fs.FS
+	server   http.Handler
+	next     http.Handler
+}
+
+// NewHandler creates a framework-independent Knife4x HTTP handler.
+func NewHandler(cfg Config, next http.Handler) (http.Handler, error) {
+	specURL, err := normalizeSpecURL(cfg.SpecURL)
+	if err != nil {
+		return nil, err
+	}
+	basePath, err := normalizeBasePath(cfg.BasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := fs.Sub(embeddedUI, staticRoot)
+	if err != nil {
+		return nil, fmt.Errorf("knife4x: open embedded UI: %w", err)
+	}
+	index, err := fs.ReadFile(files, indexFile)
+	if err != nil {
+		return nil, fmt.Errorf("knife4x: read embedded %s: %w", indexFile, err)
+	}
+	mark := bytes.Index(index, []byte(moduleScriptMark))
+	if mark < 0 {
+		return nil, fmt.Errorf("knife4x: embedded %s has no module script", indexFile)
+	}
+
+	configJSON, err := json.Marshal(browserConfig{SpecURL: specURL, BasePath: basePath})
+	if err != nil {
+		return nil, fmt.Errorf("knife4x: encode browser config: %w", err)
+	}
+	injected := make([]byte, 0, len(index)+len(configJSON)+64)
+	injected = append(injected, index[:mark]...)
+	injected = append(injected, "<script>"+configAssignment...)
+	injected = append(injected, configJSON...)
+	injected = append(injected, ";</script>\n    "...)
+	injected = append(injected, index[mark:]...)
+
+	if next == nil {
+		next = http.NotFoundHandler()
+	}
+	return &handler{
+		basePath: basePath,
+		index:    injected,
+		files:    files,
+		server:   http.FileServerFS(files),
+		next:     next,
+	}, nil
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		h.next.ServeHTTP(w, r)
+		return
+	}
+
+	name, ok := h.relativePath(r.URL.Path)
+	if !ok || !fs.ValidPath(name) || name == indexFile {
+		h.next.ServeHTTP(w, r)
+		return
+	}
+	if name == "doc.html" {
+		http.ServeContent(w, r, "doc.html", time.Time{}, bytes.NewReader(h.index))
+		return
+	}
+
+	info, err := fs.Stat(h.files, name)
+	if err != nil || !info.Mode().IsRegular() {
+		h.next.ServeHTTP(w, r)
+		return
+	}
+
+	request := r.Clone(r.Context())
+	request.URL.Path = "/" + name
+	request.URL.RawPath = ""
+	h.server.ServeHTTP(w, request)
+}
+
+func (h *handler) relativePath(requestPath string) (string, bool) {
+	if h.basePath == "/" {
+		if !strings.HasPrefix(requestPath, "/") {
+			return "", false
+		}
+		return strings.TrimPrefix(requestPath, "/"), true
+	}
+
+	prefix := h.basePath + "/"
+	if !strings.HasPrefix(requestPath, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(requestPath, prefix), true
+}
+
+func normalizeSpecURL(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("knife4x: SpecURL must not be empty")
+	}
+	if strings.HasPrefix(value, "//") {
+		return "", fmt.Errorf("knife4x: SpecURL must not be protocol-relative")
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("knife4x: invalid SpecURL: %w", err)
+	}
+	if parsed.IsAbs() {
+		if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+			return "", fmt.Errorf("knife4x: SpecURL must use HTTP(S)")
+		}
+	} else if parsed.Host != "" {
+		return "", fmt.Errorf("knife4x: SpecURL must not be protocol-relative")
+	}
+	return value, nil
+}
+
+func normalizeBasePath(value string) (string, error) {
+	if value == "" {
+		return "/", nil
+	}
+	if strings.TrimSpace(value) != value ||
+		!strings.HasPrefix(value, "/") ||
+		strings.HasPrefix(value, "//") ||
+		strings.ContainsAny(value, "?#\\") {
+		return "", fmt.Errorf("knife4x: BasePath must be a clean absolute URL path")
+	}
+
+	value = strings.TrimRight(value, "/")
+	if value == "" {
+		return "/", nil
+	}
+	if path.Clean(value) != value {
+		return "", fmt.Errorf("knife4x: BasePath must be a clean absolute URL path")
+	}
+	return value, nil
+}

--- a/knife4x/go/handler_test.go
+++ b/knife4x/go/handler_test.go
@@ -1,0 +1,202 @@
+package knife4x
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const nextStatus = 299
+
+func TestNewHandlerValidatesConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{name: "empty spec URL", cfg: Config{}},
+		{name: "blank spec URL", cfg: Config{SpecURL: " \t "}},
+		{name: "protocol-relative spec URL", cfg: Config{SpecURL: "//api.example.test/openapi.json"}},
+		{name: "non-HTTP spec URL", cfg: Config{SpecURL: "data:application/json,{}"}},
+		{name: "HTTP spec URL without host", cfg: Config{SpecURL: "https:/openapi.json"}},
+		{name: "relative base path", cfg: Config{SpecURL: "/openapi.json", BasePath: "internal"}},
+		{name: "protocol-relative base path", cfg: Config{SpecURL: "/openapi.json", BasePath: "//internal"}},
+		{name: "base path query", cfg: Config{SpecURL: "/openapi.json", BasePath: "/internal?debug=1"}},
+		{name: "base path fragment", cfg: Config{SpecURL: "/openapi.json", BasePath: "/internal#docs"}},
+		{name: "base path backslash", cfg: Config{SpecURL: "/openapi.json", BasePath: `/internal\docs`}},
+		{name: "unclean base path", cfg: Config{SpecURL: "/openapi.json", BasePath: "/internal/../docs"}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewHandler(test.cfg, nil); err == nil {
+				t.Fatal("NewHandler() error = nil, want validation error")
+			}
+		})
+	}
+}
+
+func TestHandlerServesRootUIAndPassesThroughOtherRequests(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(nextStatus)
+	})
+	got, err := NewHandler(Config{SpecURL: "/openapi.json"}, next)
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+
+	doc := request(t, got, http.MethodGet, "/doc.html", http.StatusOK)
+	body := doc.Body.String()
+	config := readInjectedConfig(t, body)
+	wantConfig := map[string]string{"specUrl": "/openapi.json", "basePath": "/"}
+	if !reflect.DeepEqual(config, wantConfig) {
+		t.Fatalf("injected config = %#v, want %#v", config, wantConfig)
+	}
+	if strings.Index(body, configAssignment) > strings.Index(body, moduleScriptMark) {
+		t.Fatal("browser config was injected after the module script")
+	}
+
+	reference := firstAssetReference(t, body)
+	request(t, got, http.MethodGet, "/"+reference, http.StatusOK)
+	request(t, got, http.MethodHead, "/doc.html", http.StatusOK)
+
+	for _, target := range []string{
+		"/",
+		"/api/ping",
+		"/openapi.json",
+		"/assets/missing.js",
+		"/index.html",
+	} {
+		request(t, got, http.MethodGet, target, nextStatus)
+	}
+	request(t, got, http.MethodPost, "/doc.html", nextStatus)
+}
+
+func TestHandlerServesSubpathAssets(t *testing.T) {
+	t.Parallel()
+
+	got, err := NewHandler(Config{
+		SpecURL:  "openapi.json",
+		BasePath: "/internal/",
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(nextStatus)
+	}))
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+
+	doc := request(t, got, http.MethodGet, "/internal/doc.html", http.StatusOK)
+	config := readInjectedConfig(t, doc.Body.String())
+	wantConfig := map[string]string{"specUrl": "openapi.json", "basePath": "/internal"}
+	if !reflect.DeepEqual(config, wantConfig) {
+		t.Fatalf("injected config = %#v, want %#v", config, wantConfig)
+	}
+
+	for _, target := range []string{
+		"/internal/assets/index.js",
+		"/internal/assets/index.css",
+		"/internal/knife4j-next-mark.svg",
+		"/internal/oauth2-redirect.html",
+	} {
+		request(t, got, http.MethodGet, target, http.StatusOK)
+	}
+
+	for _, target := range []string{
+		"/internal",
+		"/internal/",
+		"/internal/business",
+		"/doc.html",
+		"/internal/index.html",
+		"/internal/assets/missing.js",
+	} {
+		request(t, got, http.MethodGet, target, nextStatus)
+	}
+}
+
+func TestHandlerEscapesInjectedConfig(t *testing.T) {
+	t.Parallel()
+
+	specURL := `/openapi.json?value=</script><script>alert("x")</script>`
+	got, err := NewHandler(Config{SpecURL: specURL}, nil)
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+
+	doc := request(t, got, http.MethodGet, "/doc.html", http.StatusOK)
+	body := doc.Body.String()
+	if strings.Contains(body, `</script><script>alert("x")</script>`) {
+		t.Fatal("injected config contains an unescaped script terminator")
+	}
+	config := readInjectedConfig(t, body)
+	if config["specUrl"] != specURL {
+		t.Fatalf("injected specUrl = %q, want %q", config["specUrl"], specURL)
+	}
+	if len(config) != 2 {
+		t.Fatalf("injected config has %d fields, want 2", len(config))
+	}
+}
+
+func TestHandlerUsesNotFoundWhenNextIsNil(t *testing.T) {
+	t.Parallel()
+
+	got, err := NewHandler(Config{SpecURL: "https://api.example.test/openapi.json"}, nil)
+	if err != nil {
+		t.Fatalf("NewHandler() error = %v", err)
+	}
+	request(t, got, http.MethodGet, "/api/ping", http.StatusNotFound)
+}
+
+func request(t *testing.T, handler http.Handler, method, target string, wantStatus int) *httptest.ResponseRecorder {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(method, target, nil))
+	if recorder.Code != wantStatus {
+		t.Fatalf("%s %s status = %d, want %d", method, target, recorder.Code, wantStatus)
+	}
+	return recorder
+}
+
+func readInjectedConfig(t *testing.T, body string) map[string]string {
+	t.Helper()
+
+	start := strings.Index(body, configAssignment)
+	if start < 0 {
+		t.Fatal("document does not contain Knife4x config")
+	}
+	start += len(configAssignment)
+	end := strings.Index(body[start:], ";</script>")
+	if end < 0 {
+		t.Fatal("Knife4x config script is not terminated")
+	}
+
+	var config map[string]string
+	if err := json.Unmarshal([]byte(body[start:start+end]), &config); err != nil {
+		t.Fatalf("decode injected config: %v", err)
+	}
+	return config
+}
+
+func firstAssetReference(t *testing.T, body string) string {
+	t.Helper()
+
+	const marker = `src="./`
+	start := strings.Index(body, marker)
+	if start < 0 {
+		t.Fatal("document does not contain a relative script asset")
+	}
+	start += len(marker)
+	end := strings.IndexByte(body[start:], '"')
+	if end < 0 {
+		t.Fatal("relative script asset is not terminated")
+	}
+	return body[start : start+end]
+}

--- a/tools/ci-changes.sh
+++ b/tools/ci-changes.sh
@@ -31,7 +31,7 @@ while IFS= read -r path || [ -n "$path" ]; do
       java=true
       vue3=true
       ;;
-    knife4x/go/*|tools/sync-knife4x-ui.sh)
+    knife4x/go/*|tools/sync-knife4x-ui.sh|tools/test-knife4x-go.sh)
       knife4x_go=true
       ;;
     .github/workflows/*|.editorconfig|.gitattributes|.nvmrc|tools/ci-changes.sh|tools/test-ci-changes.sh)

--- a/tools/test-all.sh
+++ b/tools/test-all.sh
@@ -7,4 +7,5 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 "$repo_root/tools/test-front-core.sh"
 "$repo_root/tools/test-vue3.sh"
 "$repo_root/tools/test-docs.sh"
+"$repo_root/tools/test-knife4x-go.sh"
 "$repo_root/tools/sync-knife4x-ui.sh" --check

--- a/tools/test-ci-changes.sh
+++ b/tools/test-ci-changes.sh
@@ -42,7 +42,7 @@ for path in front/core/src/index.ts front/ui-react/src/App.tsx front/package.jso
 done
 assert_case "react test script" "$react_and_java" "tools/test-front-core.sh"
 assert_case "vue3" "$vue3_and_java" $'front/vue3/src/App.vue\ntools/test-vue3.sh'
-assert_case "knife4x go" "$knife4x_only" $'knife4x/go/README.md\ntools/sync-knife4x-ui.sh'
+assert_case "knife4x go" "$knife4x_only" $'knife4x/go/README.md\ntools/sync-knife4x-ui.sh\ntools/test-knife4x-go.sh'
 assert_case "shared configuration" "$all" $'.github/workflows/build.yml\n.editorconfig\n.gitattributes\n.nvmrc\ntools/ci-changes.sh\ntools/test-ci-changes.sh'
 assert_case "unknown path" "$all" "new-area/example.txt"
 assert_case "maintenance files" "$none" $'README.md\nCONTRIBUTING.md\nAGENTS.md\n.agent/PROJECT.md\n.gitignore\ntools/README.md\ntools/agent-status.sh\ntools/claude/run.sh\ntools/test-all.sh\ntools/extract-release-note.sh\ntools/verify-github-release.sh'

--- a/tools/test-knife4x-go.sh
+++ b/tools/test-knife4x-go.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+module_root="$repo_root/knife4x/go"
+
+unformatted="$(gofmt -l "$module_root")"
+if [ -n "$unformatted" ]; then
+  printf 'Go files need formatting:\n%s\n' "$unformatted" >&2
+  exit 1
+fi
+
+cd "$module_root"
+go vet ./...
+go test ./...


### PR DESCRIPTION
Closes #555

## 变更范围

- 建立 `github.com/songxychn/knife4j-next/knife4x/go` module，并内嵌 #554 同步的真实 React UI 资产
- 提供标准库 `NewHandler(Config{SpecURL, BasePath}, next)`：固定 `doc.html` 入口、子路径资产路由、未知请求透传
- 使用 `encoding/json` 注入严格的 `specUrl` / `basePath` 配置并保留 HTML escaping
- 增加 `httptest`，覆盖根路径、子路径、真实 JS/CSS/SVG/OAuth 资产、配置校验、脚本逃逸与 `next == nil`
- 新增 `tools/test-knife4x-go.sh`，接入 Knife4x CI lane、路径分类和 `test-all`
- module 根包含 Apache-2.0 `LICENSE`

## 验证

- `./tools/test-knife4x-go.sh`：通过
- `go test -run TestHandler -count=20 ./...`：通过
- `./tools/sync-knife4x-ui.sh --check`：通过
- `./tools/test-ci-changes.sh`：通过
- workflow YAML parse、`bash -n`、`git diff --check`：通过
- `go list -m all`：仅当前 module，无第三方依赖

## 风险与范围外

- UI 文件仍以 `front/ui-react` 为唯一源码；本 PR 不修改生成资产
- 不引入 Gin/Echo/Chi、SPA fallback、重定向、缓存策略或额外配置字段
- Gin example、完整接入文档与发布准备继续由 #556–#558 处理
- 本 PR 先保持 Draft；待 CI 全绿并由维护者审查后再进入 `status:review`