### PR TITLE
chore: 更新 Java 基础依赖

### DIFF
--- a/docs/reference/version-ref.md
+++ b/docs/reference/version-ref.md
@@ -76,10 +76,10 @@ title: 版本对照
 | 依赖 | 版本 |
 | --- | --- |
 | Java 最低版本 | `1.8`（非 Jakarta）；`17`（Jakarta / Boot4） |
-| SLF4J | `2.0.16` |
+| SLF4J | `2.0.18` |
 | Gson | `2.11.0` |
 | Javassist | `3.30.2-GA` |
-| Lombok | `1.18.36` |
+| Lombok | `1.18.46` |
 
 ## Upstream 版本对照
 

--- a/knife4j/knife4j-demo-openapi2/pom.xml
+++ b/knife4j/knife4j-demo-openapi2/pom.xml
@@ -35,7 +35,7 @@
             <version>${knife4j-spring-boot.version}</version>
         </dependency>
         <!--
-          覆盖 root pom 的 slf4j-api 2.0.16（provided），回到与 Spring Boot 2.7.18
+          覆盖 root pom 的 slf4j-api 2.0.18（provided），回到与 Spring Boot 2.7.18
           自带的 logback-classic 1.2.12 兼容的 1.7.x。SLF4J 2.x 走 ServiceLoader
           查找 SLF4JServiceProvider，logback 1.2.x 只提供 1.x 的 StaticLoggerBinder
           SPI，会让 LoggerFactory fallback 到 NOPLoggerFactory，Spring Boot banner、

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -54,7 +54,7 @@
         <knife4j-spring-boot3.version>3.4.0</knife4j-spring-boot3.version>
         <knife4j-spring-boot4.version>4.0.7</knife4j-spring-boot4.version>
         <knife4j-spring-cloud-boot4.version>2025.1.2</knife4j-spring-cloud-boot4.version>
-        <knife4j-junit-jupiter-api.version>5.11.3</knife4j-junit-jupiter-api.version>
+        <knife4j-junit-jupiter-api.version>5.14.4</knife4j-junit-jupiter-api.version>
 
         <knife4j-springfox.version>2.10.5</knife4j-springfox.version>
         <knife4j-spring-plugin.version>2.0.0.RELEASE</knife4j-spring-plugin.version>
@@ -71,18 +71,18 @@
         <knife4j-servlet.version>4.0.1</knife4j-servlet.version>
         <knife4j-servlet-jakarta.version>6.1.0</knife4j-servlet-jakarta.version>
 
-        <knife4j-slf4j.version>2.0.16</knife4j-slf4j.version>
+        <knife4j-slf4j.version>2.0.18</knife4j-slf4j.version>
         <knife4j-httpclient.version>4.5.14</knife4j-httpclient.version>
         <knife4j-gson.version>2.11.0</knife4j-gson.version>
         <knife4j-commons-lang3.version>3.20.0</knife4j-commons-lang3.version>
 
 
         <knife4j-javassist.version>3.30.2-GA</knife4j-javassist.version>
-        <knife4j-lombok.version>1.18.36</knife4j-lombok.version>
+        <knife4j-lombok.version>1.18.46</knife4j-lombok.version>
         <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
 
         <knife4j-spotless-maven-plugin.version>2.43.0</knife4j-spotless-maven-plugin.version>
-        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <!-- Keep release packaging fast by allowing callers to override this property explicitly. -->
         <knife4j-skipTests>true</knife4j-skipTests>
     </properties>


### PR DESCRIPTION
## 为什么

前端同主版本、Spring 平台补丁和 Hutool 清理已分别完成。本次继续处理一组不改变产品 API、可由现有 Java 门禁完整验证的基础依赖，避免把行为变化较大的 Gson、springdoc、Swagger 等混入。

## 变更

- SLF4J：`2.0.16` → `2.0.18`
- Lombok：`1.18.36` → `1.18.46`
- JUnit Jupiter：`5.11.3` → `5.14.4`
- Maven Surefire Plugin：`3.5.2` → `3.5.6`
- 同步版本文档和 Boot 2 demo 中的 SLF4J 说明；Boot 2 demo 仍显式使用 `slf4j-api 1.7.36`

版本均停留在当前兼容主版本：未升级到 JUnit 6，也未采用 Surefire 3.6 milestone。

## 兼容边界

- SLF4J 2.0.18、JUnit 5.14.4 与 Surefire 3.5.6 仍支持 Java 8
- Lombok 只作为 `provided` / annotation processor；仓库未使用本轮可能涉及生成行为变化的 `@Jacksonized` / `@Accessors`
- 未改 Java 源码、依赖 scope、Spring Boot 支持矩阵、Maven 坐标或运行时默认行为
- Gson、springdoc、Javassist、Swagger 因存在可观察行为或公共模型风险，留待独立 PR

## 版本依据

- [SLF4J news](https://www.slf4j.org/news.html)
- [Lombok changelog](https://projectlombok.org/changelog)
- [JUnit 5.14.4 文档](https://docs.junit.org/5.14.4/overview.html)
- [Surefire 3.5.6 release](https://github.com/apache/maven-surefire/releases/tag/surefire-3.5.6)

## 验证

- `./tools/test-java.sh`
  - 34 个 reactor 模块通过
  - 6 个配置元数据检查通过
  - 14 个 smoke 模块通过
- `./tools/test-docs.sh`
- 独立审查：无 findings，无 scope drift

无对应 issue：这是一次现场依赖维护。
