### PR TITLE
release(knife4x): 准备 Go v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http://ip:port/doc.html
 |---|---|
 | `knife4j/` | Java 主工程（starter、UI webjar、聚合、Gateway、WebFlux、smoke 与 demo） |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3 workspace）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.1.0` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
+| `knife4x/` | 嵌入式控制台：Go `v0.2.0` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
 | `docs/` | VitePress 文档站 |
 | `tools/` | 验证与发布辅助脚本（原 `scripts/`） |
 | `legacy/` | 冻结参考：`vue2`、`insight`、`sandbox`（不参与主线构建） |
@@ -92,7 +92,7 @@ http://ip:port/doc.html
 | OAS3 主线 UI | `front/ui-react` | `knife4j-openapi3-ui` webjar；Knife4x embed | 承接新功能、UX 改进和调试器增强 |
 | OAS3 解析核心 | `front/core` | React UI 内部依赖 | 服务于 OAS3 主线，不为 OAS2 扩展 |
 | OAS2 兼容 UI | `front/vue3` | `knife4j-openapi2-ui` webjar | 只接收回归修复、安全补丁与显示层 bug |
-| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.1.0` 已发布；Rust 后置；UI 不另开工程 |
+| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.2.0` 已发布；Rust 后置；UI 不另开工程 |
 | 历史代码 | `legacy/` | 无发布目标 | 仅参考，勿接常规功能任务 |
 | 文档站 | `docs/` | [knife4jnext.com](https://knife4jnext.com) | 当前对外文档主入口 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ features:
     linkText: 网关接入
 ---
 
-::: tip Knife4x Go v0.1.0
+::: tip Knife4x Go v0.2.0
 Go 服务现在也能嵌入同一套 React UI，通过标准库 `net/http` Handler 挂载
 UI、加载已有 OpenAPI 3 文档并提供调试控制台。[查看 Go 接入](/knife4x/)。
 :::

--- a/docs/knife4x/index.md
+++ b/docs/knife4x/index.md
@@ -6,7 +6,7 @@ description: 在 Go 服务中嵌入 Knife4j React UI，加载已有 OpenAPI 3 �
 # Knife4x Go
 
 Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试控制台。
-当前已发布 Go `v0.1.0`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
+当前已发布 Go `v0.2.0`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
 版本和发布流程独立于 Java `5.x`。
 
 ## 安装
@@ -14,8 +14,14 @@ Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试�
 Go module 需要 Go 1.22 或更高版本：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.1.0
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.0
 ```
+
+## v0.2.0
+
+Go `Handler` API 与路由语义保持不变，内嵌 React UI 新增中英日国际化、multipart
+必填文件校验、响应接收进度、分组级全局参数，以及二进制响应和响应 Header 展示；
+同时修复 JSON/XML 调试编辑器的 CodeMirror 运行时错误。
 
 ## 最小接入
 
@@ -82,4 +88,4 @@ func main() {
 - [完整 Go 接入说明](https://github.com/songxychn/knife4j-next/blob/master/knife4x/go/README.md)
 - [Gin 可运行示例](https://github.com/songxychn/knife4j-next/tree/master/knife4x/examples/gin)
 - [从 gin-swagger 迁移](https://github.com/songxychn/knife4j-next/blob/master/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md)
-- [Go v0.1.0 发布与验收规则](https://github.com/songxychn/knife4j-next/blob/master/knife4x/go/RELEASE.md)
+- [Go 发布与验收规则](https://github.com/songxychn/knife4j-next/blob/master/knife4x/go/RELEASE.md)

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -10,7 +10,7 @@ title: 模块说明
 | --- | --- |
 | `knife4j/` | Java 主工程——用户实际引入的 starter 和 webjar 都在这里构建 |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.1.0` 已发布，Rust 后置；UI 共用 `front/ui-react` |
+| `knife4x/` | 嵌入式控制台：Go `v0.2.0` 已发布，Rust 后置；UI 共用 `front/ui-react` |
 | `docs/` | 当前 VitePress 文档站 |
 | `tools/` | 验证、发布与任务看板脚本 |
 | `legacy/` | 冻结参考（`vue2`、`insight`、`sandbox`），不参与主线构建 |

--- a/knife4x/README.md
+++ b/knife4x/README.md
@@ -16,9 +16,9 @@ Go module 路径为：
 github.com/songxychn/knife4j-next/knife4x/go
 ```
 
-Go 首个公开版本固定为 `v0.1.0`，对应仓库 tag `knife4x/go/v0.1.0`。tag 发布前可从
-仓库 checkout 直接运行 [Gin example](examples/gin/README.md)；发布状态与完整验收步骤见
-[Go 发布清单](go/RELEASE.md)。
+Go 当前公开版本为 `v0.2.0`，对应仓库 tag `knife4x/go/v0.2.0`；首个公开版本为
+`v0.1.0`。tag 发布前可从仓库 checkout 直接运行 [Gin example](examples/gin/README.md)；
+发布状态与完整验收步骤见 [Go 发布清单](go/RELEASE.md)。
 
 ## 快速开始
 

--- a/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+++ b/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
@@ -15,10 +15,10 @@ Knife4x 替换的是嵌入式文档与调试 UI，不替代 OpenAPI 生成器。
 只有 `openapi: 3.x` JSON 可以继续。若文档使用 `swagger: "2.0"`，请先升级生成器或转换
 spec；OAS2 不能直接迁移到 Knife4x。
 
-Knife4x Go 当前公开版本为 `v0.1.0`：
+Knife4x Go 当前公开版本为 `v0.2.0`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.1.0
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.0
 ```
 
 ## 替换挂载代码

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -9,11 +9,13 @@ github.com/songxychn/knife4j-next/knife4x/go
 Knife4x 只消费 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2。核心只依赖
 标准库 `net/http`；Gin 只是可运行的组合示例，不是库依赖。
 
-当前公开版本为 `v0.1.0`，对应仓库 tag `knife4x/go/v0.1.0`：
+当前公开版本为 `v0.2.0`，对应仓库 tag `knife4x/go/v0.2.0`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.1.0
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.0
 ```
+
+`v0.2.0` 保持 `Config`、`NewHandler` 与路由语义不变，只升级内嵌 React UI。
 
 发布门禁、tag 规则与公共消费验证见 [RELEASE.md](RELEASE.md)。
 

--- a/knife4x/go/RELEASE.md
+++ b/knife4x/go/RELEASE.md
@@ -1,6 +1,6 @@
 # Knife4x Go 发布
 
-本文只冻结 Knife4x Go 的版本、tag 与验收步骤。实际创建或推送 tag 必须由维护者另行明确授权。
+本文冻结 Knife4x Go 的版本、tag 与验收步骤。实际创建或推送 tag 必须由维护者明确授权。
 
 ## 固定坐标
 
@@ -8,7 +8,8 @@
 |---|---|
 | Go module | `github.com/songxychn/knife4j-next/knife4x/go` |
 | 首个版本 | `v0.1.0` |
-| 仓库 tag | `knife4x/go/v0.1.0` |
+| 当前版本 | `v0.2.0` |
+| 当前 tag | `knife4x/go/v0.2.0` |
 | 许可证 | Apache-2.0 |
 
 Go module 位于仓库子目录，因此按
@@ -50,8 +51,8 @@ test -f knife4x/go/internal/ui/static/assets/index.css
 
 ```bash
 grep -Fq 'github.com/songxychn/knife4j-next/knife4x/go' knife4x/README.md
-grep -Fq 'knife4x/go/v0.1.0' knife4x/README.md knife4x/go/README.md
-grep -Fq 'go@v0.1.0' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+grep -Fq 'knife4x/go/v0.2.0' knife4x/README.md knife4x/go/README.md
+grep -Fq 'go@v0.2.0' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 grep -Fq 'OAS2 不能直接迁移' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 test -z "$(git status --porcelain)"
 ```
@@ -61,11 +62,11 @@ test -z "$(git status --porcelain)"
 以下命令不属于 ready-to-tag 工作项。只有维护者明确授权发布后才执行：
 
 ```bash
-git tag -a knife4x/go/v0.1.0 -m "Knife4x Go v0.1.0"
-git push origin knife4x/go/v0.1.0
+git tag -a knife4x/go/v0.2.0 -m "Knife4x Go v0.2.0"
+git push origin knife4x/go/v0.2.0
 ```
 
-不要同时创建根级 `v0.1.0` tag，不要运行 Java Maven Release，不要为首版新增
+不要同时创建根级 `v0.2.0` tag，不要运行 Java Maven Release，不要为本次发布新增
 registry、OIDC、secret 或 GitHub Release。
 
 ## 发布后公共消费验证
@@ -74,7 +75,7 @@ registry、OIDC、secret 或 GitHub Release。
 
 ```bash
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.1.0
+version=v0.2.0
 curl -fsS "https://proxy.golang.org/${module}/@v/${version}.info"
 ```
 
@@ -86,7 +87,7 @@ consumer_dir="$(mktemp -d)"
 trap 'rm -rf "$consumer_dir"' EXIT
 
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.1.0
+version=v0.2.0
 export GOPROXY=https://proxy.golang.org
 export GONOPROXY=none
 export GOMODCACHE="$consumer_dir/modcache"
@@ -132,11 +133,11 @@ test -f "$module_dir/internal/ui/static/assets/index.css"
 ```
 
 只有公共 proxy 查询、无 `replace` consumer 编译和下载内容检查都通过后，才可宣布
-Knife4x Go `v0.1.0` 发布完成。
+Knife4x Go `v0.2.0` 发布完成。
 
 ## 补丁原则
 
 - 已发布 tag 不移动、不覆盖；有问题发布新的 patch 版本。
 - 只修兼容 bug 时递增 patch；新增向后兼容能力时递增 minor。
 - `0.x` 的破坏性变更至少递增 minor，并提供迁移说明。
-- Rust 尚未发布，不为 Go `v0.1.0` 创建空 crate 或同步 tag。
+- Rust 尚未发布，不为本次 Go 版本创建空 crate 或同步 tag。


### PR DESCRIPTION
Refs #591

## 范围

- 将 Knife4x Go 当前公开版本与安装示例更新到 `v0.2.0`
- 将发布 tag、公共 GOPROXY 和无 `replace` consumer 验收清单更新为 `knife4x/go/v0.2.0`
- 补充 v0.2.0 说明：保持 `Config` / `NewHandler` 与路由语义不变，升级内嵌 React UI
- 保留首版 `v0.1.0` 历史；不改 Go 代码、`go.mod`、生成资产、workflow 或 Rust 占位

## 版本判断

`v0.1.0` 后同步了国际化、multipart 必填校验、响应进度、分组级全局参数、二进制响应/响应 Header 展示和 CodeMirror 修复，属于向后兼容新增能力，因此按现有规则递增 minor 到 `v0.2.0`。

## 验证

- 两个 module `go mod tidy -diff`：通过
- `GOCACHE=/private/tmp/codex-knife4x-go-cache-591 ./tools/test-knife4x-go.sh`：Go core / Gin tests 通过，Java tag 路由隔离断言通过
- `./tools/sync-knife4x-ui.sh --check`：内嵌 UI 资产精确一致
- `./tools/test-ci-changes.sh`、`./tools/test-docs.sh`、`git diff --check`：通过
- LICENSE、index.html、index.js、index.css 与安装/迁移入口检查：通过
- 独立 reviewer：无 findings，发布准备 diff GO

## 发布后检查

合并且 PR/master CI 全绿后，从合并后的 `master` 创建 annotated tag `knife4x/go/v0.2.0`。不得创建根级 `v0.2.0`，不触发 Java Release/Demo；发布完成以公共 `proxy.golang.org` 和全新无 `replace` consumer 的 LICENSE/UI 资产检查通过为准。