### PR TITLE
docs: 明确 Spring Security 注解展示适用范围

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -20,10 +20,11 @@ title: 常见问题
 
 ### upstream 文档还有效吗
 
-**大多数情况仍然有效**。upstream 文档 <https://doc.xiaominfo.com/> 上关于 `@ApiOperationSupport`、`knife4j.*` 配置、UI 行为的内容本 fork 完全兼容。两个例外：
+**大多数情况仍然有效**。upstream 文档 <https://doc.xiaominfo.com/> 上关于 `@ApiOperationSupport`、`knife4j.*` 配置、UI 行为的内容，本 fork 保持兼容。使用时需要注意以下边界：
 
 1. 版本发布节奏：upstream 最后一个 Maven Central 发布版本是 `4.5.0`（2024-01-08），fork 是 `5.3.3`（采用独立 SemVer 版本号）；fork 包含已确认并合入的兼容/安全修复和 React 新前端。
 2. 新 React 前端覆盖范围：upstream Vue2 前端上有的 UI 功能（Postman 导出、afterScript、版本小蓝点等）在本 fork 的新 React 前端中尚未全部覆盖；OAuth2、离线导出、自定义 Markdown 文档、自定义 Footer 等能力则已在 React UI 中补齐或重做。这些历史功能在本仓库 `front/vue3`（`knife4j-openapi2-ui` 打包产物）中继续保留。详见下文 [React 配置不生效](#react-setting-not-effective)。
+3. Spring Security 注解展示：upstream 与本 fork 的实现都只位于 `knife4j-openapi2-spring-boot-starter`（OAS2 / Springfox）；OAS3 / springdoc 系列 starter 不会自动追加这些注解。详见 [Spring Security 注解展示](./features#spring-security-注解展示)。
 
 ### 本 fork 相比 upstream 多了哪些修复
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -337,7 +337,11 @@ Knife4j 的缓存存储在浏览器的 IndexedDB 中，**强制刷新页面无�
 
 ### Spring Security 注解展示
 
-Knife4j 会将 Spring Security 的 `@PreAuthorize`、`@PostAuthorize`、`@PreFilter`、`@PostFilter` 注解信息追加到接口描述中，方便开发者了解接口的权限要求：
+::: warning 仅适用于 OAS2 / Springfox
+此增强由 `knife4j-openapi2-spring-boot-starter` 中的 `SecurityAnnotationPlugin` 提供。OAS3 / springdoc 系列 starter 不会自动将 Spring Security 方法注解追加到接口描述。
+:::
+
+在 OAS2 / Springfox 场景中，开启 `knife4j.enable=true` 后，Knife4j 会将 Spring Security 的 `@PreAuthorize`、`@PostAuthorize`、`@PreFilter`、`@PostFilter` 注解信息追加到接口描述中，方便开发者了解接口声明的权限条件：
 
 ```java
 @RestController
@@ -347,12 +351,14 @@ public class AdminController {
 
     @GetMapping("/users")
     @PreAuthorize("hasAuthority('user:list')")
-    @Operation(summary = "管理员查看用户列表")
+    @ApiOperation(value = "管理员查看用户列表")
     public List<UserVO> listUsers() { ... }
 }
 ```
 
-需要 `knife4j.enable=true` 开启增强模式。
+该功能只在接口说明中附加注解文本，不会改变实际鉴权行为，也不会生成 OpenAPI `security` 要求。
+
+OAS3 / springdoc 用户如需公开接口的鉴权契约，应显式使用 `@Operation`、`@SecurityRequirement` 等 OpenAPI 注解，并定义对应的安全方案。Knife4j 不会将任意 Spring Security SpEL 表达式推断为标准 OpenAPI 安全定义。
 
 ### JSR303 校验注解透传
 


### PR DESCRIPTION
## 关联

- 无独立 issue：根据维护者讨论结论，先修正文档中的功能适用范围。

## 变更范围

- 明确 Spring Security 注解展示由 OAS2 / Springfox starter 提供，OAS3 / springdoc 不会自动追加这些注解。
- 将 OAS2 示例改为 Swagger2 的 `@ApiOperation`，避免混用 OAS3 注解造成误解。
- 说明该能力仅附加描述文本，不改变鉴权行为，也不生成 OpenAPI `security` 要求。
- 补充 OAS3 显式声明安全契约的建议，并在 FAQ 中增加 upstream 文档的对应适用边界。

## 验证

- [x] `git diff --check`
- [x] `./tools/test-docs.sh`

## 风险与范围外

- 仅修改文档，不改变 Java 或前端运行时行为。
- 本 PR 不实现 OAS3 Spring Security 注解自动展示。
- 属于低风险文档修正，由维护者在 PR 中审阅。
