### PR TITLE
docs(knife4x): 完成 Go 接入与 gin-swagger 迁移说明

### DIFF
--- a/knife4x/README.md
+++ b/knife4x/README.md
@@ -1,27 +1,68 @@
 # Knife4x
 
-嵌入式 OpenAPI 3 文档 + 调试控制台，面向 **Go / Rust** 宿主（规划中）。
+Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 文档与调试控制台。
+当前先交付 Go，Rust 后置。
 
 ## 定位
 
-- 与 Java 线 **knife4j-next**（`knife4j/` + `doc.html`）同仓、同 UI 演进，**独立版本与发布坐标**
-- **不生成** OpenAPI；只消费标准 OpenAPI 3
-- UI 源码与 Java webjar **共用** `front/ui-react`（及 `front/core`），本目录只放宿主壳
+- 只消费标准 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2
+- Go 核心只依赖标准库 `net/http`，不绑定 Gin、Echo、Chi 等 Web 框架
+- 与 Java 线 `knife4j-next` 同仓并共用 `front/ui-react` 与 `front/core`，但 module、版本和发布流程独立于 Java `5.x`
+- 宿主壳只负责嵌入静态 UI、注入配置和挂载路由，不复制前端业务逻辑
 
-## 目录（骨架）
+Go module 路径为：
+
+```text
+github.com/songxychn/knife4j-next/knife4x/go
+```
+
+首个公开版本尚未发布。当前可从仓库 checkout 直接运行
+[Gin example](examples/gin/README.md)；发布后的安装版本与 tag 以 release 信息为准。
+
+## 快速开始
+
+先阅读 [Go 接入说明](go/README.md)。它先给出框架无关的 `http.Handler`
+用法，再说明如何组合 Gin。
+
+仓库内可直接运行：
+
+```bash
+cd knife4x/examples/gin
+go run .
+```
+
+然后打开 <http://localhost:8080/doc.html>。子路径示例：
+
+```bash
+go run . -base-path /internal
+```
+
+此时入口为 <http://localhost:8080/internal/doc.html>。`BasePath` 只表示文档挂载前缀，
+不会成为业务 API base URL。
+
+从 `gin-swagger` 切换前，请先阅读
+[迁移说明](go/MIGRATING_FROM_GIN_SWAGGER.md)：Knife4x 只接受 JSON 顶层
+`openapi: 3.x` 的文档，不能直接加载 Swagger 2 / OAS2。
+
+## 当前目录
 
 ```text
 knife4x/
-  go/          # 未来：Go module（embed UI + Handler）
-  rust/        # 未来：Rust crate（embed UI + axum 等）
-  examples/    # gin / axum 示例（占位）
+  go/          # Go module：embed UI + net/http Handler
+  rust/        # Rust crate 占位，Go MVP 完成后再实现
+  examples/
+    gin/       # 可运行的 Gin 组合示例
+    axum/      # 后置占位
 ```
 
-## 非目标（当前）
+## 配置与边界
 
-- 功能实现与发布（另开 issue / PR）
-- 第二份前端工程
-- OAS2 支持
-- 云托管文档站
+Go Handler 的公开配置只有 `SpecURL` 与 `BasePath`。默认入口是 `/doc.html`；
+关闭文档的方式是不创建或不挂载 Handler。Knife4x 不依赖 Java 的 discovery
+端点，也不提供 `enabled`、`persistAuth`、`title` 或 `tryIt` 等宿主配置字段。
 
-需求基线见仓库 issue #524。
+内嵌 UI 只能通过 `tools/sync-knife4x-ui.sh` 从共享前端源码生成，禁止手工修改
+`knife4x/go/internal/ui/static/`。
+
+本目录采用 [Apache-2.0](go/LICENSE) 许可证。产品需求与决策基线见
+[issue #524](https://github.com/songxychn/knife4j-next/issues/524)。

--- a/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+++ b/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
@@ -1,0 +1,83 @@
+# 从 gin-swagger 迁移
+
+Knife4x 替换的是嵌入式文档与调试 UI，不替代 OpenAPI 生成器。
+
+## 迁移前检查
+
+先打开现有 JSON spec，检查顶层版本字段：
+
+```json
+{
+  "openapi": "3.0.3"
+}
+```
+
+只有 `openapi: 3.x` JSON 可以继续。若文档使用 `swagger: "2.0"`，请先升级生成器或转换
+spec；OAS2 不能直接迁移到 Knife4x。
+
+首个 Knife4x Go 版本尚未发布，因此现在不要把下面命令当成可用 release。发布后确认
+release 页面已有公共版本，再执行：
+
+```bash
+go get github.com/songxychn/knife4j-next/knife4x/go@latest
+```
+
+## 替换挂载代码
+
+典型的 `gin-swagger` 路由：
+
+```go
+router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+```
+
+改为先由 Gin 提供已有的 OpenAPI 3 文档，再将整个 engine 交给 Knife4x：
+
+```go
+router := gin.New()
+router.StaticFile("/openapi.json", "./openapi.json")
+router.GET("/api/ping", servePing)
+
+handler, err := knife4x.NewHandler(knife4x.Config{
+	SpecURL: "/openapi.json",
+}, router)
+if err != nil {
+	log.Fatal(err)
+}
+log.Fatal(http.ListenAndServe(":8080", handler))
+```
+
+并增加 import：
+
+```go
+import knife4x "github.com/songxychn/knife4j-next/knife4x/go"
+```
+
+启动后入口从 `/swagger/index.html` 变为 `/doc.html`。只有确认不再使用相关生成或
+挂载能力后，才从 `go.mod` 和 imports 中移除 `gin-swagger`、`swaggerFiles` 等旧依赖。
+
+## 子路径
+
+需要把文档挂在 `/internal` 时：
+
+```go
+router.StaticFile("/internal/openapi.json", "./openapi.json")
+
+handler, err := knife4x.NewHandler(knife4x.Config{
+	SpecURL:  "openapi.json",
+	BasePath: "/internal",
+}, router)
+```
+
+入口为 `/internal/doc.html`，相对 spec 位于 `/internal/openapi.json`。业务 API
+仍按 OpenAPI 文档的 `servers` 与 path 解析，不会自动拼接 `/internal`。
+
+## 核对清单
+
+- spec 顶层是 `openapi: 3.x`
+- 宿主实际提供 `SpecURL` 指向的文档
+- 根路径打开 `/doc.html`，或在子路径打开 `${BasePath}/doc.html`
+- Try-it 请求命中预期业务 URL
+- 生产环境不需要文档时，不创建或不挂载 Knife4x Handler
+
+可运行参考见 [Gin example](../examples/gin/README.md)，完整配置语义见
+[Go 接入说明](README.md)，产品边界见 [Knife4x 总览](../README.md)。

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -1,13 +1,100 @@
 # knife4x / go
 
-Go module：`github.com/songxychn/knife4j-next/knife4x/go`。
+Go module：
 
-核心只依赖标准库 `net/http`。`NewHandler` 接收 `SpecURL` 与可选的 `BasePath`，默认在 `/doc.html`
-提供嵌入式 OpenAPI 3 控制台；未命中的请求原样交给宿主 Handler。
+```text
+github.com/songxychn/knife4j-next/knife4x/go
+```
+
+Knife4x 只消费 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2。核心只依赖
+标准库 `net/http`；Gin 只是可运行的组合示例，不是库依赖。
+
+首个公开版本尚未发布。当前请从仓库 checkout 运行示例；发布后的安装版本与 tag
+以 release 信息为准。
+
+## 标准库接入
+
+先让业务 Handler 提供 OpenAPI 3 文档和 API，再把它作为 `next` 传给
+`NewHandler`：
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+
+	knife4x "github.com/songxychn/knife4j-next/knife4x/go"
+)
+
+func main() {
+	app := http.NewServeMux()
+	app.HandleFunc("/openapi.json", serveOpenAPI)
+	app.HandleFunc("/api/ping", servePing)
+
+	handler, err := knife4x.NewHandler(knife4x.Config{
+		SpecURL: "/openapi.json",
+	}, app)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Fatal(http.ListenAndServe(":8080", handler))
+}
+
+func serveOpenAPI(w http.ResponseWriter, r *http.Request) {
+	http.ServeFile(w, r, "./openapi.json")
+}
+
+func servePing(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"message":"pong"}`))
+}
+```
+
+把顶层为 `openapi: 3.x` 的 JSON 保存为当前目录的 `openapi.json`。启动后打开
+<http://localhost:8080/doc.html>。
+
+`Config` 只有两个字段：
+
+| 字段 | 说明 |
+|---|---|
+| `SpecURL` | 必填；OpenAPI 3 文档 URL，可为根相对、相对或完整 HTTP(S) URL |
+| `BasePath` | 可选；文档挂载前缀，空值等同于 `/` |
+
+`BasePath: "/internal"` 时，文档入口为 `/internal/doc.html`，静态资源也位于
+`/internal/` 下。它不是入口文件名，也不是业务 API base URL。相对
+`SpecURL: "openapi.json"` 会解析到 `/internal/openapi.json`；根相对
+`SpecURL: "/openapi.json"` 仍指向根路径。
+
+未知路由会交给 `next`。生产环境需要关闭文档时，不创建或不挂载 Knife4x Handler
+即可。
+
+## Gin 接入
+
+Gin engine 已实现 `http.Handler`，直接把它传给同一个 `NewHandler`：
+
+```go
+router := gin.New()
+router.GET("/openapi.json", serveOpenAPI)
+router.GET("/api/ping", servePing)
+
+handler, err := knife4x.NewHandler(knife4x.Config{
+	SpecURL: "/openapi.json",
+}, router)
+if err != nil {
+	log.Fatal(err)
+}
+log.Fatal(http.ListenAndServe(":8080", handler))
+```
+
+完整可运行代码、根路径和子路径命令见
+[Gin example](../examples/gin/README.md)。从 `gin-swagger` 切换时请阅读
+[迁移说明](MIGRATING_FROM_GIN_SWAGGER.md)。
 
 ## UI 资产
 
-`internal/ui/static/` 是 `front/core` 与 `front/ui-react` 的生成快照，禁止手工修改。唯一更新方式：
+`internal/ui/static/` 是 `front/core` 与 `front/ui-react` 的生成快照，禁止手工修改。
+唯一更新方式：
 
 ```bash
 ./tools/sync-knife4x-ui.sh
@@ -19,11 +106,16 @@ Go module：`github.com/songxychn/knife4j-next/knife4x/go`。
 ./tools/sync-knife4x-ui.sh --check
 ```
 
-`static/index.html` 是 Vite 构建入口。Handler 将它暴露为 `/doc.html`；`BasePath` 只表示挂载前缀，例如
-`BasePath=/internal` 对应 `/internal/doc.html`。
+Handler 将构建入口 `static/index.html` 暴露为 `/doc.html`。Knife4x 使用自己的
+embed 配置启动，不请求 Java 的 `/knife4j/config`。
 
 ## 验证
+
+在仓库根目录运行：
 
 ```bash
 ./tools/test-knife4x-go.sh
 ```
+
+Knife4x 与 Java `5.x` 使用独立版本和发布坐标，采用
+[Apache-2.0](LICENSE) 许可证。产品边界见 [Knife4x 总览](../README.md)。

--- a/knife4x/rust/README.md
+++ b/knife4x/rust/README.md
@@ -1,5 +1,6 @@
 # knife4x / rust
 
-占位目录。未来提供 Rust crate `knife4x`，将 `front/ui-react` 构建产物 embed 并挂载 `/docs`（优先 axum）。
+占位目录。Rust crate 与 axum 示例在 Go MVP 闭环后再实现；当前不提供可安装或发布的
+Rust 包。未来宿主仍复用同一份 React UI，并遵循默认 `/doc.html` 入口。
 
-当前无实现。
+当前产品边界见 [Knife4x 总览](../README.md)。


### PR DESCRIPTION
Closes #557

## 变更范围

- 将 `knife4x/README.md` 从骨架说明更新为当前 Go-first 产品入口，明确 OpenAPI 3 JSON、框架无关 Handler、独立版本与 Apache-2.0 边界
- 扩充 `knife4x/go/README.md`：先给标准库 `http.Handler` 完整接入，再说明 Gin 组合、`SpecURL` / `BasePath` 语义和关闭文档方式
- 新增 `MIGRATING_FROM_GIN_SWAGGER.md`，要求先确认 OAS3 JSON，并给出根路径、子路径迁移与验收清单
- 清理 Rust 占位页遗留的 `/docs` 默认入口，明确 Rust / axum 后置

## 验证

- `./tools/test-knife4x-go.sh`：通过
- `./tools/test-docs.sh`：通过
- `git diff --check`：通过
- README 根路径实跑：`/doc.html`、`/assets/index.js`、`/openapi.json`、`/api/ping` 均返回 200
- README 子路径实跑：`/internal/doc.html`、`/internal/assets/index.js`、`/internal/openapi.json`、`/api/ping` 均返回 200

## 风险与范围外

- 仅改文档，不修改 Handler API、Gin example、生成资产或发布流程
- 不承诺尚未发布的版本；安装命令明确要求公共 release 可用后再执行
- 不增加 Echo / Chi / Fiber、Rust / axum 教程或第二份前端
