### PR TITLE
test(ui-react): 使用 Node 运行浏览器语义测试

### DIFF
--- a/front/ui-react/package.json
+++ b/front/ui-react/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "test": "vitest",
+    "test": "node ../node_modules/vitest/vitest.mjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css,json}\"",

--- a/front/ui-react/src/pages/api/responseBodyProgress.test.ts
+++ b/front/ui-react/src/pages/api/responseBodyProgress.test.ts
@@ -37,14 +37,16 @@ describe('readResponseBlob', () => {
 
   it('falls back to received bytes when the transfer length is unknown', async () => {
     const progress: ResponseBodyProgress[] = [];
-    await readResponseBlob(
+    const blob = await readResponseBlob(
       responseFrom(['hello world'], {
         'Content-Length': '11',
         'Content-Encoding': 'gzip',
+        'Content-Type': 'application/json',
       }),
       (value) => progress.push(value),
     );
 
+    expect(blob.type).toBe('application/json');
     expect(progress).toEqual([
       { receivedBytes: 0, totalBytes: null },
       { receivedBytes: 11, totalBytes: null },
@@ -68,9 +70,12 @@ describe('readResponseBlob', () => {
     vi.stubGlobal('TransformStream', undefined);
     const progress: ResponseBodyProgress[] = [];
 
-    const blob = await readResponseBlob(responseFrom(['hello world']), (value) => progress.push(value));
+    const blob = await readResponseBlob(responseFrom(['hello world'], { 'Content-Type': 'text/plain' }), (value) =>
+      progress.push(value),
+    );
 
     expect(await blob.text()).toBe('hello world');
+    expect(blob.type).toBe('text/plain');
     expect(progress).toEqual([
       { receivedBytes: 0, totalBytes: null },
       { receivedBytes: 11, totalBytes: null },
@@ -79,11 +84,15 @@ describe('readResponseBlob', () => {
 
   it('does not trust a CORS content length when content encoding is hidden', async () => {
     const progress: ResponseBodyProgress[] = [];
-    const response = responseFrom(['hello world'], { 'Content-Length': '11' });
+    const response = responseFrom(['hello world'], {
+      'Content-Length': '11',
+      'Content-Type': 'text/plain; charset=UTF-8',
+    });
     Object.defineProperty(response, 'type', { value: 'cors' });
 
-    await readResponseBlob(response, (value) => progress.push(value));
+    const blob = await readResponseBlob(response, (value) => progress.push(value));
 
+    expect(blob.type).toBe('text/plain;charset=utf-8');
     expect(progress[0]).toEqual({ receivedBytes: 0, totalBytes: null });
   });
 });

--- a/tools/test-front-core.sh
+++ b/tools/test-front-core.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../front"
 
+node_bin="$(command -v node || true)"
+if [ -z "$node_bin" ]; then
+  echo "Node.js 22 or newer is required for browser-semantics UI tests; use the version from .nvmrc" >&2
+  exit 1
+fi
+node_major="$("$node_bin" -p "process.versions.node.split('.')[0]")"
+if [ "$node_major" -lt 22 ]; then
+  echo "Node.js 22 or newer is required for browser-semantics UI tests; found $("$node_bin" --version)" >&2
+  exit 1
+fi
+
 bun install --frozen-lockfile
 
 # --- knife4j-schema-engine ---


### PR DESCRIPTION
## 变更说明

- 将 `knife4j-ui-react` 的 Vitest 明确交给 Node 运行，避免 `bun run` 用 Bun 1.4 的 Fetch/Blob 实现替代浏览器语义
- 在统一前端验证脚本入口校验 Node 22+，与 `.nvmrc` 和 workspace `engines.node` 保持一致
- 补齐已知长度、解压后未知长度、无 `TransformStream`、CORS 隐藏编码四条响应读取路径的 Blob MIME 断言

## 原因

Bun 1.4 的 `Response.blob()` 在流式场景会丢失 `type`。同时，使用 Bun 的 `Blob.slice` 或 `new Blob` 在产品代码中补齐 MIME，又会为 `text/plain`、`application/json` 自动追加 `charset=utf-8`，仍然偏离浏览器/Node 行为。因此本 PR 固定测试运行时，不引入 Bun 专用产品兼容逻辑。

## 验证

- `./tools/test-front-core.sh`（SchemaEngine 18/18，core 283/283，ui-react 398/398）
- `./tools/sync-knife4x-ui.sh --check`
- `./tools/test-knife4x-go.sh`
- `git diff --check`

产品源码与 Knife4x 嵌入资源无变更。

Closes #686
