### PR TITLE
chore(front): 验证 JSON Schema 2020-12 引擎方案

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -31,3 +31,8 @@
 ```bash
 ./tools/upload-images.sh /absolute/path/before.png /absolute/path/after.png
 ```
+
+## 架构探针
+
+`test-json-schema-engine-spike.sh` — 运行 issue #683 的 JSON Schema 2020-12
+语义、浏览器构建、CSP 与性能探针。该探针不接入产品运行时。

--- a/tools/spikes/json-schema-2020-12/DECISION.md
+++ b/tools/spikes/json-schema-2020-12/DECISION.md
@@ -1,0 +1,131 @@
+# JSON Schema 2020-12 引擎接入决策
+
+- 状态：phase 0 通过，允许进入独立的 phase 1 实现设计
+- 日期：2026-08-30
+- 任务：[issue #683](https://github.com/songxychn/knife4j-next/issues/683)
+- 前置：[PR #682](https://github.com/songxychn/knife4j-next/pull/682) 合并后才能接入产品运行时
+
+## 决策
+
+Knife4j 不自行实现 JSON Schema validator。下一阶段可以采用
+`@hyperjump/json-schema`，但必须封装在 Knife4j 自有的现代 ESM
+`SchemaEngine` 适配层后面，并默认采用仅内存 registry、禁止外部资源加载的策略。
+
+这里的“完整”限定为：对 JSON Schema Draft 2020-12 标准 vocabularies 与
+OpenAPI 3.1 base dialect 正确执行 Schema Resource、URI、动态作用域、求值、
+validation 和 annotations 语义。它不表示执行任意未知 vocabulary，也不表示把
+任意 Schema 无损压成唯一字段树。规范求值、Schema 图读取、字段树投影和示例生成
+必须是四个不同的内部概念。
+
+依据：
+
+- [JSON Schema 2020-12 Core](https://json-schema.org/draft/2020-12/json-schema-core)
+- [OpenAPI 3.1.1](https://spec.openapis.org/oas/v3.1.1.html)
+- [Hyperjump JSON Schema](https://github.com/hyperjump-io/json-schema)
+
+## 探针结果
+
+固定版本：
+
+- `@hyperjump/json-schema@1.17.8`
+- `@hyperjump/browser@1.5.0`
+- Bun 1.4.0
+
+`./tools/test-json-schema-engine-spike.sh` 当前覆盖并通过：
+
+- 跨资源 `$dynamicAnchor` / `$dynamicRef` 与有限实例递归
+- `$id`、嵌入 Schema Resource、`$anchor` 和 boolean schema
+- `unevaluatedProperties`、`prefixItems` / `unevaluatedItems`
+- 基于实际成功求值分支收集 annotations
+- registry 内的 compound schema bundling
+- OpenAPI 3.1 整文档校验与 springdoc 风格 Schema Object 求值
+- 未注册外部引用在调用 `fetch` 前被资源策略拒绝
+- 未知 OpenAPI dialect 明确拒绝，不猜测 vocabulary
+
+浏览器构建结果：
+
+| 指标 | 结果 |
+|---|---:|
+| minified ESM | 150,650 bytes |
+| gzip -9 | 24,343 bytes |
+| `eval` / `new Function` | 0 |
+| Node 内置导入 | 0 |
+
+Headless Chrome 152 实测页面使用以下 CSP，仍能完成动态引用求值：
+
+```text
+default-src 'none'; script-src 'self'; connect-src 'none'; base-uri 'none'; form-action 'none'
+```
+
+网络记录只有本地 `index.html` 与 `browser-probe.js`。这个结论只覆盖本探针的
+import graph；不能外推到 Hyperjump 的所有可选 format、plugin 或未来版本。每次
+升级依赖都必须重新执行 CSP 页面和静态扫描。
+
+合成宽对象的单机结果如下。它们用于发现数量级风险，不是性能承诺：
+
+| properties | Schema 大小 | 注册 | 编译 | 单次校验 |
+|---:|---:|---:|---:|---:|
+| 250 | 14,052 B | 0.39–0.49 ms | 18.33–19.44 ms | 0.24–0.27 ms |
+| 2,500 | 146,802 B | 3.10–3.45 ms | 51.29–52.44 ms | 1.71–1.84 ms |
+| 10,000 | 596,802 B | 10.33–10.60 ms | 179.27–186.01 ms | 6.97–8.28 ms |
+
+环境为 macOS arm64 / Bun 1.4.0，连续四次本地运行；正式实现需要增加真实 Springdoc 文档、
+深递归、组合分支和内存峰值测试。
+
+## 为什么选择 Hyperjump 作为首选
+
+Hyperjump 同时提供 Draft 2020-12、OpenAPI 3.1 dialect、Schema registry、
+compound bundling、浏览器构建和非 validation 工具入口。本探针验证了 Knife4j
+当前最缺失的动态作用域与 Schema Resource 语义。
+
+其他候选仍保留为退出路径：
+
+| 候选 | 适合点 | 当前缺口 |
+|---|---|---|
+| [Ajv](https://ajv.js.org/) | validation、错误输出与生态成熟 | 主要面向 validation/code generation，不直接提供 Knife4j 所需的 Schema Resource 图和 UI 遍历层；默认代码生成还需单独处理严格 CSP |
+| [json-schema-library](https://github.com/sagold/json-schema-library) | 遍历、数据生成与 2020-12 支持 | 没有内建 OpenAPI 3.1 dialect，需要自建 dialect/annotation 映射；维护面较集中 |
+| [Scalar OpenAPI Parser](https://github.com/scalar/scalar/blob/main/packages/openapi-parser/README.md) | OpenAPI 文档解析、dereference 与 bundling | 不能作为完整 JSON Schema 引擎；当前仍有公开的 [`$dynamicRef` 问题](https://github.com/scalar/scalar/issues/9414) |
+
+[Bowtie](https://bowtie.report/) 只作为官方测试集兼容性的方向性信号；其 issue
+计数包含可选、未实现或运行问题，不能直接当作库质量排名。
+
+## 必须由适配层吸收的风险
+
+1. **实验性 API**：Schema 图读取和 annotations 使用 Hyperjump 的
+   `experimental` exports，可能在 minor 版本变化。产品代码只能依赖 Knife4j
+   自有接口，并固定精确依赖版本。
+2. **全局状态**：Hyperjump 的 registry、dialect 与 URI scheme plugin 是模块级
+   状态。适配层必须管理文档生命周期、稳定 retrieval URI、冲突检测与清理，不能
+   让页面组件直接注册/注销。
+3. **嵌入资源索引**：嵌入式 `$id` 资源保留在根文档的 browser context，不自动
+   成为可独立检索的全局 registry 项。探针用受限回退查找证明可行；产品实现应在
+   注册时建立 `resource URI -> document context` 索引，避免 O(n) 扫描。
+4. **annotation 依赖实例**：annotation 来自一次实际求值，不能只凭 Schema 静态
+   读取。字段说明等静态 UI 信息应读取 Schema 图；调试校验结果再读取 evaluation
+   annotations。
+5. **默认网络能力**：上游默认启用 HTTP、HTTPS 和文件读取。Knife4j 必须在处理
+   用户文档前移除这些 scheme。未来加载器采用显式 opt-in，并限制同源/白名单、
+   credentials、content type、字节数、资源数、深度、时间、取消和缓存。
+6. **编译缓存**：直接 `validate(uri, instance)` 会重复编译。产品层需要按文档身份、
+   dialect 和 canonical URI 缓存 validator，并在文档卸载时失效。
+7. **资源耗尽**：规范允许递归和高组合复杂度。网络限制不能替代求值预算；还需要
+   节点数、分支数、实例深度、执行时间与可取消策略。
+
+## 下一阶段边界
+
+phase 1 只建立 `front/schema-engine` ESM workspace 与内部 API：
+
+```ts
+interface SchemaEngine {
+  registerDocument(document: unknown, retrievalUri: string): Promise<void>
+  resolve(schemaUri: string): Promise<SchemaNode>
+  evaluate(schemaUri: string, instance: unknown): Promise<EvaluationResult>
+  unregisterDocument(retrievalUri: string): void
+}
+```
+
+完成条件：使用官方 2020-12 测试子集与真实 Springdoc OAS 3.1 固定夹具验证资源图、
+动态作用域、错误分类、缓存失效和资源预算；默认网络请求数必须为零。
+
+phase 1 不修改字段树、示例或调试 UI。UI 投影与受控外部引用分别进入后续 issue，
+从而可以在不回退 #682 单文档消费基线的情况下独立回滚引擎接入。

--- a/tools/spikes/json-schema-2020-12/README.md
+++ b/tools/spikes/json-schema-2020-12/README.md
@@ -1,0 +1,52 @@
+# JSON Schema 2020-12 engine spike
+
+Issue: [#683](https://github.com/songxychn/knife4j-next/issues/683)
+
+This isolated package tests whether Knife4j can delegate JSON Schema Draft
+2020-12 resource resolution and evaluation to Hyperjump without changing the
+current product runtime. It is not a shipped workspace and is not imported by
+`front/core` or `front/ui-react`.
+
+## Run
+
+From the repository root:
+
+```bash
+./tools/test-json-schema-engine-spike.sh
+```
+
+The command installs exact dependency versions from the official npm registry,
+runs TypeScript checking and the semantic tests, produces a minified browser
+bundle, scans it for dynamic code execution and Node built-ins, and runs
+generated-schema timing probes. Generated files are written under `dist/` and
+remain untracked.
+
+To check the strict-CSP page manually:
+
+```bash
+cd tools/spikes/json-schema-2020-12/dist
+python3 -m http.server 4173 --bind 127.0.0.1
+```
+
+Open `http://127.0.0.1:4173/`. The page uses `script-src 'self'` without
+`'unsafe-eval'` and `connect-src 'none'`. A successful run sets
+`document.body.dataset.status` to `passed`.
+
+## Evidence covered
+
+- `$id`, embedded Schema Resources, `$anchor`, `$dynamicAnchor` and
+  `$dynamicRef`
+- recursive evaluation and `unevaluatedProperties`
+- `prefixItems` with `unevaluatedItems`
+- boolean schemas
+- evaluation-dependent annotations
+- registry-only compound-schema bundling
+- OpenAPI 3.1 base dialect with a springdoc-style component schema
+- default denial of HTTP, HTTPS and file retrieval before `fetch`
+- browser ESM bundling and strict-CSP execution
+
+The dynamic-reference and unevaluated fixtures are reduced cases based on the
+[JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/tests/draft2020-12).
+
+See [DECISION.md](./DECISION.md) for the architectural conclusion and product
+boundaries.

--- a/tools/spikes/json-schema-2020-12/bun.lock
+++ b/tools/spikes/json-schema-2020-12/bun.lock
@@ -1,0 +1,43 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "knife4j-json-schema-2020-12-spike",
+      "dependencies": {
+        "@hyperjump/browser": "1.5.0",
+        "@hyperjump/json-schema": "1.17.8",
+      },
+      "devDependencies": {
+        "typescript": "5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@hyperjump/browser": ["@hyperjump/browser@1.5.0", "", { "dependencies": { "@hyperjump/json-pointer": "^1.1.0", "@hyperjump/uri": "^1.2.0", "content-type": "^1.0.5", "just-curry-it": "^5.3.0" } }, "sha512-h+fGXfmMOAxYjd2aZ4Y5jpP2WRi0TAkBmKNtoNJKcJLOahNrurwHEUgd1/jO2Hs2j/b/G1EhX0edX8ntXkH2MA=="],
+
+    "@hyperjump/json-pointer": ["@hyperjump/json-pointer@1.1.2", "", {}, "sha512-zPNgu1zdhtjQHFNLGzvEsLDsLOEvhRj6u6ktIQmlz7YPESv5uF8SnAe3Dq0oL6gZ6OGWSLq2n7pphRNF6Hpg6w=="],
+
+    "@hyperjump/json-schema": ["@hyperjump/json-schema@1.17.8", "", { "dependencies": { "@hyperjump/json-pointer": "^1.1.0", "@hyperjump/json-schema-formats": "^1.0.0", "@hyperjump/pact": "^1.2.0", "@hyperjump/uri": "^1.2.0", "content-type": "^1.0.4", "json-stringify-deterministic": "^1.0.12", "just-curry-it": "^5.3.0", "uuid": "^14.0.0" }, "peerDependencies": { "@hyperjump/browser": "^1.1.0" } }, "sha512-XOqbR9GRNHaH4JEXHdbsm7xfYwudZG7HVDq3qPZUb1gi+ZQPklgNvhMi6zf0Plf433qR61MK+xeeprUwUUvGPg=="],
+
+    "@hyperjump/json-schema-formats": ["@hyperjump/json-schema-formats@1.0.5", "", { "dependencies": { "@hyperjump/uri": "^1.3.2", "idn-hostname": "^15.1.2" } }, "sha512-JHMa2YwBmHG7N1LD4sOKx3gfYJjXDiV1MRPIpN2huma/hTLMoCZ/cGe2tCQsfqD9KgjFaRO2mmXFlamwdN3/wQ=="],
+
+    "@hyperjump/pact": ["@hyperjump/pact@1.4.0", "", {}, "sha512-01Q7VY6BcAkp9W31Fv+ciiZycxZHGlR2N6ba9BifgyclHYHdbaZgITo0U6QMhYRlem4k8pf8J31/tApxvqAz8A=="],
+
+    "@hyperjump/uri": ["@hyperjump/uri@1.3.5", "", {}, "sha512-GxiCm6iMt2j74T00mo0hHnJT1hNVGZMcuja5Mi+YHyPZhltKT6pQXLIpc8tPPL5bWaB/8je5UJy8lZZ0+9mBKw=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "idn-hostname": ["idn-hostname@15.1.16", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-0w0WNGfPVfRCH5mUbXLPXCjFA2g7gTjM7dlNeEick0p3dzRlIv52haUXPz32BzSxvutayt8xlnKwQrZbUoh0VA=="],
+
+    "json-stringify-deterministic": ["json-stringify-deterministic@1.0.16", "", {}, "sha512-barjhF/wL0ot1i7AVA3gDDfuBIS1Iz7dlYmO6fZnVDUXtB/EJKjqREA/FUndo+kCGYLI67jH3hXKQMwuTFhbpQ=="],
+
+    "just-curry-it": ["just-curry-it@5.3.0", "", {}, "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uuid": ["uuid@14.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ=="],
+  }
+}

--- a/tools/spikes/json-schema-2020-12/package.json
+++ b/tools/spikes/json-schema-2020-12/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "knife4j-json-schema-2020-12-spike",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "build:browser": "bun run scripts/build-browser.ts",
+    "benchmark": "bun run scripts/benchmark.ts",
+    "check": "bun run typecheck && bun test && bun run build:browser && bun run benchmark"
+  },
+  "dependencies": {
+    "@hyperjump/browser": "1.5.0",
+    "@hyperjump/json-schema": "1.17.8"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/tools/spikes/json-schema-2020-12/scripts/benchmark.ts
+++ b/tools/spikes/json-schema-2020-12/scripts/benchmark.ts
@@ -1,0 +1,87 @@
+import { performance } from 'node:perf_hooks'
+import { resolve } from 'node:path'
+import { validate } from '@hyperjump/json-schema/openapi-3-1'
+import {
+  HyperjumpSchemaEngineProbe,
+  JSON_SCHEMA_2020_12,
+  type JsonValue,
+} from '../src/hyperjump-adapter'
+
+const makeCase = (propertyCount: number) => {
+  const properties: Record<string, JsonValue> = {}
+  const instance: Record<string, JsonValue> = {}
+  const required: string[] = []
+
+  for (let index = 0; index < propertyCount; index += 1) {
+    const name = `field_${index}`
+    properties[name] = { type: 'integer', minimum: index }
+    instance[name] = index
+    required.push(name)
+  }
+
+  return {
+    schema: {
+      $schema: JSON_SCHEMA_2020_12,
+      type: 'object',
+      properties,
+      required,
+      unevaluatedProperties: false,
+    } satisfies JsonValue,
+    instance: instance satisfies JsonValue,
+  }
+}
+
+const runCase = async (propertyCount: number) => {
+  const engine = new HyperjumpSchemaEngineProbe()
+  const uri = `https://benchmark.knife4j.example/schema-${propertyCount}`
+  const { schema, instance } = makeCase(propertyCount)
+  const schemaBytes = new TextEncoder().encode(JSON.stringify(schema)).byteLength
+
+  const registrationStarted = performance.now()
+  await engine.registerDocument(schema, uri)
+  const registrationMs = performance.now() - registrationStarted
+
+  const compilationStarted = performance.now()
+  const validator = await validate(uri)
+  const compilationMs = performance.now() - compilationStarted
+
+  const iterations = propertyCount >= 10_000 ? 5 : 20
+  const validationStarted = performance.now()
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const result = validator(instance)
+    if (!result.valid) {
+      throw new Error(`Benchmark instance unexpectedly failed for ${propertyCount} properties.`)
+    }
+  }
+  const validationMs = (performance.now() - validationStarted) / iterations
+
+  engine.dispose()
+  return {
+    propertyCount,
+    schemaBytes,
+    registrationMs: Number(registrationMs.toFixed(2)),
+    compilationMs: Number(compilationMs.toFixed(2)),
+    validationMs: Number(validationMs.toFixed(2)),
+    iterations,
+  }
+}
+
+const report = {
+  runtime: `Bun ${Bun.version}`,
+  platform: `${process.platform}-${process.arch}`,
+  generatedAt: new Date().toISOString(),
+  cases: [],
+} as {
+  runtime: string
+  platform: string
+  generatedAt: string
+  cases: Awaited<ReturnType<typeof runCase>>[]
+}
+
+for (const propertyCount of [250, 2_500, 10_000]) {
+  report.cases.push(await runCase(propertyCount))
+}
+
+const output = resolve(import.meta.dir, '../dist/benchmark-report.json')
+await Bun.write(output, `${JSON.stringify(report, null, 2)}\n`)
+console.log(JSON.stringify(report, null, 2))

--- a/tools/spikes/json-schema-2020-12/scripts/build-browser.ts
+++ b/tools/spikes/json-schema-2020-12/scripts/build-browser.ts
@@ -1,0 +1,77 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { basename, resolve } from 'node:path'
+
+const spikeRoot = resolve(import.meta.dir, '..')
+const outdir = resolve(spikeRoot, 'dist')
+
+await rm(outdir, { recursive: true, force: true })
+await mkdir(outdir, { recursive: true })
+
+const result = await Bun.build({
+  entrypoints: [resolve(spikeRoot, 'src/browser-probe.ts')],
+  outdir,
+  target: 'browser',
+  format: 'esm',
+  minify: true,
+  sourcemap: 'none',
+})
+
+if (!result.success) {
+  for (const log of result.logs) {
+    console.error(log)
+  }
+  process.exit(1)
+}
+
+const output = result.outputs.find((candidate) => candidate.path.endsWith('.js'))
+if (!output) {
+  throw new Error('Bun did not produce a browser JavaScript bundle.')
+}
+
+const bytes = new Uint8Array(await output.arrayBuffer())
+const source = new TextDecoder().decode(bytes)
+const forbiddenPatterns = [
+  { name: 'eval', pattern: /\beval\s*\(/ },
+  { name: 'new Function', pattern: /new\s+Function\b/ },
+  { name: 'Node built-in import', pattern: /["']node:/ },
+]
+const findings = forbiddenPatterns
+  .filter(({ pattern }) => pattern.test(source))
+  .map(({ name }) => name)
+
+if (findings.length > 0) {
+  throw new Error(`Browser bundle contains forbidden constructs: ${findings.join(', ')}`)
+}
+
+const hasher = new Bun.CryptoHasher('sha256')
+hasher.update(bytes)
+const report = {
+  bun: Bun.version,
+  entry: 'src/browser-probe.ts',
+  output: basename(output.path),
+  rawBytes: bytes.byteLength,
+  gzipBytes: Bun.gzipSync(bytes, { level: 9 }).byteLength,
+  sha256: hasher.digest('hex'),
+  dynamicCodeExecutionFindings: findings,
+}
+
+const html = `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src 'none'; base-uri 'none'; form-action 'none'">
+    <title>Knife4j JSON Schema 2020-12 CSP probe</title>
+  </head>
+  <body data-status="pending">
+    <output>pending</output>
+    <script type="module" src="./${basename(output.path)}"></script>
+  </body>
+</html>
+`
+
+await Promise.all([
+  Bun.write(resolve(outdir, 'build-report.json'), `${JSON.stringify(report, null, 2)}\n`),
+  writeFile(resolve(outdir, 'index.html'), html),
+])
+
+console.log(JSON.stringify(report, null, 2))

--- a/tools/spikes/json-schema-2020-12/src/browser-probe.ts
+++ b/tools/spikes/json-schema-2020-12/src/browser-probe.ts
@@ -1,0 +1,82 @@
+import {
+  HyperjumpSchemaEngineProbe,
+  JSON_SCHEMA_2020_12,
+} from './hyperjump-adapter'
+
+const rootUri = 'https://browser-probe.knife4j.example/tree'
+const strictUri = 'https://browser-probe.knife4j.example/strict-tree'
+
+export const runBrowserProbe = async (): Promise<Record<string, unknown>> => {
+  const engine = new HyperjumpSchemaEngineProbe()
+
+  try {
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        $id: rootUri,
+        $dynamicAnchor: 'node',
+        type: 'object',
+        properties: {
+          value: true,
+          children: {
+            type: 'array',
+            items: { $dynamicRef: '#node' },
+          },
+        },
+      },
+      rootUri,
+    )
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        $id: strictUri,
+        $dynamicAnchor: 'node',
+        $ref: rootUri,
+        unevaluatedProperties: false,
+      },
+      strictUri,
+    )
+
+    const valid = await engine.evaluate(strictUri, {
+      value: 'root',
+      children: [{ value: 'leaf', children: [] }],
+    })
+    const invalid = await engine.evaluate(strictUri, {
+      value: 'root',
+      children: [{ value: 'leaf', extra: true }],
+    })
+    const resource = await engine.resolve(strictUri)
+
+    if (!valid.valid || invalid.valid) {
+      throw new Error('Dynamic reference evaluation produced an unexpected result.')
+    }
+
+    return {
+      valid: valid.valid,
+      invalidRejected: !invalid.valid,
+      dialectId: resource.dialectId,
+      dynamicAnchors: Object.keys(resource.dynamicAnchors),
+      externalResourceLoading: 'disabled',
+    }
+  } finally {
+    engine.dispose()
+  }
+}
+
+declare global {
+  interface Window {
+    knife4jSchemaProbe?: Record<string, unknown>
+  }
+}
+
+try {
+  const result = await runBrowserProbe()
+  window.knife4jSchemaProbe = result
+  document.body.dataset.status = 'passed'
+  document.querySelector('output')!.textContent = JSON.stringify(result)
+} catch (error) {
+  document.body.dataset.status = 'failed'
+  document.querySelector('output')!.textContent =
+    error instanceof Error ? error.stack ?? error.message : String(error)
+  throw error
+}

--- a/tools/spikes/json-schema-2020-12/src/hyperjump-adapter.ts
+++ b/tools/spikes/json-schema-2020-12/src/hyperjump-adapter.ts
@@ -1,0 +1,289 @@
+import {
+  removeUriSchemePlugin,
+  UnsupportedUriSchemeError,
+  type Browser,
+} from '@hyperjump/browser'
+import {
+  registerSchema,
+  unregisterSchema,
+  type Output,
+  type OutputUnit,
+  type SchemaObject,
+} from '@hyperjump/json-schema/openapi-3-1'
+import { interpret as collectEvaluationAnnotations } from '@hyperjump/json-schema/annotations/experimental'
+import {
+  allNodes,
+  fromJs,
+  type JsonNode,
+} from '@hyperjump/json-schema/annotated-instance/experimental'
+import { bundle } from '@hyperjump/json-schema/bundle'
+import {
+  BASIC,
+  canonicalUri,
+  compile,
+  getSchema,
+  interpret,
+  toSchema,
+  type CompiledSchema,
+  type SchemaDocument,
+} from '@hyperjump/json-schema/experimental'
+
+export const JSON_SCHEMA_2020_12 =
+  'https://json-schema.org/draft/2020-12/schema'
+export const OPENAPI_31_BASE_DIALECT =
+  'https://spec.openapis.org/oas/3.1/dialect/base'
+
+const OPENAPI_31_SCHEMA_BASE =
+  'https://spec.openapis.org/oas/3.1/schema-base'
+const OPENAPI_31_SCHEMA_DRAFT_2020_12 =
+  'https://spec.openapis.org/oas/3.1/schema-draft-2020-12'
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+export interface AnnotationResult {
+  instanceLocation: string
+  keywordId: string
+  values: unknown[]
+}
+
+export interface EvaluationResult {
+  valid: boolean
+  errors: OutputUnit[]
+  annotations: AnnotationResult[]
+}
+
+export interface ResolvedSchemaResource {
+  requestedUri: string
+  canonicalUri: string
+  baseUri: string
+  dialectId: string
+  anchors: Record<string, string>
+  dynamicAnchors: Record<string, string>
+  schema: unknown
+}
+
+export class SchemaResourcePolicyError extends Error {
+  public readonly code = 'EXTERNAL_RESOURCE_LOADING_DISABLED'
+  public readonly resourceUri?: string
+
+  public constructor(operationUri: string, cause: unknown) {
+    const retrievalMessage =
+      cause instanceof Error
+        ? /Unable to load resource '([^']+)'/.exec(cause.message)
+        : null
+    super(
+      `External schema resource loading is disabled while resolving '${operationUri}'.`,
+      { cause },
+    )
+    this.name = 'SchemaResourcePolicyError'
+    this.resourceUri = retrievalMessage?.[1]
+  }
+}
+
+/**
+ * Hyperjump enables http(s) and file retrieval by default. Knife4j must start
+ * from a registry-only policy and add any future loader explicitly.
+ */
+export const lockDownExternalResourceLoading = (): void => {
+  removeUriSchemePlugin('http')
+  removeUriSchemePlugin('https')
+  removeUriSchemePlugin('file')
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const contextDialectFor = (document: unknown): string => {
+  if (!isRecord(document) || typeof document.openapi !== 'string') {
+    return JSON_SCHEMA_2020_12
+  }
+
+  if (!/^3\.1\.\d+(?:-.+)?$/.test(document.openapi)) {
+    throw new Error(
+      `The spike adapter only accepts OpenAPI 3.1.x documents; received '${document.openapi}'.`,
+    )
+  }
+
+  const dialect = document.jsonSchemaDialect
+  if (dialect === undefined || dialect === OPENAPI_31_BASE_DIALECT) {
+    return OPENAPI_31_SCHEMA_BASE
+  }
+  if (dialect === JSON_SCHEMA_2020_12) {
+    return OPENAPI_31_SCHEMA_DRAFT_2020_12
+  }
+
+  throw new Error(
+    `The spike adapter does not load the custom OpenAPI dialect '${String(dialect)}'.`,
+  )
+}
+
+const collectAnnotations = (root: JsonNode): AnnotationResult[] => {
+  const annotations: AnnotationResult[] = []
+
+  for (const node of allNodes(root)) {
+    for (const [keywordId, values] of Object.entries(node.annotations)) {
+      annotations.push({
+        instanceLocation: node.pointer,
+        keywordId,
+        values,
+      })
+    }
+  }
+
+  return annotations
+}
+
+const hasUnsupportedSchemeCause = (error: unknown): boolean => {
+  let current = error
+  while (current instanceof Error) {
+    if (current instanceof UnsupportedUriSchemeError) {
+      return true
+    }
+    current = current.cause
+  }
+  return false
+}
+
+const normalizeResourceError = (error: unknown, operationUri: string): never => {
+  if (hasUnsupportedSchemeCause(error)) {
+    throw new SchemaResourcePolicyError(operationUri, error)
+  }
+  throw error
+}
+
+/**
+ * A deliberately small anti-corruption layer for the phase 0 probe. It keeps
+ * Hyperjump's experimental graph and annotation APIs out of Knife4j product
+ * code while their stability is evaluated.
+ */
+export class HyperjumpSchemaEngineProbe {
+  private readonly registeredUris = new Set<string>()
+
+  public constructor() {
+    lockDownExternalResourceLoading()
+  }
+
+  public async registerDocument(
+    document: JsonValue,
+    retrievalUri: string,
+  ): Promise<void> {
+    const parsedUri = new URL(retrievalUri)
+    if (parsedUri.hash) {
+      throw new Error('A retrieval URI must not contain a fragment.')
+    }
+
+    registerSchema(
+      document as SchemaObject | boolean,
+      parsedUri.href,
+      contextDialectFor(document),
+    )
+    this.registeredUris.add(parsedUri.href)
+  }
+
+  public async resolve(schemaUri: string): Promise<ResolvedSchemaResource> {
+    const resource = await this.getRegisteredResource(schemaUri)
+
+    return {
+      requestedUri: schemaUri,
+      canonicalUri: canonicalUri(resource),
+      baseUri: resource.document.baseUri,
+      dialectId: resource.document.dialectId,
+      anchors: { ...resource.document.anchors },
+      dynamicAnchors: { ...resource.document.dynamicAnchors },
+      schema: toSchema(resource, {
+        includeDialect: 'always',
+        includeEmbedded: true,
+      }),
+    }
+  }
+
+  public async evaluate(
+    schemaUri: string,
+    instance: JsonValue,
+  ): Promise<EvaluationResult> {
+    try {
+      const resource = await this.getRegisteredResource(schemaUri)
+      const compiledSchema: CompiledSchema = await compile(resource)
+      const validation: Output = interpret(
+        compiledSchema,
+        fromJs(instance),
+        BASIC,
+      )
+      if (!validation.valid) {
+        return {
+          valid: false,
+          errors: 'errors' in validation ? validation.errors ?? [] : [],
+          annotations: [],
+        }
+      }
+
+      const annotatedInstance = collectEvaluationAnnotations(
+        compiledSchema,
+        fromJs(instance),
+        BASIC,
+      )
+      return {
+        valid: true,
+        errors: [],
+        annotations: collectAnnotations(annotatedInstance),
+      }
+    } catch (error) {
+      return normalizeResourceError(error, schemaUri)
+    }
+  }
+
+  public async bundle(schemaUri: string): Promise<unknown> {
+    try {
+      return await bundle(schemaUri, { alwaysIncludeDialect: true })
+    } catch (error) {
+      normalizeResourceError(error, schemaUri)
+    }
+  }
+
+  public unregisterDocument(retrievalUri: string): void {
+    const normalizedUri = new URL(retrievalUri).href
+    if (!this.registeredUris.delete(normalizedUri)) {
+      return
+    }
+    unregisterSchema(normalizedUri)
+  }
+
+  public dispose(): void {
+    for (const uri of this.registeredUris) {
+      unregisterSchema(uri)
+    }
+    this.registeredUris.clear()
+  }
+
+  private async getRegisteredResource(
+    schemaUri: string,
+  ): Promise<Browser<SchemaDocument>> {
+    let directError: unknown
+    try {
+      return await getSchema(schemaUri)
+    } catch (error) {
+      directError = error
+    }
+
+    // Hyperjump keeps embedded $id resources in the root document's browser
+    // context rather than adding every embedded identifier to its global
+    // registry. Hide that lookup detail behind the adapter.
+    for (const rootUri of this.registeredUris) {
+      try {
+        const root = await getSchema(rootUri)
+        return await getSchema(schemaUri, root)
+      } catch {
+        // Try the next registered root. Network schemes have already been
+        // removed, so a miss cannot trigger I/O.
+      }
+    }
+
+    return normalizeResourceError(directError, schemaUri)
+  }
+}

--- a/tools/spikes/json-schema-2020-12/tests/hyperjump-adapter.test.ts
+++ b/tools/spikes/json-schema-2020-12/tests/hyperjump-adapter.test.ts
@@ -1,0 +1,257 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import {
+  HyperjumpSchemaEngineProbe,
+  JSON_SCHEMA_2020_12,
+  SchemaResourcePolicyError,
+} from '../src/hyperjump-adapter'
+
+const engine = new HyperjumpSchemaEngineProbe()
+
+afterAll(() => {
+  engine.dispose()
+})
+
+describe('JSON Schema 2020-12 resource and evaluation semantics', () => {
+  test('honors dynamic scope across registered schema resources', async () => {
+    const treeUri = 'https://fixtures.knife4j.example/tree'
+    const strictTreeUri = 'https://fixtures.knife4j.example/strict-tree'
+
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        $id: treeUri,
+        $dynamicAnchor: 'node',
+        type: 'object',
+        properties: {
+          data: true,
+          children: {
+            type: 'array',
+            items: { $dynamicRef: '#node' },
+          },
+        },
+      },
+      treeUri,
+    )
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        $id: strictTreeUri,
+        $dynamicAnchor: 'node',
+        $ref: treeUri,
+        unevaluatedProperties: false,
+      },
+      strictTreeUri,
+    )
+
+    await expect(
+      engine.evaluate(strictTreeUri, {
+        data: 1,
+        children: [{ data: 2, children: [] }],
+      }),
+    ).resolves.toMatchObject({ valid: true })
+    await expect(
+      engine.evaluate(strictTreeUri, {
+        data: 1,
+        children: [{ data: 2, extra: true }],
+      }),
+    ).resolves.toMatchObject({ valid: false })
+
+    const resource = await engine.resolve(strictTreeUri)
+    expect(resource.dialectId).toBe(JSON_SCHEMA_2020_12)
+    expect(resource.dynamicAnchors).toHaveProperty('node')
+  })
+
+  test('resolves embedded resources, anchors, and boolean schemas', async () => {
+    const containerUri = 'https://fixtures.knife4j.example/container'
+    const embeddedUri = 'https://fixtures.knife4j.example/postal'
+    const falseUri = 'https://fixtures.knife4j.example/never'
+
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        $id: containerUri,
+        $defs: {
+          postal: {
+            $id: embeddedUri,
+            $anchor: 'value',
+            type: 'string',
+            pattern: '^[0-9]{6}$',
+          },
+        },
+        $ref: `${embeddedUri}#value`,
+      },
+      containerUri,
+    )
+    await engine.registerDocument(false, falseUri)
+
+    const embedded = await engine.resolve(`${embeddedUri}#value`)
+    expect(embedded.baseUri).toBe(embeddedUri)
+    expect(embedded.anchors).toHaveProperty('value')
+    await expect(
+      engine.evaluate(`${embeddedUri}#value`, '310000'),
+    ).resolves.toMatchObject({ valid: true })
+    await expect(engine.evaluate(containerUri, '310000')).resolves.toMatchObject({
+      valid: true,
+    })
+    await expect(engine.evaluate(containerUri, 'invalid')).resolves.toMatchObject({
+      valid: false,
+    })
+    await expect(engine.evaluate(falseUri, null)).resolves.toMatchObject({
+      valid: false,
+    })
+  })
+
+  test('honors unevaluatedItems after prefixItems', async () => {
+    const tupleUri = 'https://fixtures.knife4j.example/tuple'
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        prefixItems: [{ type: 'string' }],
+        unevaluatedItems: false,
+      },
+      tupleUri,
+    )
+
+    await expect(engine.evaluate(tupleUri, ['ok'])).resolves.toMatchObject({
+      valid: true,
+    })
+    await expect(engine.evaluate(tupleUri, ['ok', 2])).resolves.toMatchObject({
+      valid: false,
+    })
+  })
+
+  test('returns annotations from the actual successful evaluation', async () => {
+    const annotationUri = 'https://fixtures.knife4j.example/annotations'
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        title: 'Pet identifier',
+        description: 'A stable pet id',
+        type: 'string',
+        default: 'pet-1',
+        examples: ['pet-2'],
+      },
+      annotationUri,
+    )
+
+    const result = await engine.evaluate(annotationUri, 'pet-3')
+    expect(result.valid).toBe(true)
+    expect(result.annotations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          instanceLocation: '',
+          keywordId: 'https://json-schema.org/keyword/title',
+          values: ['Pet identifier'],
+        }),
+      ]),
+    )
+  })
+
+  test('bundles registered resources without rewriting their reference identity', async () => {
+    const valueUri = 'https://fixtures.knife4j.example/value'
+    const rootUri = 'https://fixtures.knife4j.example/bundle-root'
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        $id: valueUri,
+        type: 'string',
+      },
+      valueUri,
+    )
+    await engine.registerDocument(
+      {
+        $schema: JSON_SCHEMA_2020_12,
+        $id: rootUri,
+        type: 'object',
+        properties: { value: { $ref: valueUri } },
+      },
+      rootUri,
+    )
+
+    const bundled = (await engine.bundle(rootUri)) as Record<string, unknown>
+    expect(JSON.stringify(bundled)).toContain(valueUri)
+    expect(bundled).toHaveProperty('$defs')
+  })
+})
+
+describe('OpenAPI 3.1 dialect and browser resource policy', () => {
+  test('evaluates a springdoc-style Schema Object in an OpenAPI 3.1 document', async () => {
+    const documentUri = 'https://fixtures.knife4j.example/springdoc.openapi.json'
+    const document = {
+      openapi: '3.1.1',
+      info: { title: 'Springdoc probe', version: '1.0.0' },
+      paths: {},
+      components: {
+        schemas: {
+          Pet: {
+            type: 'object',
+            required: ['id'],
+            properties: {
+              id: { type: 'integer', format: 'int64' },
+              nickname: { type: ['string', 'null'] },
+            },
+          },
+        },
+      },
+    }
+
+    await engine.registerDocument(document, documentUri)
+    await expect(
+      engine.evaluate('https://spec.openapis.org/oas/3.1/schema-base', document),
+    ).resolves.toMatchObject({ valid: true })
+    await expect(
+      engine.evaluate(`${documentUri}#/components/schemas/Pet`, {
+        id: 1,
+        nickname: null,
+      }),
+    ).resolves.toMatchObject({ valid: true })
+    await expect(
+      engine.evaluate(`${documentUri}#/components/schemas/Pet`, {
+        nickname: 'missing id',
+      }),
+    ).resolves.toMatchObject({ valid: false })
+  })
+
+  test('rejects custom OpenAPI dialects instead of guessing their vocabulary', async () => {
+    await expect(
+      engine.registerDocument(
+        {
+          openapi: '3.1.1',
+          jsonSchemaDialect: 'https://dialects.knife4j.example/custom',
+          info: { title: 'Unsupported dialect', version: '1.0.0' },
+          paths: {},
+        },
+        'https://fixtures.knife4j.example/custom-dialect.openapi.json',
+      ),
+    ).rejects.toThrow('does not load the custom OpenAPI dialect')
+  })
+
+  test('rejects unregistered external resources before fetch', async () => {
+    const rootUri = 'https://fixtures.knife4j.example/network-root'
+    let fetchCalls = 0
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => {
+      fetchCalls += 1
+      throw new Error('fetch must not be called')
+    }) as typeof fetch
+
+    try {
+      await engine.registerDocument(
+        {
+          $schema: JSON_SCHEMA_2020_12,
+          $ref: 'https://unregistered.knife4j.example/external',
+        },
+        rootUri,
+      )
+
+      await expect(engine.evaluate(rootUri, 'value')).rejects.toMatchObject({
+        name: SchemaResourcePolicyError.name,
+        code: 'EXTERNAL_RESOURCE_LOADING_DISABLED',
+        resourceUri: 'https://unregistered.knife4j.example/external',
+      })
+      expect(fetchCalls).toBe(0)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/tools/spikes/json-schema-2020-12/tsconfig.json
+++ b/tools/spikes/json-schema-2020-12/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/tools/test-json-schema-engine-spike.sh
+++ b/tools/test-json-schema-engine-spike.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPIKE_DIR="${ROOT_DIR}/tools/spikes/json-schema-2020-12"
+
+cd "${SPIKE_DIR}"
+bun install --frozen-lockfile --registry https://registry.npmjs.org
+bun run check


### PR DESCRIPTION
## 背景

PR #682 为 OpenAPI 3.1 建立单文档消费基线，但完整的 JSON Schema 2020-12 资源与求值语义不能继续通过现有本地 JSON Pointer resolver 逐项补丁。本 PR 完成 phase 0：验证成熟引擎的浏览器可行性，并冻结后续接入边界。

Closes #683

## 契约快照

### 支持版本

- JSON Schema Draft 2020-12 标准 vocabularies。
- OpenAPI 3.1 base dialect。
- 保持 OpenAPI 3.0.x 当前行为；后续产品接入以 #682 已合并为前置条件。

### 本 PR 范围

- 固定 `@hyperjump/json-schema@1.17.8`、`@hyperjump/browser@1.5.0`，建立独立、可重复的 phase 0 探针。
- 验证 Schema Resource、嵌入 `$id`、anchor、动态作用域、递归、unevaluated 语义、boolean schema、annotations、bundling 与 OpenAPI 3.1 dialect。
- 提供默认 registry-only 的适配层原型：在处理文档前移除 HTTP、HTTPS 和 file scheme，未知 dialect 明确拒绝。
- 验证现代 ESM 浏览器构建、严格 CSP、包体与合成大 Schema 性能。
- 记录采用条件、替代方案、风险与 phase 1 接口边界。

### 非目标

- 不接入 `front/core` / `front/ui-react` 运行时，不改变用户可见行为。
- 不开放跨文档网络加载，不修改 CI workflow。
- 不宣称任意 Schema 能无损扁平化为唯一字段树或生成唯一示例。
- 不包含 OpenAPI 3.2、Vue3/OAS2、Java/springdoc 升级。

## 主要结论

- Hyperjump 可以正确承担本轮验证的 2020-12 与 OAS 3.1 求值语义，浏览器体积不是主要阻碍。
- Schema 图读取与 annotations 依赖 upstream `experimental` exports，必须由 Knife4j 自有适配层隔离并固定版本。
- Hyperjump 的 registry 与 URI plugin 是全局状态；嵌入式 `$id` 资源也不会自动成为全局 registry 项。phase 1 必须管理生命周期并建立独立资源索引。
- annotation 来自对具体实例的实际求值，不能作为无实例的静态 Schema 元数据 API。
- 上游默认具备网络读取能力；Knife4j 必须默认禁用，未来加载器另行设计白名单、凭据、大小、数量、深度、时间、取消和缓存限制。

完整结论见 `tools/spikes/json-schema-2020-12/DECISION.md`。

## 验证

`./tools/test-json-schema-engine-spike.sh`：

- TypeScript 5.9.3 strict typecheck 通过。
- Bun：8 tests / 22 assertions 全部通过。
- Browser ESM：150,650 bytes，gzip -9 为 24,343 bytes。
- 静态扫描：`eval`、`new Function`、Node 内置导入均为 0。
- 合成 10,000 properties / 596,802 bytes Schema：四次本地运行的编译约 179–186 ms，单次校验约 7.0–8.3 ms。

Headless Chrome 152 实测：

- CSP：`default-src 'none'; script-src 'self'; connect-src 'none'; base-uri 'none'; form-action 'none'`。
- 动态引用的合法实例通过、额外属性实例被拒绝。
- 网络记录仅包含本地 `index.html` 与 `browser-probe.js` 两个请求。

## 风险与审查

- 探针代码不会进入产品 bundle；生成的 `dist/` 保持 untracked。
- 新探针未接入 CI，避免在 phase 0 顺带修改 workflow；复核命令已固定在仓库脚本中。
- 这是架构决策 PR，需要维护者人工审查；当前未以自动 reviewer 代替该决策。
- phase 1 将另开实现任务，不在 review 中隐式扩张本 PR。
