### PR TITLE
chore: 更新 Spring 平台补丁版本

### DIFF
--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <knife4j-java.version>17</knife4j-java.version>
-        <knife4j-spring-boot3.version>3.5.14</knife4j-spring-boot3.version>
+        <knife4j-spring-boot3.version>3.5.16</knife4j-spring-boot3.version>
         <knife4j-spring-cloud3.version>2025.0.3</knife4j-spring-cloud3.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     </properties>

--- a/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <knife4j-java.version>17</knife4j-java.version>
-        <knife4j-spring-boot3.version>3.5.14</knife4j-spring-boot3.version>
+        <knife4j-spring-boot3.version>3.5.16</knife4j-spring-boot3.version>
         <knife4j-spring-cloud3.version>2025.0.3</knife4j-spring-cloud3.version>
     </properties>
 

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -52,8 +52,8 @@
         <knife4j-spring-boot.version>2.7.18</knife4j-spring-boot.version>
         <knife4j-spring3.version>6.2.0</knife4j-spring3.version>
         <knife4j-spring-boot3.version>3.4.0</knife4j-spring-boot3.version>
-        <knife4j-spring-boot4.version>4.0.6</knife4j-spring-boot4.version>
-        <knife4j-spring-cloud-boot4.version>2025.1.1</knife4j-spring-cloud-boot4.version>
+        <knife4j-spring-boot4.version>4.0.7</knife4j-spring-boot4.version>
+        <knife4j-spring-cloud-boot4.version>2025.1.2</knife4j-spring-cloud-boot4.version>
         <knife4j-junit-jupiter-api.version>5.11.3</knife4j-junit-jupiter-api.version>
 
         <knife4j-springfox.version>2.10.5</knife4j-springfox.version>


### PR DESCRIPTION
## 为什么

跟进 Spring 平台当前稳定补丁版本，并保持 Boot 4 与 Spring Cloud 2025.1 的官方配套关系。本次没有对应 issue，按独立维护项提交。

- Spring Boot 4.0.7 发布说明：https://spring.io/blog/2026/06/10/spring-boot-4-0-7-available-now/
- Spring Cloud 2025.1.2 发布说明：https://spring.io/blog/2026/06/11/spring-cloud-2025-1-2-aka-oakwood-has-been-released/

## 变更

- Spring Boot 4：`4.0.6` → `4.0.7`
- Spring Cloud Boot 4：`2025.1.1` → `2025.1.2`
- Gateway Server Web MVC 的 Spring Boot 3.5：`3.5.14` → `3.5.16`
- 同步对应 Boot 3.5 smoke 模块版本

## 影响

只更新测试/编译所用的平台 BOM 与补丁版本，不改变 Maven 坐标、默认兼容承诺或业务代码。

## 验证

- `JAVA_HOME=/Users/baizhukui/Library/Java/JavaVirtualMachines/corretto-17.0.16/Contents/Home ./tools/test-java.sh`
  - Maven 34 个 reactor 模块全部成功
  - 6 个配置元数据模块通过
  - 14 个 smoke 模块通过
  - Boot 4 smoke 实际使用 4.0.7，Boot 3.5 Gateway smoke 实际使用 3.5.16