### PR TITLE
docs(knife4x): 冻结 Go v0.1.0 发布规则

### DIFF
--- a/knife4x/README.md
+++ b/knife4x/README.md
@@ -16,8 +16,9 @@ Go module 路径为：
 github.com/songxychn/knife4j-next/knife4x/go
 ```
 
-首个公开版本尚未发布。当前可从仓库 checkout 直接运行
-[Gin example](examples/gin/README.md)；发布后的安装版本与 tag 以 release 信息为准。
+Go 首个公开版本固定为 `v0.1.0`，对应仓库 tag `knife4x/go/v0.1.0`。tag 发布前可从
+仓库 checkout 直接运行 [Gin example](examples/gin/README.md)；发布状态与完整验收步骤见
+[Go 发布清单](go/RELEASE.md)。
 
 ## 快速开始
 
@@ -64,5 +65,6 @@ Go Handler 的公开配置只有 `SpecURL` 与 `BasePath`。默认入口是 `/do
 内嵌 UI 只能通过 `tools/sync-knife4x-ui.sh` 从共享前端源码生成，禁止手工修改
 `knife4x/go/internal/ui/static/`。
 
-本目录采用 [Apache-2.0](go/LICENSE) 许可证。产品需求与决策基线见
+本目录与 Java 主线同样采用 [Apache-2.0](go/LICENSE) 许可证（SPDX 标识：
+`Apache-2.0`），但 module、版本与发布流程相互独立。产品需求与决策基线见
 [issue #524](https://github.com/songxychn/knife4j-next/issues/524)。

--- a/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+++ b/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
@@ -15,11 +15,11 @@ Knife4x 替换的是嵌入式文档与调试 UI，不替代 OpenAPI 生成器。
 只有 `openapi: 3.x` JSON 可以继续。若文档使用 `swagger: "2.0"`，请先升级生成器或转换
 spec；OAS2 不能直接迁移到 Knife4x。
 
-首个 Knife4x Go 版本尚未发布，因此现在不要把下面命令当成可用 release。发布后确认
-release 页面已有公共版本，再执行：
+首个 Knife4x Go 版本固定为 `v0.1.0`。在仓库 tag `knife4x/go/v0.1.0` 尚未发布且
+公共 Go proxy 尚未可查前，不要执行下面命令；发布完成后再运行：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@latest
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.1.0
 ```
 
 ## 替换挂载代码

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -9,8 +9,8 @@ github.com/songxychn/knife4j-next/knife4x/go
 Knife4x 只消费 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2。核心只依赖
 标准库 `net/http`；Gin 只是可运行的组合示例，不是库依赖。
 
-首个公开版本尚未发布。当前请从仓库 checkout 运行示例；发布后的安装版本与 tag
-以 release 信息为准。
+首个公开版本固定为 `v0.1.0`，对应仓库 tag `knife4x/go/v0.1.0`。tag 发布前请从
+仓库 checkout 运行示例；发布门禁、tag 步骤与公共消费验证见 [RELEASE.md](RELEASE.md)。
 
 ## 标准库接入
 

--- a/knife4x/go/RELEASE.md
+++ b/knife4x/go/RELEASE.md
@@ -1,0 +1,141 @@
+# Knife4x Go 发布
+
+本文只冻结 Knife4x Go 的版本、tag 与验收步骤。实际创建或推送 tag 必须由维护者另行明确授权。
+
+## 固定坐标
+
+| 项 | 值 |
+|---|---|
+| Go module | `github.com/songxychn/knife4j-next/knife4x/go` |
+| 首个版本 | `v0.1.0` |
+| 仓库 tag | `knife4x/go/v0.1.0` |
+| 许可证 | Apache-2.0 |
+
+Go module 位于仓库子目录，因此按
+[Go Modules Reference](https://go.dev/ref/mod#mapping-versions-to-commits)，tag 必须带
+`knife4x/go/` 前缀。Knife4x 版本独立于 Java `5.x`；现有 Java Release 与 Demo
+workflow 的自动 tag 触发器只接收根级 `v*` tag，不接收 `knife4x/go/v*`。
+`./tools/test-knife4x-go.sh` 会以无副作用断言保护这条边界。
+
+## 发布前门禁
+
+在干净 checkout 的仓库根目录执行。候选提交必须已经合入 `master`：
+
+```bash
+git fetch origin master
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)"
+test -z "$(git status --porcelain)"
+
+(cd knife4x/go && go mod tidy -diff)
+(cd knife4x/examples/gin && go mod tidy -diff)
+
+./tools/test-knife4x-go.sh
+./tools/sync-knife4x-ui.sh --check
+./tools/test-ci-changes.sh
+./tools/test-docs.sh
+git diff --check
+```
+
+`test-knife4x-go.sh` 同时覆盖 Go 格式、`go vet`、核心测试、Gin 根路径/子路径冒烟和
+Java tag 路由隔离。再检查将进入 module 下载包的许可证与 UI 资产：
+
+```bash
+test -f knife4x/go/LICENSE
+test -f knife4x/go/internal/ui/static/index.html
+test -f knife4x/go/internal/ui/static/assets/index.js
+test -f knife4x/go/internal/ui/static/assets/index.css
+```
+
+最后核对用户入口与迁移文档：
+
+```bash
+grep -Fq 'github.com/songxychn/knife4j-next/knife4x/go' knife4x/README.md
+grep -Fq 'knife4x/go/v0.1.0' knife4x/README.md knife4x/go/README.md
+grep -Fq 'go@v0.1.0' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+grep -Fq 'OAS2 不能直接迁移' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+test -z "$(git status --porcelain)"
+```
+
+## 创建 tag
+
+以下命令不属于 ready-to-tag 工作项。只有维护者明确授权发布后才执行：
+
+```bash
+git tag -a knife4x/go/v0.1.0 -m "Knife4x Go v0.1.0"
+git push origin knife4x/go/v0.1.0
+```
+
+不要同时创建根级 `v0.1.0` tag，不要运行 Java Maven Release，不要为首版新增
+registry、OIDC、secret 或 GitHub Release。
+
+## 发布后公共消费验证
+
+先直接查询公共 Go proxy；这里不使用 `direct` fallback：
+
+```bash
+module=github.com/songxychn/knife4j-next/knife4x/go
+version=v0.1.0
+curl -fsS "https://proxy.golang.org/${module}/@v/${version}.info"
+```
+
+再用全新 consumer 下载、编译并挂载 Handler。临时 `GOMODCACHE` 保证验证的确来自公共
+proxy，不复用仓库内 module 或 `replace`：
+
+```bash
+consumer_dir="$(mktemp -d)"
+trap 'rm -rf "$consumer_dir"' EXIT
+
+module=github.com/songxychn/knife4j-next/knife4x/go
+version=v0.1.0
+export GOPROXY=https://proxy.golang.org
+export GOMODCACHE="$consumer_dir/modcache"
+
+cd "$consumer_dir"
+go mod init example.com/knife4x-consumer
+go get "$module@$version"
+
+cat > main.go <<'EOF'
+package main
+
+import (
+	"net/http"
+
+	knife4x "github.com/songxychn/knife4j-next/knife4x/go"
+)
+
+func main() {
+	handler, err := knife4x.NewHandler(
+		knife4x.Config{SpecURL: "/openapi.json"},
+		http.NewServeMux(),
+	)
+	if err != nil {
+		panic(err)
+	}
+	_ = &http.Server{Addr: ":8080", Handler: handler}
+}
+EOF
+
+if grep -Eq '^[[:space:]]*replace([[:space:](])' go.mod; then
+	echo "consumer go.mod must not contain replace" >&2
+	exit 1
+fi
+
+go build ./...
+go list -m all | grep -Fx "$module $version"
+
+module_dir="$(go list -m -f '{{.Dir}}' "$module")"
+test -f "$module_dir/LICENSE"
+test -f "$module_dir/internal/ui/static/index.html"
+test -f "$module_dir/internal/ui/static/assets/index.js"
+test -f "$module_dir/internal/ui/static/assets/index.css"
+```
+
+只有公共 proxy 查询、无 `replace` consumer 编译和下载内容检查都通过后，才可宣布
+Knife4x Go `v0.1.0` 发布完成。
+
+## 补丁原则
+
+- 已发布 tag 不移动、不覆盖；有问题发布新的 patch 版本。
+- 只修兼容 bug 时递增 patch；新增向后兼容能力时递增 minor。
+- `0.x` 的破坏性变更至少递增 minor，并提供迁移说明。
+- Rust 尚未发布，不为 Go `v0.1.0` 创建空 crate 或同步 tag。

--- a/knife4x/go/RELEASE.md
+++ b/knife4x/go/RELEASE.md
@@ -78,8 +78,8 @@ version=v0.1.0
 curl -fsS "https://proxy.golang.org/${module}/@v/${version}.info"
 ```
 
-再用全新 consumer 下载、编译并挂载 Handler。临时 `GOMODCACHE` 保证验证的确来自公共
-proxy，不复用仓库内 module 或 `replace`：
+再用全新 consumer 下载、编译并挂载 Handler。`GONOPROXY=none` 强制该公开 module
+仍通过公共 proxy 下载；临时 `GOMODCACHE` 避免复用本机缓存：
 
 ```bash
 consumer_dir="$(mktemp -d)"
@@ -88,6 +88,7 @@ trap 'rm -rf "$consumer_dir"' EXIT
 module=github.com/songxychn/knife4j-next/knife4x/go
 version=v0.1.0
 export GOPROXY=https://proxy.golang.org
+export GONOPROXY=none
 export GOMODCACHE="$consumer_dir/modcache"
 
 cd "$consumer_dir"

--- a/tools/test-knife4x-go.sh
+++ b/tools/test-knife4x-go.sh
@@ -7,6 +7,39 @@ module_roots=(
   "$repo_root/knife4x/examples/gin"
 )
 
+assert_java_tag_filter() {
+  local workflow=$1
+  local actual
+
+  actual="$(
+    awk '
+      /^[[:space:]]+tags:[[:space:]]*$/ { in_tags=1; next }
+      in_tags && /^[[:space:]]+-[[:space:]]+/ {
+        value=$0
+        sub(/^[[:space:]]+-[[:space:]]+/, "", value)
+        gsub(/^[\047\042]|[\047\042]$/, "", value)
+        print value
+        next
+      }
+      in_tags { exit }
+    ' "$workflow"
+  )"
+  if [ "$actual" != "v*" ]; then
+    printf 'Java workflow tag filter changed in %s: %s\n' "$workflow" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_java_tag_filter "$repo_root/.github/workflows/release.yml"
+assert_java_tag_filter "$repo_root/.github/workflows/deploy-demo.yml"
+
+case "knife4x/go/v0.1.0" in
+  v*)
+    echo "Knife4x Go tag must not match the Java v* release route" >&2
+    exit 1
+    ;;
+esac
+
 unformatted="$(gofmt -l "${module_roots[@]}")"
 if [ -n "$unformatted" ]; then
   printf 'Go files need formatting:\n%s\n' "$unformatted" >&2


### PR DESCRIPTION
Closes #558

## 变更

- 新增 `knife4x/go/RELEASE.md`，冻结 module、`v0.1.0` 与 `knife4x/go/v0.1.0` tag 规则。
- 写明 ready-to-tag 门禁、维护者授权后的 tag 命令，以及公共 `GOPROXY` + 全新无 `replace` consumer 验收。
- 检查下载内容包含 Apache-2.0 `LICENSE` 与内嵌 UI 资产。
- 在现有 Knife4x Go 门禁中断言 Java Release / Demo 仍只由根级 `v*` tag 自动触发。
- 同步总览、Go README 与 `gin-swagger` 迁移说明的首版安装口径。

## 验证

- `(cd knife4x/go && go mod tidy -diff)`
- `(cd knife4x/examples/gin && go mod tidy -diff)`
- `./tools/test-knife4x-go.sh`
- `./tools/sync-knife4x-ui.sh --check`
- `./tools/test-ci-changes.sh`
- `./tools/test-docs.sh`
- `git diff --check`
- 远端 `knife4x/go/v0.1.0` tag 当前不存在；公共 Go proxy 对该版本返回 404。

## 风险与边界

- 未创建或推送任何 tag，未触发实际发布。
- 未修改 Java Maven Release / Demo workflow，只增加无副作用的匹配保护断言。
- 未引入 registry、OIDC、secret、Rust 或其他框架范围。
