### PR TITLE
docs: 将 Knife4x Go 纳入文档站

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http://ip:port/doc.html
 |---|---|
 | `knife4j/` | Java 主工程（starter、UI webjar、聚合、Gateway、WebFlux、smoke 与 demo） |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3 workspace）、`vue3`（OAS2 兼容） |
-| `knife4x/` | Go/Rust 嵌入式控制台骨架（规划中，与 `front/ui-react` 共用 UI） |
+| `knife4x/` | 嵌入式控制台：Go `v0.1.0` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
 | `docs/` | VitePress 文档站 |
 | `tools/` | 验证与发布辅助脚本（原 `scripts/`） |
 | `legacy/` | 冻结参考：`vue2`、`insight`、`sandbox`（不参与主线构建） |
@@ -92,7 +92,7 @@ http://ip:port/doc.html
 | OAS3 主线 UI | `front/ui-react` | `knife4j-openapi3-ui` webjar；Knife4x embed | 承接新功能、UX 改进和调试器增强 |
 | OAS3 解析核心 | `front/core` | React UI 内部依赖 | 服务于 OAS3 主线，不为 OAS2 扩展 |
 | OAS2 兼容 UI | `front/vue3` | `knife4j-openapi2-ui` webjar | 只接收回归修复、安全补丁与显示层 bug |
-| Knife4x | `knife4x/` | Go / Rust 宿主壳 | 骨架阶段；UI 不另开工程 |
+| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.1.0` 已发布；Rust 后置；UI 不另开工程 |
 | 历史代码 | `legacy/` | 无发布目标 | 仅参考，勿接常规功能任务 |
 | 文档站 | `docs/` | [knife4jnext.com](https://knife4jnext.com) | 当前对外文档主入口 |
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       { text: '快速开始', link: '/guide/getting-started' },
       { text: '功能', link: '/guide/features' },
       { text: '迁移', link: '/guide/migration' },
+      { text: 'Knife4x', link: '/knife4x/' },
       { text: '配置参考', link: '/reference/configuration' },
       {
         text: '在线 Demo',
@@ -69,6 +70,7 @@ export default defineConfig({
       {
         text: '接入指南',
         items: [
+          { text: 'Knife4x Go', link: '/knife4x/' },
           { text: 'Spring Cloud Gateway 聚合', link: '/guide/gateway' },
           { text: 'Disk / Nacos / Eureka 聚合', link: '/guide/aggregation' },
           { text: 'Spring WebFlux 接入', link: '/guide/webflux' },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
       {
         text: '在线 Demo',
         items: [
-          { text: 'OpenAPI 3（Spring Boot 3 + React UI）', link: 'https://openapi3.demo.knife4jnext.com/doc.html' },
+          { text: 'OpenAPI 3（Spring Boot 4 + React UI）', link: 'https://openapi3.demo.knife4jnext.com/doc.html' },
           { text: 'OpenAPI 2（Spring Boot 2 + Vue 3 UI）', link: 'https://openapi2.demo.knife4jnext.com/doc.html' }
         ]
       },

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,11 @@ features:
     linkText: 网关接入
 ---
 
+::: tip Knife4x Go v0.1.0
+Go 服务现在也能嵌入同一套 React UI，通过标准库 `net/http` Handler 挂载
+UI、加载已有 OpenAPI 3 文档并提供调试控制台。[查看 Go 接入](/knife4x/)。
+:::
+
 ## 这是 Knife4j 的 fork，不是重写
 
 `knife4j-next` 是 [`xiaoymin/knife4j`](https://github.com/xiaoymin/knife4j) 的社区维护分支。

--- a/docs/knife4x/index.md
+++ b/docs/knife4x/index.md
@@ -1,0 +1,85 @@
+---
+title: Knife4x Go
+description: 在 Go 服务中嵌入 Knife4j React UI，加载已有 OpenAPI 3 文档并挂载调试控制台。
+---
+
+# Knife4x Go
+
+Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试控制台。
+当前已发布 Go `v0.1.0`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
+版本和发布流程独立于 Java `5.x`。
+
+## 安装
+
+Go module 需要 Go 1.22 或更高版本：
+
+```bash
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.1.0
+```
+
+## 最小接入
+
+先由业务 Handler 提供 OpenAPI 3 JSON 和 API，再把它传给 Knife4x：
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+
+	knife4x "github.com/songxychn/knife4j-next/knife4x/go"
+)
+
+func main() {
+	app := http.NewServeMux()
+	app.HandleFunc("/openapi.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"openapi":"3.0.3",
+			"info":{"title":"Example API","version":"1.0.0"},
+			"paths":{}
+		}`))
+	})
+
+	handler, err := knife4x.NewHandler(knife4x.Config{
+		SpecURL: "/openapi.json",
+	}, app)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Fatal(http.ListenAndServe(":8080", handler))
+}
+```
+
+启动后访问 `http://localhost:8080/doc.html`。
+
+## 配置
+
+| 字段 | 要求 | 说明 |
+| --- | --- | --- |
+| `SpecURL` | 必填 | 已有 OpenAPI 3 文档 URL，可使用根相对、相对或完整 HTTP(S) URL |
+| `BasePath` | 可选 | UI 挂载前缀；必须是以 `/` 开头的 clean absolute path，空值等同于 `/` |
+
+例如 `BasePath: "/internal"` 时，入口为 `/internal/doc.html`。生产环境不需要文档时，
+不要创建或挂载 Knife4x Handler；Knife4x 不额外提供 `enabled` 开关。
+
+相对 `SpecURL: "openapi.json"` 会在该前缀下解析为 `/internal/openapi.json`；
+根相对 `SpecURL: "/openapi.json"` 仍指向根路径。Knife4x 不拥有的请求会交回传入的
+业务 Handler。使用跨域的完整 URL 时，目标服务必须允许浏览器 CORS。
+
+## 使用边界
+
+- 只消费已有的 OpenAPI 3 JSON，不生成 spec，不支持 OAS2 / Swagger 2。
+- 只提供 `{BasePath}/doc.html` 入口，不为 `/` 或 `index.html` 增加重定向或 SPA fallback。
+- Go 核心只依赖标准库 `net/http`；Gin 是可运行示例，不是库依赖。
+- Go Handler 将配置注入 UI，Knife4x 不请求 Java 的 `/knife4j/config`。
+- Go 使用独立 `0.x` 版本；Java `5.x` 发布说明和 Maven 坐标不适用于 Knife4x。
+
+## 更多资料
+
+- [完整 Go 接入说明](https://github.com/songxychn/knife4j-next/blob/master/knife4x/go/README.md)
+- [Gin 可运行示例](https://github.com/songxychn/knife4j-next/tree/master/knife4x/examples/gin)
+- [从 gin-swagger 迁移](https://github.com/songxychn/knife4j-next/blob/master/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md)
+- [Go v0.1.0 发布与验收规则](https://github.com/songxychn/knife4j-next/blob/master/knife4x/go/RELEASE.md)

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -10,10 +10,12 @@ title: 模块说明
 | --- | --- |
 | `knife4j/` | Java 主工程——用户实际引入的 starter 和 webjar 都在这里构建 |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3）、`vue3`（OAS2 兼容） |
-| `knife4x/` | Go/Rust 嵌入式控制台骨架（规划中，UI 共用 `front/ui-react`） |
+| `knife4x/` | 嵌入式控制台：Go `v0.1.0` 已发布，Rust 后置；UI 共用 `front/ui-react` |
 | `docs/` | 当前 VitePress 文档站 |
 | `tools/` | 验证、发布与任务看板脚本 |
 | `legacy/` | 冻结参考（`vue2`、`insight`、`sandbox`），不参与主线构建 |
+
+Go 服务不使用 Maven starter，请直接查看 [Knife4x Go 接入](/knife4x/)。
 
 ## Java 模块（`knife4j/` 下）
 

--- a/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+++ b/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
@@ -15,8 +15,7 @@ Knife4x 替换的是嵌入式文档与调试 UI，不替代 OpenAPI 生成器。
 只有 `openapi: 3.x` JSON 可以继续。若文档使用 `swagger: "2.0"`，请先升级生成器或转换
 spec；OAS2 不能直接迁移到 Knife4x。
 
-首个 Knife4x Go 版本固定为 `v0.1.0`。在仓库 tag `knife4x/go/v0.1.0` 尚未发布且
-公共 Go proxy 尚未可查前，不要执行下面命令；发布完成后再运行：
+Knife4x Go 当前公开版本为 `v0.1.0`：
 
 ```bash
 go get github.com/songxychn/knife4j-next/knife4x/go@v0.1.0

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -9,8 +9,13 @@ github.com/songxychn/knife4j-next/knife4x/go
 Knife4x 只消费 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2。核心只依赖
 标准库 `net/http`；Gin 只是可运行的组合示例，不是库依赖。
 
-首个公开版本固定为 `v0.1.0`，对应仓库 tag `knife4x/go/v0.1.0`。tag 发布前请从
-仓库 checkout 运行示例；发布门禁、tag 步骤与公共消费验证见 [RELEASE.md](RELEASE.md)。
+当前公开版本为 `v0.1.0`，对应仓库 tag `knife4x/go/v0.1.0`：
+
+```bash
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.1.0
+```
+
+发布门禁、tag 规则与公共消费验证见 [RELEASE.md](RELEASE.md)。
 
 ## 标准库接入
 


### PR DESCRIPTION
Closes #574

## 改动

- 在首页、顶部导航和接入指南侧栏增加 Knife4x Go 入口
- 新增单页接入文档，覆盖 Go `v0.1.0`、`net/http` 最小示例、`SpecURL` / `BasePath` 与公开路由语义
- 明确 Knife4x 只加载已有 OAS3 spec，Gin 仅为示例，版本与 Java `5.x` 独立
- 修正文档与 Go README 中仍称“规划中”或“tag 发布前”的过期说明
- 修正在线 Demo 菜单，将 OpenAPI 3 技术栈更新为 Spring Boot 4 + React UI

## 边界

- 不修改 Java `5.x` 发布说明、Maven 坐标或产品兼容承诺
- Rust 仍保持后置，不新增占位实现
- 不复制完整 Go README，只保留文档站所需的最小接入页和源文档链接

## 验证

- `./tools/test-docs.sh`
- `GOCACHE=/tmp/knife4x-go-build-cache ./tools/test-knife4x-go.sh`
- `./tools/test-ci-changes.sh`
- `git diff --check`
- 本地视觉检查：首页入口、顶部导航、在线 Demo 菜单、侧栏与 `/knife4x/` 页面均正常

CI 预期只运行 docs 与 Knife4x Go 相关任务。