### PR TITLE
chore(knife4x): 准备 Go v0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http://ip:port/doc.html
 |---|---|
 | `knife4j/` | Java 主工程（starter、UI webjar、聚合、Gateway、WebFlux、smoke 与 demo） |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3 workspace）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.4.1` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
+| `knife4x/` | 嵌入式控制台：Go `v0.4.2` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
 | `docs/` | VitePress 文档站 |
 | `tools/` | 验证与发布辅助脚本（原 `scripts/`） |
 | `legacy/` | 冻结参考：`vue2`、`insight`、`sandbox`（不参与主线构建） |
@@ -92,7 +92,7 @@ http://ip:port/doc.html
 | OAS3 主线 UI | `front/ui-react` | `knife4j-openapi3-ui` webjar；Knife4x embed | 承接新功能、UX 改进和调试器增强 |
 | OAS3 解析核心 | `front/core` | React UI 内部依赖 | 服务于 OAS3 主线，不为 OAS2 扩展 |
 | OAS2 兼容 UI | `front/vue3` | `knife4j-openapi2-ui` webjar | 只接收回归修复、安全补丁与显示层 bug |
-| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.4.1` 已发布；Rust 后置；UI 不另开工程 |
+| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.4.2` 已发布；Rust 后置；UI 不另开工程 |
 | 历史代码 | `legacy/` | 无发布目标 | 仅参考，勿接常规功能任务 |
 | 文档站 | `docs/` | [knife4jnext.com](https://knife4jnext.com) | 当前对外文档主入口 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ features:
     linkText: 网关接入
 ---
 
-::: tip Knife4x Go v0.4.1
+::: tip Knife4x Go v0.4.2
 Go 服务现在也能嵌入同一套 React UI，通过标准库 `net/http` Handler 挂载
 UI、加载已有 OpenAPI 3 文档并提供调试控制台。[查看 Go 接入](/knife4x/)。
 :::

--- a/docs/knife4x/index.md
+++ b/docs/knife4x/index.md
@@ -6,7 +6,7 @@ description: 在 Go 服务中嵌入 Knife4j React UI，加载已有 OpenAPI 3 �
 # Knife4x Go
 
 Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试控制台。
-当前已发布 Go `v0.4.1`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
+当前已发布 Go `v0.4.2`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
 版本和发布流程独立于 Java `5.x`。
 
 ## 安装
@@ -14,8 +14,14 @@ Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试�
 Go module 需要 Go 1.22 或更高版本：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.4.1
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.4.2
 ```
+
+## v0.4.2
+
+Go `Handler` API 与路由语义保持不变，内嵌 React UI 修复动态参数开关未接入表单请求体
+的问题；开启后，urlencoded 与 multipart Body 可以添加 OpenAPI 未声明的文本字段，
+并在预览、真实请求、缓存、历史与重置间保持一致。
 
 ## v0.4.1
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -10,7 +10,7 @@ title: 模块说明
 | --- | --- |
 | `knife4j/` | Java 主工程——用户实际引入的 starter 和 webjar 都在这里构建 |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.4.1` 已发布，Rust 后置；UI 共用 `front/ui-react` |
+| `knife4x/` | 嵌入式控制台：Go `v0.4.2` 已发布，Rust 后置；UI 共用 `front/ui-react` |
 | `docs/` | 当前 VitePress 文档站 |
 | `tools/` | 验证、发布与任务看板脚本 |
 | `legacy/` | 冻结参考（`vue2`、`insight`、`sandbox`），不参与主线构建 |

--- a/knife4x/README.md
+++ b/knife4x/README.md
@@ -16,7 +16,7 @@ Go module 路径为：
 github.com/songxychn/knife4j-next/knife4x/go
 ```
 
-Go 当前公开版本为 `v0.4.1`，对应仓库 tag `knife4x/go/v0.4.1`；首个公开版本为
+Go 当前公开版本为 `v0.4.2`，对应仓库 tag `knife4x/go/v0.4.2`；首个公开版本为
 `v0.1.0`。tag 发布前可从仓库 checkout 直接运行 [Gin example](examples/gin/README.md)；
 发布状态与完整验收步骤见 [Go 发布清单](go/RELEASE.md)。
 

--- a/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+++ b/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
@@ -15,10 +15,10 @@ Knife4x 替换的是嵌入式文档与调试 UI，不替代 OpenAPI 生成器。
 只有 `openapi: 3.x` JSON 可以继续。若文档使用 `swagger: "2.0"`，请先升级生成器或转换
 spec；OAS2 不能直接迁移到 Knife4x。
 
-Knife4x Go 当前公开版本为 `v0.4.1`：
+Knife4x Go 当前公开版本为 `v0.4.2`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.4.1
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.4.2
 ```
 
 ## 替换挂载代码

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -9,15 +9,15 @@ github.com/songxychn/knife4j-next/knife4x/go
 Knife4x 只消费 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2。核心只依赖
 标准库 `net/http`；Gin 只是可运行的组合示例，不是库依赖。
 
-当前公开版本为 `v0.4.1`，对应仓库 tag `knife4x/go/v0.4.1`：
+当前公开版本为 `v0.4.2`，对应仓库 tag `knife4x/go/v0.4.2`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.4.1
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.4.2
 ```
 
-`v0.4.1` 保持 `Config`、`NewHandler` 与路由语义不变，内嵌 React UI 恢复 HTML、
-DOC、DOCX 与整篇 Markdown 离线导出中的请求示例和响应示例，并覆盖显式 example、
-named example、本地引用与 schema 生成回退。
+`v0.4.2` 保持 `Config`、`NewHandler` 与路由语义不变，内嵌 React UI 修复动态参数开关
+未接入表单请求体的问题；开启后，urlencoded 与 multipart Body 可以添加 OpenAPI
+未声明的文本字段，并在预览、真实请求、缓存、历史与重置间保持一致。
 
 发布门禁、tag 规则与公共消费验证见 [RELEASE.md](RELEASE.md)。
 

--- a/knife4x/go/RELEASE.md
+++ b/knife4x/go/RELEASE.md
@@ -8,8 +8,8 @@
 |---|---|
 | Go module | `github.com/songxychn/knife4j-next/knife4x/go` |
 | 首个版本 | `v0.1.0` |
-| 当前版本 | `v0.4.1` |
-| 当前 tag | `knife4x/go/v0.4.1` |
+| 当前版本 | `v0.4.2` |
+| 当前 tag | `knife4x/go/v0.4.2` |
 | 许可证 | Apache-2.0 |
 
 Go module 位于仓库子目录，因此按
@@ -51,8 +51,8 @@ test -f knife4x/go/internal/ui/static/assets/index.css
 
 ```bash
 grep -Fq 'github.com/songxychn/knife4j-next/knife4x/go' knife4x/README.md
-grep -Fq 'knife4x/go/v0.4.1' knife4x/README.md knife4x/go/README.md
-grep -Fq 'go@v0.4.1' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+grep -Fq 'knife4x/go/v0.4.2' knife4x/README.md knife4x/go/README.md
+grep -Fq 'go@v0.4.2' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 grep -Fq 'OAS2 不能直接迁移' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 test -z "$(git status --porcelain)"
 ```
@@ -62,11 +62,11 @@ test -z "$(git status --porcelain)"
 以下命令不属于 ready-to-tag 工作项。只有维护者明确授权发布后才执行：
 
 ```bash
-git tag -a knife4x/go/v0.4.1 -m "Knife4x Go v0.4.1"
-git push origin knife4x/go/v0.4.1
+git tag -a knife4x/go/v0.4.2 -m "Knife4x Go v0.4.2"
+git push origin knife4x/go/v0.4.2
 ```
 
-不要同时创建根级 `v0.4.1` tag，不要运行 Java Maven Release，不要为本次发布新增
+不要同时创建根级 `v0.4.2` tag，不要运行 Java Maven Release，不要为本次发布新增
 registry、OIDC、secret 或 GitHub Release。
 
 ## 发布后公共消费验证
@@ -76,7 +76,7 @@ proxy 记录的 origin hash 与 annotated tag 指向的 commit 一致，且 ref 
 
 ```bash
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.4.1
+version=v0.4.2
 tag="knife4x/go/${version}"
 tag_commit="$(git rev-list -n 1 "$tag")"
 proxy_info="$(curl -fsS "https://proxy.golang.org/${module}/@v/${version}.info")"
@@ -92,7 +92,7 @@ test "$proxy_ref" = "refs/tags/$tag"
 
 ```bash
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.4.1
+version=v0.4.2
 sum_response="$(curl -fsS "https://sum.golang.org/lookup/${module}@${version}")"
 printf '%s\n' "$sum_response"
 printf '%s\n' "$sum_response" | grep -F "${module} ${version} h1:"
@@ -107,7 +107,7 @@ consumer_dir="$(mktemp -d)"
 trap 'rm -rf "$consumer_dir"' EXIT
 
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.4.1
+version=v0.4.2
 export GOPROXY=https://proxy.golang.org
 export GONOPROXY=none
 export GOMODCACHE="$consumer_dir/modcache"
@@ -153,7 +153,7 @@ test -f "$module_dir/internal/ui/static/assets/index.css"
 ```
 
 只有公共 proxy 的 origin hash / ref、`sum.golang.org` checksum、无 `replace` consumer
-编译和下载内容检查都通过后，才可宣布 Knife4x Go `v0.4.1` 发布完成。
+编译和下载内容检查都通过后，才可宣布 Knife4x Go `v0.4.2` 发布完成。
 
 ## 补丁原则
 


### PR DESCRIPTION
## 目标

Closes #651

独立准备 Knife4x Go `v0.4.2` 发布。

## 范围

- 纳入 Go v0.4.1 之后已合并并同步到内嵌 UI 的 PR #650 / issue #649。
- 更新 Go/Knife4x 用户入口、版本历史与 `RELEASE.md` 到 `v0.4.2`。
- 保持 `Config`、`NewHandler`、路由语义和 Go module 内容不变。
- 不创建根级 Go tag、GitHub Release 或 Java 发布流程。

## 验证

- 两个模块 `go mod tidy -diff`：通过。
- `./tools/test-knife4x-go.sh`：Go 主模块与 Gin 示例通过。
- `./tools/sync-knife4x-ui.sh --check`：内嵌 UI 资产一致。
- `./tools/test-ci-changes.sh`：通过。
- `./tools/test-docs.sh`：通过。
- LICENSE、index.html、index.js、index.css 与用户入口版本引用检查：通过。
- `git diff --check`：通过。

## 风险

仅同步版本文档和发布清单。正式 annotated tag、公共 Go proxy origin、checksum database、无 replace 隔离 consumer 与 Java 工作流隔离验收将在本 PR 合并且最终 master CI 全绿后执行。