### PR TITLE
release: 准备 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | 仓库来源 | fork 自 `xiaoymin/knife4j` |
 | 当前定位 | 社区维护分支，不是 upstream 官方仓库 |
 | Java 主坐标 | `com.baizhukui` |
-| 当前稳定版本 | `5.0.18` |
+| 当前稳定版本 | `5.1.0` |
 | 默认访问入口 | `http://ip:port/doc.html` |
 | 文档站 | [knife4jnext.com](https://knife4jnext.com) |
 
@@ -27,7 +27,7 @@
 
 ### 选择 Starter
 
-版本统一使用当前稳定版本 `5.0.18`。
+版本统一使用当前稳定版本 `5.1.0`。
 
 | 使用场景 | Maven `artifactId` |
 |---|---|
@@ -46,7 +46,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/docs/guide/aggregation.md
+++ b/docs/guide/aggregation.md
@@ -24,7 +24,7 @@ Spring Boot 3（Jakarta）：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 
 <dependency>
@@ -41,7 +41,7 @@ Spring Boot 4 换成 `knife4j-aggregation-boot4-spring-boot-starter`：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-aggregation-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 
 <dependency>

--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -31,7 +31,7 @@ knife4j-next 提供两个并列的 demo 工程，分别覆盖两条独立的 UI 
 | 组件 | 版本 | 说明 |
 | --- | --- | --- |
 | Spring Boot | `4.0.6` | demo `pom.xml` 通过 Boot BOM 显式声明 |
-| knife4j starter | `knife4j-openapi3-boot4-spring-boot-starter` | 本仓库 `5.0.18` |
+| knife4j starter | `knife4j-openapi3-boot4-spring-boot-starter` | 本仓库 `5.1.0` |
 | JDK | 17 | Dockerfile base image `eclipse-temurin:17-jre-alpine` |
 | springdoc-openapi | `3.0.3` | 由 starter 管理 |
 
@@ -100,7 +100,7 @@ docker run --rm -p 8080:8080 \
 | 组件 | 版本 | 说明 |
 | --- | --- | --- |
 | Spring Boot | `2.7.18` | 由根 pom `knife4j-spring-boot.version` 管理 |
-| knife4j starter | `knife4j-openapi2-spring-boot-starter` | 本仓库 `5.0.18` |
+| knife4j starter | `knife4j-openapi2-spring-boot-starter` | 本仓库 `5.1.0` |
 | JDK | 8 | Dockerfile base image `eclipse-temurin:8-jre-alpine` |
 | springfox | `2.10.5` | Swagger 2 注解解析 |
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -32,7 +32,7 @@ Knife4j 的 `doc.html` 默认嵌入在 Spring Boot 应用中。在某些场景�
 # 在 Maven 仓库中找到 knife4j-openapi3-ui 的 jar
 # 解压 META-INF/resources/ 目录
 mkdir -p /opt/knife4j-static
-unzip -j ~/.m2/repository/com/baizhukui/knife4j-openapi3-ui/5.0.18/knife4j-openapi3-ui-5.0.18.jar \
+unzip -j ~/.m2/repository/com/baizhukui/knife4j-openapi3-ui/5.1.0/knife4j-openapi3-ui-5.1.0.jar \
   "META-INF/resources/*" -d /opt/knife4j-static/
 ```
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -22,13 +22,14 @@ title: 常见问题
 
 **大多数情况仍然有效**。upstream 文档 <https://doc.xiaominfo.com/> 上关于 `@ApiOperationSupport`、`knife4j.*` 配置、UI 行为的内容本 fork 完全兼容。两个例外：
 
-1. 版本发布节奏：upstream 最后一个 Maven Central 发布版本是 `4.5.0`（2024-01-08），fork 是 `5.0.18`（采用独立 SemVer 版本号）；fork 包含已确认并合入的兼容/安全修复和 React 新前端。
+1. 版本发布节奏：upstream 最后一个 Maven Central 发布版本是 `4.5.0`（2024-01-08），fork 是 `5.1.0`（采用独立 SemVer 版本号）；fork 包含已确认并合入的兼容/安全修复和 React 新前端。
 2. 新 React 前端覆盖范围：upstream Vue2 前端上有的 UI 功能（Postman 导出、afterScript、版本小蓝点等）在本 fork 的新 React 前端中尚未全部覆盖；OAuth2、离线导出、自定义 Markdown 文档、自定义 Footer 等能力则已在 React UI 中补齐或重做。这些历史功能在本仓库 `front/vue3`（`knife4j-openapi2-ui` 打包产物）中继续保留。详见下文 [React 配置不生效](#react-setting-not-effective)。
 
 ### 本 fork 相比 upstream 多了哪些修复
 
 | 版本 | 修复/新增内容 | 对应 upstream issue |
 | --- | --- | --- |
+| `5.1.0` | 次版本：React 嵌入式启动、调试器响应进度、multipart 必填文件校验、响应示例与长 Token 预览，以及中英日国际化 | — |
 | `5.0.18` | 补丁修复：新增 Gateway Server Web MVC 聚合 starter 和 Boot 3.5 smoke，starter 发布包补齐 Spring Boot 配置元数据 | — |
 | `5.0.17` | 补丁修复：React UI Tab 右键菜单只在标签上触发，避免文档内容区右键误弹菜单；在线 demo 仅随发布 tag 更新 | — |
 | `5.0.16` | 补丁修复：React UI 调试页按接口请求历史、自定义 Markdown 超长英文换行，以及仓库按产品线重组与文档默认 Boot4 坐标 | — |

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -42,7 +42,7 @@ Gateway 主工程 `pom.xml`：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -59,7 +59,7 @@ Spring Cloud Gateway 5 使用新的 WebFlux starter 坐标：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -78,7 +78,7 @@ Server Web MVC 使用 Servlet 技术栈，不能引入上面的 WebFlux Gateway 
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -29,7 +29,7 @@ title: 快速开始
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -79,7 +79,7 @@ Controller 写法与 Boot 3.x Jakarta 版一致，annotation 使用 `io.swagger.
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -154,7 +154,7 @@ React 新前端会读取部分 `knife4j.setting.*` UI 默认值，例如 `langua
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -188,7 +188,7 @@ UI 同样是新 React 版本，注意覆盖范围提示。
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -17,7 +17,7 @@ title: 产品介绍
 | 访问入口（doc.html / v2 / v3 api-docs） | 保留 | 完全一致 |
 | 仓库 | `xiaoymin/knife4j` | [`songxychn/knife4j-next`](https://github.com/songxychn/knife4j-next) |
 | 发布渠道 | Maven Central | Maven Central |
-| 当前版本 | `4.5.0`（最后一个 Maven Central 发布版本） | `5.0.18` |
+| 当前版本 | `4.5.0`（最后一个 Maven Central 发布版本） | `5.1.0` |
 | 文档站 | [doc.xiaominfo.com](https://doc.xiaominfo.com/) | 本站（`knife4jnext.com`） |
 
 **迁移的最小单位是改 `groupId`，业务代码、配置键、访问路径都不必动。** 详见 [迁移指引](./migration)。

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -35,7 +35,7 @@ After：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -57,7 +57,7 @@ After：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -85,7 +85,7 @@ After：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -131,7 +131,7 @@ knife4j:
 ## 迁移步骤
 
 1. **更新 Maven 依赖坐标**：全部 `com.github.xiaoymin` → `com.baizhukui`。
-2. **确认版本**：升到 `5.0.18`（当前稳定补丁版本）。
+2. **确认版本**：升到 `5.1.0`（当前稳定版本）。
 3. **刷新依赖**：`mvn -U clean verify` 或 `mvn dependency:tree | grep knife4j` 检查无残留旧坐标。
 4. **启动验证**：访问 `/doc.html`，确认能看到接口列表。
 5. **如切到 OpenAPI3 系列 starter**：额外检查是否用了 Springfox 专属注解（`@DynamicParameters` 等），必要时替换为 DTO 实体类方式（参考 [注解速查](../reference/annotations)）。

--- a/docs/guide/springfox-migration.md
+++ b/docs/guide/springfox-migration.md
@@ -45,7 +45,7 @@ Swagger2 注解 (@Api, @ApiOperation…)  →  OpenAPI3 注解 (@Tag, @Operation
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -55,7 +55,7 @@ Swagger2 注解 (@Api, @ApiOperation…)  →  OpenAPI3 注解 (@Tag, @Operation
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -372,14 +372,14 @@ public class UserController {/* ... */}
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 
 <!-- Spring Boot 3.x Jakarta -->
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/docs/guide/webflux.md
+++ b/docs/guide/webflux.md
@@ -51,7 +51,7 @@ title: WebFlux 接入
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -101,7 +101,7 @@ public class UserController {
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-webflux-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ features:
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -65,7 +65,7 @@ features:
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -84,10 +84,11 @@ knife4j:
 
 启动应用后访问 `http://localhost:8080/doc.html`。完整流程见 [快速开始](/guide/getting-started)。
 
-## 5.0.18 版本亮点 <Badge type="tip" text="最新" />
+## 5.1.0 版本亮点 <Badge type="tip" text="最新" />
 
-- 🚪 新增 Spring Cloud Gateway Server Web MVC 聚合 starter，覆盖 Boot 3.5 的 MANUAL、受限 DISCOVER、Basic 认证与 `/doc.html` smoke 场景
-- ⚙️ 发布 starter JAR 内置 Spring Boot 配置元数据，IDE 可识别 `knife4j.enable`、`knife4j.production` 等配置项
+- 🌍 后端、React 与 Vue3 补齐中英日国际化链路，语言切换与 `Accept-Language` 行为保持一致
+- ⬇️ React 调试器支持响应接收进度，已知总长时展示百分比，否则展示已接收大小
+- 🧪 补强 multipart 必填文件校验、响应媒体示例与长 Token 请求预览
 
 完整更新列表见 [发布说明](/release-notes/)。
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -13,7 +13,7 @@ title: 兼容矩阵
 
 | 维度 | 版本 |
 | --- | --- |
-| knife4j-next | `5.0.18` |
+| knife4j-next | `5.1.0` |
 | Java 最低版本 | `1.8`（openapi2 / openapi3 非 Jakarta）；`17`（Jakarta / Boot4） |
 | Springfox | `2.10.5`（openapi2 starter） |
 | springdoc-openapi | `1.8.0`（Boot 2.x）；`2.8.9`（Boot 3.x Jakarta）；`3.0.3`（Boot 4.x） |

--- a/docs/reference/version-ref.md
+++ b/docs/reference/version-ref.md
@@ -8,7 +8,8 @@ title: 版本对照
 
 | knife4j-next 版本 | Spring Boot 2.x | Spring Boot 3.x | Spring Boot 4.x | 说明 |
 | --- | --- | --- | --- | --- |
-| `5.0.18` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ✅ 4.0.6 | 当前版本，补丁修复版本 |
+| `5.1.0` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ✅ 4.0.6 | 当前版本，前端体验与国际化 |
+| `5.0.18` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ✅ 4.0.6 | 补丁修复版本 |
 | `5.0.17` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ✅ 4.0.6 | 补丁修复版本 |
 | `5.0.16` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ✅ 4.0.6 | 补丁修复版本 |
 | `5.0.15` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ✅ 4.0.6 | 补丁修复版本 |
@@ -29,11 +30,11 @@ title: 版本对照
 | `5.0.0` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ❌ | 首个正式稳定版本 |
 
 > knife4j-next 从 `5.0.0` 起采用独立 [SemVer](https://semver.org/lang/zh-CN/) 版本号，与上游 knife4j 版本号无关。
-> `5.0.18` 包含 Boot4 WebMVC starter、Boot4 Gateway starter、Boot4 独立聚合 starter，以及 Boot 3.5 Gateway Server Web MVC 聚合 starter；可直接使用 `com.baizhukui:knife4j-openapi3-boot4-spring-boot-starter:5.0.18`、`com.baizhukui:knife4j-gateway-boot4-spring-boot-starter:5.0.18`、`com.baizhukui:knife4j-aggregation-boot4-spring-boot-starter:5.0.18` 和 `com.baizhukui:knife4j-gateway-webmvc-spring-boot-starter:5.0.18`。
+> `5.1.0` 包含 Boot4 WebMVC starter、Boot4 Gateway starter、Boot4 独立聚合 starter，以及 Boot 3.5 Gateway Server Web MVC 聚合 starter；可直接使用 `com.baizhukui:knife4j-openapi3-boot4-spring-boot-starter:5.1.0`、`com.baizhukui:knife4j-gateway-boot4-spring-boot-starter:5.1.0`、`com.baizhukui:knife4j-aggregation-boot4-spring-boot-starter:5.1.0` 和 `com.baizhukui:knife4j-gateway-webmvc-spring-boot-starter:5.1.0`。
 
 ## 核心依赖版本
 
-以下为 `knife4j-next 5.0.18` 内部管理的依赖版本，用户一般不需要手动指定。
+以下为 `knife4j-next 5.1.0` 内部管理的依赖版本，用户一般不需要手动指定。
 
 ### Boot 2.x（非 Jakarta）线
 
@@ -85,7 +86,8 @@ title: 版本对照
 
 | upstream 版本 | knife4j-next 版本 | 说明 |
 | --- | --- | --- |
-| `4.5.0`（上游 Maven Central 最后发布版本） | `5.0.18` | 当前版本：包含全部 fork 安全修复 + Boot 3.4/3.5/4.0 兼容 + Gateway Server Web MVC / Boot4 Gateway / 独立聚合 + React UI + 补丁修复 |
+| `4.5.0`（上游 Maven Central 最后发布版本） | `5.1.0` | 当前版本：包含全部 fork 安全修复 + Boot 3.4/3.5/4.0 兼容 + React UI 调试与三语增强 |
+| `4.5.0` | `5.0.18` | 补丁修复版本 |
 | `4.5.0` | `5.0.17` | 补丁修复版本 |
 | `4.5.0` | `5.0.16` | 补丁修复版本 |
 | `4.5.0` | `5.0.15` | 补丁修复版本 |

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -12,7 +12,23 @@ title: 发布说明
 
 ## knife4j-next 版本
 
-### 5.0.18 <Badge type="tip" text="最新" />
+### 5.1.0 <Badge type="tip" text="最新" />
+
+`5.1.0` 是基于 `5.0.18` 的向后兼容次版本，新增 React 嵌入式启动能力，集中增强调试与文档体验，并补齐中英日国际化链路。
+
+**调试与文档体验（React UI）**
+
+- React UI 支持通过 `window.__KNIFE4X_CONFIG__` 进入嵌入模式，校验 `specUrl` / `basePath`，直接加载单一 OpenAPI 3 文档且不请求 Java discovery 端点（PR #549，issue #548）。
+- 响应文档示例优先展示 OpenAPI media type 中显式声明的 `example` / `examples.*.value`，没有显式示例时再回退到 schema 生成值（PR #560，issue #550）。
+- 请求预览中的 Header / Query 长连续值不再撑坏表格；默认折叠为两行，可展开并复制完整值（PR #559，issue #551）。
+- multipart schema `required` 声明的文件字段会在发送前校验；未选择必填文件时显示字段级错误并阻止请求（PR #570，issue #569）。
+- 非 SSE 响应在接收阶段显示进度：可安全读取总长时展示百分比和总量，否则展示已接收大小（PR #571，issue #567）。
+
+**中英日国际化**
+
+- 后端补充 `ja-JP` 语言枚举；React 与 Vue3 统一 `zh-CN`、`en-US`、`ja-JP` 的规范化、旧缓存迁移、语言切换和 `Accept-Language` 行为，并补齐文档、Schema、导出与运行时提示等三语文案（PR #568）。
+
+### 5.0.18
 
 `5.0.18` 是基于 `5.0.17` 的补丁版本，新增 Spring Cloud Gateway Server Web MVC 聚合 starter，补齐 starter 发布包的 Spring Boot 配置元数据，并将提交前检查收敛为版本化 Git hook。
 
@@ -390,7 +406,7 @@ Maven 坐标：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -8,7 +8,7 @@ title: 路线图
 
 ---
 
-## 当前阶段：5.0.18 已发布
+## 当前阶段：5.1.0 已发布
 
 ### 已完成 ✅
 
@@ -37,7 +37,7 @@ title: 路线图
 | React 前端 | 离线文档导出（HTML / Word） | ✅ |
 | React 前端 | 真实 API 数据对接（/v3/api-docs） | ✅ |
 | React 前端 | 集成到 `knife4j-openapi3-ui` webjar | ✅ |
-| React 前端 | i18n 中英文切换 | ✅ |
+| React 前端 | i18n 中英日切换 | ✅ |
 | React 前端 | 设置面板（Header 右上角整合） | ✅ |
 | React 前端 | Tab 右键菜单 + 刷新后状态持久化 | ✅ |
 | React 前端 | 侧边栏接口搜索高亮 + Method 过滤条 | ✅ |

--- a/knife4j/MIGRATION.md
+++ b/knife4j/MIGRATION.md
@@ -20,7 +20,7 @@ With:
 <dependency>
   <groupId>com.baizhukui</groupId>
   <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-  <version>5.0.18</version>
+  <version>5.1.0</version>
 </dependency>
 ```
 

--- a/knife4j/README.md
+++ b/knife4j/README.md
@@ -12,7 +12,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -49,7 +49,7 @@ Spring Boot 4.x 使用独立 starter，避免把现有 Spring Boot 3.x + springd
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -61,7 +61,7 @@ Spring Boot 4.x 的 Spring Cloud Gateway 5 聚合场景使用独立 gateway star
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Spring Boot 4.x 的独立聚合服务使用独立 aggregation starter：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-aggregation-boot4-spring-boot-starter</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
 </dependency>
 ```
 

--- a/knife4j/knife4j-aggregation-boot4-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-boot4-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
 
     <artifactId>knife4j-aggregation-boot4-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-aggregation-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-core/pom.xml
+++ b/knife4j/knife4j-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-demo-openapi2/pom.xml
+++ b/knife4j/knife4j-demo-openapi2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-demo-openapi3/pom.xml
+++ b/knife4j/knife4j-demo-openapi3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-dependencies/pom.xml
+++ b/knife4j/knife4j-dependencies/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-dependencies</artifactId>

--- a/knife4j/knife4j-gateway-boot4-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-boot4-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
 
     <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-openapi2-ui/pom.xml
+++ b/knife4j/knife4j-openapi2-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-openapi2-ui</artifactId>

--- a/knife4j/knife4j-openapi3-boot4-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-boot4-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
 
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
 
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-openapi3-ui/pom.xml
+++ b/knife4j/knife4j-openapi3-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
     <name>knife4j-openapi3-webflux-jakarta-spring-boot-starter</name>

--- a/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
     </parent>
     <artifactId>knife4j-openapi3-webflux-spring-boot-starter</artifactId>
     <name>knife4j-openapi3-webflux-spring-boot-starter</name>

--- a/knife4j/knife4j-smoke-tests/aggregation-boot2-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/aggregation-boot2-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot2-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot2-openapi3-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-openapi3-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot2-webflux-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-webflux-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-gateway-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-gateway-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot4-aggregation-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot4-aggregation-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot4-gateway-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot4-gateway-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.0.18</version>
+        <version>5.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j</artifactId>
-    <version>5.0.18</version>
+    <version>5.1.0</version>
     <modules>
         <module>knife4j-core</module>
         <module>knife4j-dependencies</module>


### PR DESCRIPTION
Closes #572

## 范围

- 将 34 个 Maven POM 的版本从 `5.0.18` 更新到 `5.1.0`
- 更新 README、文档中的当前稳定版本引用
- 补充 5.1.0 发布说明，覆盖 #549、#559、#560、#568、#570、#571
- Knife4x Go 与仓库工具改动保持独立，不纳入 Java/Maven 5.1.0 发布说明

## 验证

- `./tools/verify-release-modules.sh`：16 个发布模块一致
- `./tools/test-docs.sh`：通过
- `./tools/test-java.sh`：34/34 模块构建成功；6 个配置元数据模块通过；14/14 starter smoke 通过
- `git diff --check`：通过
- 独立 reviewer：通过，无遗留问题

## 发布后检查

合并后按既有流程创建 annotated tag `v5.1.0`，等待 Release / Demo workflow，通过 Maven Central 16 模块、GitHub Release 正文和独立公开消费者验收。