### PR TITLE
release(knife4x): 准备 Go v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http://ip:port/doc.html
 |---|---|
 | `knife4j/` | Java 主工程（starter、UI webjar、聚合、Gateway、WebFlux、smoke 与 demo） |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3 workspace）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.2.2` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
+| `knife4x/` | 嵌入式控制台：Go `v0.2.3` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
 | `docs/` | VitePress 文档站 |
 | `tools/` | 验证与发布辅助脚本（原 `scripts/`） |
 | `legacy/` | 冻结参考：`vue2`、`insight`、`sandbox`（不参与主线构建） |
@@ -92,7 +92,7 @@ http://ip:port/doc.html
 | OAS3 主线 UI | `front/ui-react` | `knife4j-openapi3-ui` webjar；Knife4x embed | 承接新功能、UX 改进和调试器增强 |
 | OAS3 解析核心 | `front/core` | React UI 内部依赖 | 服务于 OAS3 主线，不为 OAS2 扩展 |
 | OAS2 兼容 UI | `front/vue3` | `knife4j-openapi2-ui` webjar | 只接收回归修复、安全补丁与显示层 bug |
-| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.2.2` 已发布；Rust 后置；UI 不另开工程 |
+| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.2.3` 已发布；Rust 后置；UI 不另开工程 |
 | 历史代码 | `legacy/` | 无发布目标 | 仅参考，勿接常规功能任务 |
 | 文档站 | `docs/` | [knife4jnext.com](https://knife4jnext.com) | 当前对外文档主入口 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ features:
     linkText: 网关接入
 ---
 
-::: tip Knife4x Go v0.2.2
+::: tip Knife4x Go v0.2.3
 Go 服务现在也能嵌入同一套 React UI，通过标准库 `net/http` Handler 挂载
 UI、加载已有 OpenAPI 3 文档并提供调试控制台。[查看 Go 接入](/knife4x/)。
 :::

--- a/docs/knife4x/index.md
+++ b/docs/knife4x/index.md
@@ -6,7 +6,7 @@ description: 在 Go 服务中嵌入 Knife4j React UI，加载已有 OpenAPI 3 �
 # Knife4x Go
 
 Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试控制台。
-当前已发布 Go `v0.2.2`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
+当前已发布 Go `v0.2.3`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
 版本和发布流程独立于 Java `5.x`。
 
 ## 安装
@@ -14,13 +14,13 @@ Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试�
 Go module 需要 Go 1.22 或更高版本：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.2
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.3
 ```
 
-## v0.2.2
+## v0.2.3
 
-Go `Handler` API 与路由语义保持不变，内嵌 React UI 同步补丁：独立聚合场景补齐并限制
-`knife4j-gateway-request` 路由头发送范围，避免下游 `api-docs` 404。
+Go `Handler` API 与路由语义保持不变，内嵌 React UI 同步补丁：宽屏固定 Header / 接口标签 /
+Footer 与区域独立滚动，窄屏保留 document 滚动回退，并限制超长自定义 Footer 高度。
 
 ## 最小接入
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -10,7 +10,7 @@ title: 模块说明
 | --- | --- |
 | `knife4j/` | Java 主工程——用户实际引入的 starter 和 webjar 都在这里构建 |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.2.2` 已发布，Rust 后置；UI 共用 `front/ui-react` |
+| `knife4x/` | 嵌入式控制台：Go `v0.2.3` 已发布，Rust 后置；UI 共用 `front/ui-react` |
 | `docs/` | 当前 VitePress 文档站 |
 | `tools/` | 验证、发布与任务看板脚本 |
 | `legacy/` | 冻结参考（`vue2`、`insight`、`sandbox`），不参与主线构建 |

--- a/knife4x/README.md
+++ b/knife4x/README.md
@@ -16,7 +16,7 @@ Go module 路径为：
 github.com/songxychn/knife4j-next/knife4x/go
 ```
 
-Go 当前公开版本为 `v0.2.2`，对应仓库 tag `knife4x/go/v0.2.2`；首个公开版本为
+Go 当前公开版本为 `v0.2.3`，对应仓库 tag `knife4x/go/v0.2.3`；首个公开版本为
 `v0.1.0`。tag 发布前可从仓库 checkout 直接运行 [Gin example](examples/gin/README.md)；
 发布状态与完整验收步骤见 [Go 发布清单](go/RELEASE.md)。
 

--- a/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+++ b/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
@@ -15,10 +15,10 @@ Knife4x 替换的是嵌入式文档与调试 UI，不替代 OpenAPI 生成器。
 只有 `openapi: 3.x` JSON 可以继续。若文档使用 `swagger: "2.0"`，请先升级生成器或转换
 spec；OAS2 不能直接迁移到 Knife4x。
 
-Knife4x Go 当前公开版本为 `v0.2.2`：
+Knife4x Go 当前公开版本为 `v0.2.3`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.2
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.3
 ```
 
 ## 替换挂载代码

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -9,14 +9,14 @@ github.com/songxychn/knife4j-next/knife4x/go
 Knife4x 只消费 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2。核心只依赖
 标准库 `net/http`；Gin 只是可运行的组合示例，不是库依赖。
 
-当前公开版本为 `v0.2.2`，对应仓库 tag `knife4x/go/v0.2.2`：
+当前公开版本为 `v0.2.3`，对应仓库 tag `knife4x/go/v0.2.3`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.2
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.2.3
 ```
 
-`v0.2.2` 保持 `Config`、`NewHandler` 与路由语义不变，只同步内嵌 React UI 补丁
-（聚合路由请求补齐并限制 `knife4j-gateway-request` 发送范围）。
+`v0.2.3` 保持 `Config`、`NewHandler` 与路由语义不变，只同步内嵌 React UI 补丁
+（宽屏固定页面布局与区域滚动，窄屏保留 document 滚动回退）。
 
 发布门禁、tag 规则与公共消费验证见 [RELEASE.md](RELEASE.md)。
 

--- a/knife4x/go/RELEASE.md
+++ b/knife4x/go/RELEASE.md
@@ -8,8 +8,8 @@
 |---|---|
 | Go module | `github.com/songxychn/knife4j-next/knife4x/go` |
 | 首个版本 | `v0.1.0` |
-| 当前版本 | `v0.2.2` |
-| 当前 tag | `knife4x/go/v0.2.2` |
+| 当前版本 | `v0.2.3` |
+| 当前 tag | `knife4x/go/v0.2.3` |
 | 许可证 | Apache-2.0 |
 
 Go module 位于仓库子目录，因此按
@@ -51,8 +51,8 @@ test -f knife4x/go/internal/ui/static/assets/index.css
 
 ```bash
 grep -Fq 'github.com/songxychn/knife4j-next/knife4x/go' knife4x/README.md
-grep -Fq 'knife4x/go/v0.2.2' knife4x/README.md knife4x/go/README.md
-grep -Fq 'go@v0.2.2' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+grep -Fq 'knife4x/go/v0.2.3' knife4x/README.md knife4x/go/README.md
+grep -Fq 'go@v0.2.3' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 grep -Fq 'OAS2 不能直接迁移' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 test -z "$(git status --porcelain)"
 ```
@@ -62,11 +62,11 @@ test -z "$(git status --porcelain)"
 以下命令不属于 ready-to-tag 工作项。只有维护者明确授权发布后才执行：
 
 ```bash
-git tag -a knife4x/go/v0.2.2 -m "Knife4x Go v0.2.2"
-git push origin knife4x/go/v0.2.2
+git tag -a knife4x/go/v0.2.3 -m "Knife4x Go v0.2.3"
+git push origin knife4x/go/v0.2.3
 ```
 
-不要同时创建根级 `v0.2.2` tag，不要运行 Java Maven Release，不要为本次发布新增
+不要同时创建根级 `v0.2.3` tag，不要运行 Java Maven Release，不要为本次发布新增
 registry、OIDC、secret 或 GitHub Release。
 
 ## 发布后公共消费验证
@@ -75,7 +75,7 @@ registry、OIDC、secret 或 GitHub Release。
 
 ```bash
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.2.2
+version=v0.2.3
 curl -fsS "https://proxy.golang.org/${module}/@v/${version}.info"
 ```
 
@@ -87,7 +87,7 @@ consumer_dir="$(mktemp -d)"
 trap 'rm -rf "$consumer_dir"' EXIT
 
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.2.2
+version=v0.2.3
 export GOPROXY=https://proxy.golang.org
 export GONOPROXY=none
 export GOMODCACHE="$consumer_dir/modcache"
@@ -133,7 +133,7 @@ test -f "$module_dir/internal/ui/static/assets/index.css"
 ```
 
 只有公共 proxy 查询、无 `replace` consumer 编译和下载内容检查都通过后，才可宣布
-Knife4x Go `v0.2.2` 发布完成。
+Knife4x Go `v0.2.3` 发布完成。
 
 ## 补丁原则
 


### PR DESCRIPTION
## 摘要
- 将 Knife4x Go 当前公开版本同步为 `v0.2.3`
- 发布说明：同步 React UI 固定布局与区域滚动补丁（PR #621 / issue #620）
- `Config` / `NewHandler` / 路由语义不变

Closes #623

## 验证
- `go mod tidy -diff`（`knife4x/go`、`knife4x/examples/gin`）
- `./tools/test-knife4x-go.sh`
- `./tools/sync-knife4x-ui.sh --check`
- `./tools/test-ci-changes.sh`
- `git diff --check`
- 后续补跑 `./tools/test-docs.sh`