### PR TITLE
fix(aggregation): 保留转发 Host 中的目标端口

### DIFF
--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcher.java
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcher.java
@@ -302,7 +302,11 @@ public class RouteDispatcher {
         requestUrlBuilder.append(fromUri);
         // String requestUrl=uri+fromUri;
         String requestUrl = requestUrlBuilder.toString();
-        String host = URI.create(uri).getHost();
+        URI targetUri = URI.create(uri);
+        String host = targetUri.getHost();
+        if (targetUri.getPort() != -1) {
+            host += ":" + targetUri.getPort();
+        }
         if (logger.isDebugEnabled()) {
             logger.debug("目标请求Url:{},请求类型:{},Host:{}", requestUrl, request.getMethod(), host);
         }

--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcherHostTest.java
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcherHostTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.aggre.core;
+
+import com.github.xiaoymin.knife4j.aggre.cloud.CloudRoute;
+import com.github.xiaoymin.knife4j.aggre.core.cache.RouteInMemoryCache;
+import com.github.xiaoymin.knife4j.aggre.core.common.ExecutorEnum;
+import com.github.xiaoymin.knife4j.aggre.core.executor.ApacheClientExecutor;
+import com.github.xiaoymin.knife4j.aggre.core.pojo.HeaderWrapper;
+import com.github.xiaoymin.knife4j.aggre.repository.CloudRepository;
+import com.github.xiaoymin.knife4j.aggre.spring.support.CloudSetting;
+import com.github.xiaoymin.knife4j.aggre.spring.support.OpenAPIV3Setting;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 回归 #679：聚合转发的 Host 必须保留目标端口，且不能带入 URI 用户信息。
+ */
+class RouteDispatcherHostTest {
+
+    @TestFactory
+    Stream<DynamicTest> buildsHostFromTargetHostAndExplicitPort() {
+        String[][] cases = {
+                {"http://docs.example:18080", "docs.example:18080"},
+                {"https://docs.example:8443", "docs.example:8443"},
+                {"http://docs.example:80", "docs.example:80"},
+                {"https://docs.example:443", "docs.example:443"},
+                {"http://docs.example", "docs.example"},
+                {"https://docs.example", "docs.example"},
+                {"http://127.0.0.1:18080", "127.0.0.1:18080"},
+                {"http://[2001:db8::1]:18080", "[2001:db8::1]:18080"},
+                {"http://[2001:db8::1]", "[2001:db8::1]"},
+                {"http://demo:placeholder@docs.example:18080", "docs.example:18080"}
+        };
+        return Arrays.stream(cases).map(testCase -> DynamicTest.dynamicTest(testCase[0], () -> {
+            RouteRequestContext context = buildContext(testCase[0], null, "/v3/api-docs");
+            List<String> hosts = context.getHeaders().stream()
+                    .filter(header -> "Host".equalsIgnoreCase(header.getName()))
+                    .map(HeaderWrapper::getValue)
+                    .collect(Collectors.toList());
+            assertEquals(Collections.singletonList(testCase[1]), hosts,
+                    "必须替换入口 Host，且只发送一个目标 Host");
+            assertEquals(testCase[0] + "/v3/api-docs", context.getUrl());
+            assertEquals("/v3/api-docs", context.getOriginalUri());
+        }));
+    }
+
+    @Test
+    void forwardsCloudDocumentHostWithPortOverHttp() throws IOException {
+        assertHttpForwarding("/v3/api-docs", false);
+    }
+
+    @Test
+    void forwardsDebugTargetHostWithPortOverHttp() throws IOException {
+        assertHttpForwarding("/users", true);
+    }
+
+    private void assertHttpForwarding(String path, boolean debugRequest) throws IOException {
+        HttpServer downstream = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        downstream.createContext("/", exchange -> {
+            String received = exchange.getRequestHeaders().getFirst("Host") + "\n"
+                    + exchange.getRequestURI().getRawPath();
+            byte[] body = received.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/plain;charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(body);
+            }
+        });
+        downstream.start();
+        try {
+            String authority = "127.0.0.1:" + downstream.getAddress().getPort();
+            String target = "http://" + authority;
+            String documentUri = debugRequest ? "http://documents.example:18080" : target;
+            String debugUri = debugRequest ? target : "http://debug.example:18081";
+            RouteRequestContext context = buildContext(documentUri, debugUri, path);
+            assertEquals(target + path, context.getUrl());
+
+            RouteResponse response = new ApacheClientExecutor(1000).executor(context);
+            assertEquals(200, response.getStatusCode());
+            assertEquals(authority + "\n" + path, response.text(),
+                    "下游实际收到的 Host 必须包含目标端口");
+        } finally {
+            downstream.stop(0);
+        }
+    }
+
+    private RouteRequestContext buildContext(String uri, String debugUri, String path) throws IOException {
+        CloudRoute route = new CloudRoute();
+        route.setName("host-port-regression");
+        route.setUri(uri);
+        route.setLocation("/v3/api-docs");
+        route.setServicePath("/service");
+        route.setDebugUrl(debugUri);
+        CloudSetting setting = new CloudSetting();
+        setting.setEnable(true);
+        setting.setRoutes(Collections.singletonList(route));
+        CloudRepository repository = new CloudRepository(setting);
+        RouteDispatcher dispatcher = new RouteDispatcher(repository, new RouteInMemoryCache(),
+                ExecutorEnum.APACHE, "/aggregate", new OpenAPIV3Setting());
+        HttpServletRequest request = (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getRequestURI":
+                            return "/aggregate/service" + path;
+                        case "getMethod":
+                            return "GET";
+                        case "getHeaderNames":
+                            return Collections.enumeration(Arrays.asList("hOsT", RouteDispatcher.ROUTE_PROXY_HEADER_NAME));
+                        case "getHeader":
+                            if ("Host".equalsIgnoreCase((String) args[0])) {
+                                return "gateway.example:19090";
+                            }
+                            if (RouteDispatcher.ROUTE_PROXY_HEADER_NAME.equals(args[0])) {
+                                return route.pkId();
+                            }
+                            return null;
+                        case "getParameterNames":
+                            return Collections.enumeration(Collections.emptyList());
+                        case "getContentType":
+                        case "getInputStream":
+                            return null;
+                        default:
+                            throw new UnsupportedOperationException("Unexpected request method: " + method.getName());
+                    }
+                });
+        RouteRequestContext context = new RouteRequestContext();
+        dispatcher.buildContext(context, request);
+        return context;
+    }
+}

--- a/knife4j/knife4j-aggregation-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcher.java
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/src/main/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcher.java
@@ -274,7 +274,11 @@ public class RouteDispatcher {
         requestUrlBuilder.append(fromUri);
         // String requestUrl=uri+fromUri;
         String requestUrl = requestUrlBuilder.toString();
-        String host = URI.create(uri).getHost();
+        URI targetUri = URI.create(uri);
+        String host = targetUri.getHost();
+        if (targetUri.getPort() != -1) {
+            host += ":" + targetUri.getPort();
+        }
         if (logger.isDebugEnabled()) {
             logger.debug("目标请求Url:{},请求类型:{},Host:{}", requestUrl, request.getMethod(), host);
         }

--- a/knife4j/knife4j-aggregation-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcherHostTest.java
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/src/test/java/com/github/xiaoymin/knife4j/aggre/core/RouteDispatcherHostTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2017-2023 Knife4j(xiaoymin@foxmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.github.xiaoymin.knife4j.aggre.core;
+
+import com.github.xiaoymin.knife4j.aggre.cloud.CloudRoute;
+import com.github.xiaoymin.knife4j.aggre.core.cache.RouteInMemoryCache;
+import com.github.xiaoymin.knife4j.aggre.core.common.ExecutorEnum;
+import com.github.xiaoymin.knife4j.aggre.core.executor.ApacheClientExecutor;
+import com.github.xiaoymin.knife4j.aggre.core.pojo.HeaderWrapper;
+import com.github.xiaoymin.knife4j.aggre.repository.CloudRepository;
+import com.github.xiaoymin.knife4j.aggre.spring.support.CloudSetting;
+import com.sun.net.httpserver.HttpServer;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 回归 #679：聚合转发的 Host 必须保留目标端口，且不能带入 URI 用户信息。
+ */
+class RouteDispatcherHostTest {
+
+    @TestFactory
+    Stream<DynamicTest> buildsHostFromTargetHostAndExplicitPort() {
+        String[][] cases = {
+                {"http://docs.example:18080", "docs.example:18080"},
+                {"https://docs.example:8443", "docs.example:8443"},
+                {"http://docs.example:80", "docs.example:80"},
+                {"https://docs.example:443", "docs.example:443"},
+                {"http://docs.example", "docs.example"},
+                {"https://docs.example", "docs.example"},
+                {"http://127.0.0.1:18080", "127.0.0.1:18080"},
+                {"http://[2001:db8::1]:18080", "[2001:db8::1]:18080"},
+                {"http://[2001:db8::1]", "[2001:db8::1]"},
+                {"http://demo:placeholder@docs.example:18080", "docs.example:18080"}
+        };
+        return Arrays.stream(cases).map(testCase -> DynamicTest.dynamicTest(testCase[0], () -> {
+            RouteRequestContext context = buildContext(testCase[0], null, "/v3/api-docs");
+            List<String> hosts = context.getHeaders().stream()
+                    .filter(header -> "Host".equalsIgnoreCase(header.getName()))
+                    .map(HeaderWrapper::getValue)
+                    .collect(Collectors.toList());
+            assertEquals(Collections.singletonList(testCase[1]), hosts,
+                    "必须替换入口 Host，且只发送一个目标 Host");
+            assertEquals(testCase[0] + "/v3/api-docs", context.getUrl());
+            assertEquals("/v3/api-docs", context.getOriginalUri());
+        }));
+    }
+
+    @Test
+    void forwardsCloudDocumentHostWithPortOverHttp() throws IOException {
+        assertHttpForwarding("/v3/api-docs", false);
+    }
+
+    @Test
+    void forwardsDebugTargetHostWithPortOverHttp() throws IOException {
+        assertHttpForwarding("/users", true);
+    }
+
+    private void assertHttpForwarding(String path, boolean debugRequest) throws IOException {
+        HttpServer downstream = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        downstream.createContext("/", exchange -> {
+            String received = exchange.getRequestHeaders().getFirst("Host") + "\n"
+                    + exchange.getRequestURI().getRawPath();
+            byte[] body = received.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/plain;charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(body);
+            }
+        });
+        downstream.start();
+        try {
+            String authority = "127.0.0.1:" + downstream.getAddress().getPort();
+            String target = "http://" + authority;
+            String documentUri = debugRequest ? "http://documents.example:18080" : target;
+            String debugUri = debugRequest ? target : "http://debug.example:18081";
+            RouteRequestContext context = buildContext(documentUri, debugUri, path);
+            assertEquals(target + path, context.getUrl());
+
+            RouteResponse response = new ApacheClientExecutor(1000).executor(context);
+            assertEquals(200, response.getStatusCode());
+            assertEquals(authority + "\n" + path, response.text(),
+                    "下游实际收到的 Host 必须包含目标端口");
+        } finally {
+            downstream.stop(0);
+        }
+    }
+
+    private RouteRequestContext buildContext(String uri, String debugUri, String path) throws IOException {
+        CloudRoute route = new CloudRoute();
+        route.setName("host-port-regression");
+        route.setUri(uri);
+        route.setLocation("/v3/api-docs");
+        route.setServicePath("/service");
+        route.setDebugUrl(debugUri);
+        CloudSetting setting = new CloudSetting();
+        setting.setEnable(true);
+        setting.setRoutes(Collections.singletonList(route));
+        CloudRepository repository = new CloudRepository(setting);
+        RouteDispatcher dispatcher = new RouteDispatcher(repository, new RouteInMemoryCache(),
+                ExecutorEnum.APACHE, "/aggregate");
+        HttpServletRequest request = (HttpServletRequest) Proxy.newProxyInstance(
+                HttpServletRequest.class.getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getRequestURI":
+                            return "/aggregate/service" + path;
+                        case "getMethod":
+                            return "GET";
+                        case "getHeaderNames":
+                            return Collections.enumeration(Arrays.asList("hOsT", RouteDispatcher.ROUTE_PROXY_HEADER_NAME));
+                        case "getHeader":
+                            if ("Host".equalsIgnoreCase((String) args[0])) {
+                                return "gateway.example:19090";
+                            }
+                            if (RouteDispatcher.ROUTE_PROXY_HEADER_NAME.equals(args[0])) {
+                                return route.pkId();
+                            }
+                            return null;
+                        case "getParameterNames":
+                            return Collections.enumeration(Collections.emptyList());
+                        case "getContentType":
+                        case "getInputStream":
+                            return null;
+                        default:
+                            throw new UnsupportedOperationException("Unexpected request method: " + method.getName());
+                    }
+                });
+        RouteRequestContext context = new RouteRequestContext();
+        dispatcher.buildContext(context, request);
+        return context;
+    }
+}


### PR DESCRIPTION
## 关联问题

Closes #679

修复前真实 HTTP 证据与冻结契约：[issue 评论](https://github.com/songxychn/knife4j-next/issues/679#issuecomment-5452613141)。

## 变更

- 同步修复 Servlet 与 Jakarta 两份 `RouteDispatcher`：由目标主机和显式端口构造转发 Host，避免 `URI.getHost()` 丢失端口。
- 保留缺省端口、显式 80/443 和 IPv6 的既有 URI 语义，Host 跟随最终选中的文档地址或 `debugUrl`。
- 不直接复制 `getRawAuthority()`，避免将 URI 用户信息带入 Host。
- 两个模块各新增 12 条回归测试，包含真实 Apache HTTP 转发到本地随机端口的文档请求与调试请求。

生产代码仅有两处同构修改，不改路径拼接、入口 Host 过滤或目标 URL。

## 契约快照

- 沿用现有 Java/Servlet/Jakarta/Boot 支持矩阵；Boot 4 继续复用 Jakarta 实现。
- 范围：现有 HTTP/HTTPS 目标的 Host 主机与显式端口；不新增默认端口；显式端口与 IPv6 方括号保留。
- 入口 Host 仍被过滤，只发送一个目标 Host；URI 用户信息不会复制到 Host。
- 非目标：前端、OpenAPI 支持版本、聚合配置、认证策略、userinfo 认证支持、重定向策略、HTTP 客户端替换、依赖或新模块。

## 验证

- 基线 `960d79e` 未修改生产代码时，两个模块各 12 条测试中 9 条失败；真实下游收到的 Host 缺失随机端口。
- 同一批定向测试修复后：24/24 通过；Spotless 两模块通过。
- 完整 `./tools/test-java.sh`：JDK 17 下通过，包含 6 个模块的配置元数据检查与全部 14 个 smoke 模块，均无测试失败或错误。
- 独立审查：reviewer `review_679` 已对 `3687bb742e51d55b5216bb7e175d2ddfe3989da7` 完成一轮全量审查，结论 `approve`，无 findings、无范围漂移；主 agent 已核对实际 diff 与验证证据。无需定向复核。
- PR CI：[Build #33172399928](https://github.com/songxychn/knife4j-next/actions/runs/33172399928) 已在当前 head `3687bb742e51d55b5216bb7e175d2ddfe3989da7` 上通过：`changes` 与 `java-build-test` 成功，其余检查按改动范围跳过。无待处理 PR 审查评论。

定向测试从 `knife4j/` 目录执行：

```bash
mvn -B -ntp -fae \
  -pl knife4j-aggregation-spring-boot-starter,knife4j-aggregation-jakarta-spring-boot-starter \
  -am -Dknife4j-skipTests=false -Dtest=RouteDispatcherHostTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

## 审查与风险

审查预算：一轮全量独立审查，最多一轮针对已采纳 finding 的定向复核；追加提交后重新确认当前 SHA 的验证和 CI。

行为变化限于修正转发 Host 中的显式端口。测试覆盖域名、IPv4、IPv6、缺省/显式端口、入口 Host 替换、URI 用户信息隔离与 `debugUrl` 选择；不改变其他路由行为。
