### PR TITLE
fix(release): 支持 Maven Central 延迟发布与安全收尾

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,30 +8,70 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "Recovery mode (never deploys Maven artifacts)"
+        required: true
+        type: choice
+        options:
+          - finalize-only
+      tag:
+        description: "Existing annotated vX.Y.Z tag to finalize"
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc') }}
+    timeout-minutes: 180
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')) || (github.event_name == 'workflow_dispatch' && inputs.mode == 'finalize-only') }}
     permissions:
       contents: write
     env:
-      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-      CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      RELEASE_ROOT: ${{ github.event_name == 'workflow_dispatch' && format('{0}/release-source', github.workspace) || github.workspace }}
     defaults:
       run:
         working-directory: knife4j
     steps:
-      - name: Checkout
+      - name: Checkout release tag for publishing
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Checkout recovery tooling
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v7
 
-      - name: Verify release module list
-        run: tools/verify-release-modules.sh
+      - name: Checkout release tag for finalize-only
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          path: release-source
+          fetch-depth: 0
+
+      - name: Verify release context and prepare notes
+        run: |
+          release_notes="$RUNNER_TEMP/github-release-notes.md"
+          VERIFY_RELEASE_REPO_ROOT="$RELEASE_ROOT" \
+            tools/verify-release-context.sh "$RELEASE_TAG" "$release_notes"
+          echo "GITHUB_RELEASE_NOTES=$release_notes" >> "$GITHUB_ENV"
         working-directory: .
 
-      - name: Set up JDK 17
+      - name: Verify release module list
+        run: |
+          VERIFY_RELEASE_REPO_ROOT="$RELEASE_ROOT" \
+            tools/verify-release-modules.sh
+        working-directory: .
+
+      - name: Set up JDK 17 for publishing
+        if: ${{ github.event_name == 'push' }}
         uses: actions/setup-java@v5
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         with:
           distribution: temurin
           java-version: "17"
@@ -42,51 +82,66 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
+      - name: Set up JDK 17 for finalize-only verification
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
       - name: Set up Node.js
+        if: ${{ github.event_name == 'push' }}
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
       - name: Set up bun
+        if: ${{ github.event_name == 'push' }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
 
       - name: Install front/vue3 dependencies (bun)
+        if: ${{ github.event_name == 'push' }}
         run: bun install --frozen-lockfile
         working-directory: front/vue3
 
       - name: Install front workspace dependencies
+        if: ${{ github.event_name == 'push' }}
         run: bun install --frozen-lockfile
         working-directory: front
 
-      - name: Prepare GitHub Release notes
-        run: |
-          version="${GITHUB_REF_NAME#v}"
-          release_notes="$RUNNER_TEMP/github-release-notes.md"
-          tools/extract-release-note.sh "$version" > "$release_notes"
-          echo "GITHUB_RELEASE_NOTES=$release_notes" >> "$GITHUB_ENV"
-        working-directory: .
-
       - name: Publish to Maven Central
+        if: ${{ github.event_name == 'push' }}
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           release_modules="$(sed -E 's/[[:space:]]*#.*$//' ../tools/release-modules.txt | sed '/^[[:space:]]*$/d' | paste -sd, -)"
           mvn -B -ntp -Prelease deploy \
             -pl "$release_modules" \
             -am
 
+      - name: Verify public Maven Central artifacts
+        run: |
+          VERIFY_MAVEN_REPO_ROOT="$RELEASE_ROOT" \
+            tools/verify-maven-central.sh "${RELEASE_TAG#v}"
+        working-directory: .
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          title="knife4j-next ${GITHUB_REF_NAME#v}"
-          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit "$GITHUB_REF_NAME" \
+          title="knife4j-next ${RELEASE_TAG#v}"
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$title" \
               --notes-file "$GITHUB_RELEASE_NOTES"
           else
-            gh release create "$GITHUB_REF_NAME" \
+            gh release create "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$title" \
               --notes-file "$GITHUB_RELEASE_NOTES" \
@@ -97,5 +152,5 @@ jobs:
       - name: Verify GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: tools/verify-github-release.sh "$GITHUB_REF_NAME" "$GITHUB_RELEASE_NOTES"
+        run: tools/verify-github-release.sh "$RELEASE_TAG" "$GITHUB_RELEASE_NOTES"
         working-directory: .

--- a/knife4j/RELEASE.md
+++ b/knife4j/RELEASE.md
@@ -17,7 +17,7 @@
 ## CI workflows
 
 - `.github/workflows/build.yml` 在 PR 和 `master` push 时运行 `mvn verify` 等验证。
-- `.github/workflows/release.yml` 在推送 `v*` tag 时发布 Maven Central 构件，并创建 GitHub Release。
+- `.github/workflows/release.yml` 在推送 `v*` tag 时发布 Maven Central 构件，验证公共仓库精确构件 URL 后创建 GitHub Release；手动触发只提供 `finalize-only` 安全收尾。
 - `.github/workflows/deploy-demo.yml` 仅在推送 `v*` tag（或 `workflow_dispatch`）时构建并部署在线 demo，**不在** `master` 合并时自动部署，避免 demo 超前于已发布版本。
 
 ## Release flow
@@ -25,7 +25,7 @@
 1. 确认 `knife4j/pom.xml` 和所有子模块版本正确。
 2. 在 `docs/release-notes/index.md` 增加对应版本小节，例如 `### 5.0.8`。
 3. 提交并合并 release prep PR，等待 PR CI 和 `master` push CI 通过。
-4. 创建并推送 tag，例如 `v5.0.8`。
+4. 创建并推送 annotated tag，例如 `v5.0.8`。
 5. 等待 GitHub Actions `Release` workflow 完成发布。
 6. 等待同一次 tag 触发的 `Build and Deploy Demo` workflow 完成 demo 镜像发布。
 7. 验收发布完成条件：
@@ -41,3 +41,16 @@
 GitHub Release body 由 `.github/workflows/release.yml` 调用 `tools/extract-release-note.sh` 从 `docs/release-notes/index.md` 自动抽取。
 
 如果 release note 中没有当前 tag 对应的小节，Release workflow 必须失败，不允许发布一个没有 GitHub Release 说明的版本。
+
+## Central 延迟与 `finalize-only` 恢复
+
+正常发布只由 tag push 触发。Central Publishing Plugin 保留 `autoPublish=true` 与 `waitUntil=published`，最多等待 7200 秒并每 15 秒轮询；GitHub Actions job 的 180 分钟上限为后续公共构件验证预留了余量。
+
+如果 `Publish to Maven Central` 已输出 deployment ID、bundle 上传成功，但等待 Central 发布超时：
+
+1. 保留失败 run 和原 tag，先核对 deployment 状态及精确 POM/JAR URL。Central 目录索引返回 404 不能作为构件缺失结论。
+2. **禁止重新运行 `mvn deploy`、移动 tag 或重传同版本构件。** 发布构件不可覆盖，模糊日志也不能视为上传失败。
+3. 等公共构件可见后，在 Actions 中手动运行 `Release`，选择唯一的 `finalize-only` mode，并填写已有 annotated `vX.Y.Z` tag。
+4. 恢复路径会 checkout 该 tag，校验 tag/POM/发布说明一致，读取 `tools/release-modules.txt` 检查父 POM、各模块 POM/JAR、签名、SHA-1 和 UI JAR，再幂等创建或更新 GitHub Release。
+
+`finalize-only` 不执行 Maven deploy，也不读取 Central/GPG secrets。tag 不存在或不是 annotated tag、checkout/POM 版本不一致、发布说明缺失、公共构件不完整时都会失败关闭；公共仓库超过有界等待时只报告缺失模块，不自动重传。

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -475,6 +475,8 @@
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
                             <waitUntil>published</waitUntil>
+                            <waitMaxTime>7200</waitMaxTime>
+                            <waitPollingInterval>15</waitPollingInterval>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,6 +7,7 @@
 | 脚本 | 作用 |
 |---|---|
 | `test-java.sh` | spotless + Maven verify + smoke 证据 |
+| `test-release-tools.sh` | Release 上下文、Central 构件与安全收尾脚本回归 |
 | `test-front-core.sh` | core + React format/lint/test/build |
 | `test-vue3.sh` | Vue3 构建与产物检查 |
 | `test-docs.sh` | 文档站构建 |
@@ -14,7 +15,12 @@
 
 ## 发布
 
-`release-modules.txt`、`verify-release-modules.sh`、`extract-release-note.sh`、`verify-github-release.sh` — 由 release/build workflow 使用。
+- `release-modules.txt`、`verify-release-modules.sh`：发布模块真相源及 BOM 一致性校验。
+- `verify-release-context.sh`：校验 annotated `vX.Y.Z` tag、当前 checkout、POM 版本和发布说明一致。
+- `verify-maven-central.sh`：按精确 URL 有界轮询公共 POM/JAR、签名和 SHA-1，并检查 UI JAR 可读取。
+- `extract-release-note.sh`、`verify-github-release.sh`：生成并核对幂等 GitHub Release。
+
+`verify-maven-central.sh` 默认最多检查 31 次、每次间隔 60 秒；测试或故障排查可通过 `MAVEN_CENTRAL_MAX_ATTEMPTS`、`MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS` 和 `MAVEN_CENTRAL_BASE_URL` 收紧边界。
 
 ## 任务看板
 

--- a/tools/ci-changes.sh
+++ b/tools/ci-changes.sh
@@ -15,7 +15,7 @@ while IFS= read -r path || [ -n "$path" ]; do
     docs/*|tools/test-docs.sh)
       docs=true
       ;;
-    knife4j/*|tools/test-java.sh|tools/verify-configuration-metadata.sh|tools/verify-release-modules.sh|tools/release-modules.txt|.java-version)
+    knife4j/*|tools/test-java.sh|tools/test-release-tools.sh|tools/test-fixtures/mock-maven-central-curl.sh|tools/extract-release-note.sh|tools/verify-configuration-metadata.sh|tools/verify-release-context.sh|tools/verify-maven-central.sh|tools/verify-release-modules.sh|tools/release-modules.txt|.java-version)
       java=true
       ;;
     front/core/*|front/ui-react/*|front/package.json|front/bun.lock)
@@ -37,7 +37,7 @@ while IFS= read -r path || [ -n "$path" ]; do
     .github/workflows/*|.bun-version|.editorconfig|.gitattributes|.nvmrc|tools/ci-changes.sh|tools/test-ci-changes.sh)
       full=true
       ;;
-    README.md|CONTRIBUTING.md|AGENTS.md|.agent/*|.gitignore|tools/README.md|tools/agent-status.sh|tools/claude/*|tools/test-all.sh|tools/extract-release-note.sh|tools/verify-github-release.sh)
+    README.md|CONTRIBUTING.md|AGENTS.md|.agent/*|.gitignore|tools/README.md|tools/agent-status.sh|tools/claude/*|tools/test-all.sh|tools/verify-github-release.sh)
       ;;
     *)
       full=true

--- a/tools/extract-release-note.sh
+++ b/tools/extract-release-note.sh
@@ -15,13 +15,22 @@ if [ ! -f "$notes_file" ]; then
 fi
 
 awk -v version="$version" '
+  function matches_version_heading(line, text, suffix) {
+    text = line
+    sub(/^###[ \t]+/, "", text)
+    if (substr(text, 1, length(version)) != version) {
+      return 0
+    }
+    suffix = substr(text, length(version) + 1, 1)
+    return suffix == "" || suffix == " " || suffix == "\t" || suffix == "<"
+  }
+
   BEGIN {
     found = 0
     emitted = 0
-    heading = "^###[ \t]+" version "([ \t]|$|<)"
   }
 
-  $0 ~ heading {
+  /^###[ \t]+/ && matches_version_heading($0) {
     found = 1
     emitted++
     print "## " version

--- a/tools/test-ci-changes.sh
+++ b/tools/test-ci-changes.sh
@@ -36,7 +36,7 @@ knife4x_only="$(outputs false false false false true)"
 all="$(outputs true true true true true)"
 
 assert_case "docs" "$docs_only" $'docs/guide/index.md\ntools/test-docs.sh'
-assert_case "java" "$java_only" $'knife4j/knife4j-core/pom.xml\ntools/test-java.sh\ntools/verify-configuration-metadata.sh\ntools/verify-release-modules.sh\ntools/release-modules.txt\n.java-version'
+assert_case "java" "$java_only" $'knife4j/knife4j-core/pom.xml\ntools/test-java.sh\ntools/test-release-tools.sh\ntools/test-fixtures/mock-maven-central-curl.sh\ntools/extract-release-note.sh\ntools/verify-configuration-metadata.sh\ntools/verify-release-context.sh\ntools/verify-maven-central.sh\ntools/verify-release-modules.sh\ntools/release-modules.txt\n.java-version'
 for path in front/core/src/index.ts front/ui-react/src/App.tsx front/package.json front/bun.lock; do
   assert_case "react and knife4x: $path" "$react_java_and_knife4x" "$path"
 done
@@ -45,7 +45,7 @@ assert_case "vue3" "$vue3_and_java" $'front/vue3/src/App.vue\ntools/test-vue3.sh
 assert_case "knife4x go" "$knife4x_only" $'knife4x/go/README.md\nknife4x/examples/gin/main.go\ntools/sync-knife4x-ui.sh\ntools/test-knife4x-go.sh'
 assert_case "shared configuration" "$all" $'.github/workflows/build.yml\n.bun-version\n.editorconfig\n.gitattributes\n.nvmrc\ntools/ci-changes.sh\ntools/test-ci-changes.sh'
 assert_case "unknown path" "$all" "new-area/example.txt"
-assert_case "maintenance files" "$none" $'README.md\nCONTRIBUTING.md\nAGENTS.md\n.agent/PROJECT.md\n.gitignore\ntools/README.md\ntools/agent-status.sh\ntools/claude/run.sh\ntools/test-all.sh\ntools/extract-release-note.sh\ntools/verify-github-release.sh'
+assert_case "maintenance files" "$none" $'README.md\nCONTRIBUTING.md\nAGENTS.md\n.agent/PROJECT.md\n.gitignore\ntools/README.md\ntools/agent-status.sh\ntools/claude/run.sh\ntools/test-all.sh\ntools/verify-github-release.sh'
 assert_case "empty input" "$all" "__EMPTY__"
 
 printf 'ci change classification tests passed\n'

--- a/tools/test-fixtures/mock-maven-central-curl.sh
+++ b/tools/test-fixtures/mock-maven-central-curl.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${MOCK_CURL_STATE_DIR:?MOCK_CURL_STATE_DIR is required}"
+: "${MOCK_CURL_PLAN:?MOCK_CURL_PLAN is required}"
+: "${MOCK_CURL_VALID_JAR:?MOCK_CURL_VALID_JAR is required}"
+
+output_file="/dev/null"
+is_head=false
+url=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output|-o)
+      output_file="$2"
+      shift 2
+      ;;
+    --write-out|-w|--connect-timeout|--max-time|--range)
+      shift 2
+      ;;
+    --head|-I)
+      is_head=true
+      shift
+      ;;
+    --fail|--location|--silent|--show-error)
+      shift
+      ;;
+    --*)
+      echo "unsupported mock curl option: $1" >&2
+      exit 2
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$url" ]; then
+  echo "mock curl URL is required" >&2
+  exit 2
+fi
+
+mkdir -p "$MOCK_CURL_STATE_DIR"
+printf '%s\t%s\n' "$is_head" "$url" >> "$MOCK_CURL_STATE_DIR/requests.log"
+
+key="$(printf '%s' "$url" | cksum | awk '{print $1}')"
+count_file="$MOCK_CURL_STATE_DIR/$key.count"
+count=0
+if [ -f "$count_file" ]; then
+  count="$(sed -n '1p' "$count_file")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+
+while IFS='|' read -r pattern failure_count http_code exit_status message; do
+  if [ -z "$pattern" ]; then
+    continue
+  fi
+  if [[ "$url" == *"$pattern"* ]] && [ "$count" -le "$failure_count" ]; then
+    printf '%s' "$http_code"
+    if [ -n "$message" ]; then
+      printf '%s\n' "$message" >&2
+    fi
+    exit "$exit_status"
+  fi
+done < "$MOCK_CURL_PLAN"
+
+if [ "$is_head" = false ] && [ "$output_file" != "/dev/null" ]; then
+  if [ -n "${MOCK_CURL_INVALID_JAR_PATTERN:-}" ] && [[ "$url" == *"$MOCK_CURL_INVALID_JAR_PATTERN"* ]]; then
+    printf 'not a jar\n' > "$output_file"
+  else
+    cp "$MOCK_CURL_VALID_JAR" "$output_file"
+  fi
+fi
+
+printf '200'

--- a/tools/test-java.sh
+++ b/tools/test-java.sh
@@ -7,6 +7,7 @@ if [ -z "${JAVA_HOME:-}" ]; then
 fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+"$REPO_ROOT/tools/test-release-tools.sh"
 cd "$REPO_ROOT/knife4j"
 
 mvn -B -ntp spotless:check

--- a/tools/test-release-tools.sh
+++ b/tools/test-release-tools.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+central_verifier="$repo_root/tools/verify-maven-central.sh"
+context_verifier="$repo_root/tools/verify-release-context.sh"
+mock_curl="$repo_root/tools/test-fixtures/mock-maven-central-curl.sh"
+workflow="$repo_root/.github/workflows/release.yml"
+pom_file="$repo_root/knife4j/pom.xml"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+fail() {
+  echo "release tooling test failed: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "Expected to find in $file: $expected" >&2
+    sed -n '1,220p' "$file" >&2
+    fail "missing expected output"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    echo "Did not expect to find in $file: $unexpected" >&2
+    sed -n '1,220p' "$file" >&2
+    fail "unexpected output"
+  fi
+}
+
+fixture_root="$tmp_root/maven-fixture"
+mkdir -p \
+  "$fixture_root/tools" \
+  "$fixture_root/knife4j/api" \
+  "$fixture_root/knife4j/bom" \
+  "$fixture_root/knife4j/knife4j-test-ui"
+
+printf '%s\n' \
+  '<project>' \
+  '  <groupId>com.example</groupId>' \
+  '  <artifactId>parent</artifactId>' \
+  '  <version>1.2.3</version>' \
+  '  <packaging>pom</packaging>' \
+  '</project>' > "$fixture_root/knife4j/pom.xml"
+printf '%s\n' '<project>' '<artifactId>api</artifactId>' '</project>' > "$fixture_root/knife4j/api/pom.xml"
+printf '%s\n' '<project>' '<artifactId>bom</artifactId>' '<packaging>pom</packaging>' '</project>' > "$fixture_root/knife4j/bom/pom.xml"
+printf '%s\n' '<project>' '<artifactId>knife4j-test-ui</artifactId>' '</project>' > "$fixture_root/knife4j/knife4j-test-ui/pom.xml"
+printf '%s\n' api bom knife4j-test-ui > "$fixture_root/tools/release-modules.txt"
+
+jar_payload="$tmp_root/jar-payload"
+valid_jar="$tmp_root/valid.jar"
+mkdir -p "$jar_payload/META-INF/resources"
+printf '<!doctype html>\n' > "$jar_payload/META-INF/resources/doc.html"
+jar cf "$valid_jar" -C "$jar_payload" .
+
+verifier_status=0
+verifier_log=""
+verifier_requests=""
+
+run_verifier() {
+  local name="$1"
+  local plan_content="$2"
+  local attempts="$3"
+  local invalid_jar_pattern="${4:-}"
+  local case_root="$tmp_root/$name"
+  local plan_file="$case_root/plan"
+
+  mkdir -p "$case_root/state"
+  printf '%s' "$plan_content" > "$plan_file"
+  verifier_log="$case_root/output.log"
+  verifier_requests="$case_root/state/requests.log"
+
+  set +e
+  env \
+    VERIFY_MAVEN_REPO_ROOT="$fixture_root" \
+    MAVEN_CENTRAL_BASE_URL="https://central.example/maven2" \
+    MAVEN_CENTRAL_MAX_ATTEMPTS="$attempts" \
+    MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS=0 \
+    MAVEN_CENTRAL_CONNECT_TIMEOUT_SECONDS=1 \
+    MAVEN_CENTRAL_REQUEST_TIMEOUT_SECONDS=1 \
+    MAVEN_CENTRAL_CURL_BIN="$mock_curl" \
+    MOCK_CURL_STATE_DIR="$case_root/state" \
+    MOCK_CURL_PLAN="$plan_file" \
+    MOCK_CURL_VALID_JAR="$valid_jar" \
+    MOCK_CURL_INVALID_JAR_PATTERN="$invalid_jar_pattern" \
+    "$central_verifier" 1.2.3 > "$verifier_log" 2>&1
+  verifier_status=$?
+  set -e
+}
+
+run_verifier all-available "" 1
+[ "$verifier_status" -eq 0 ] || fail "all available case should pass"
+assert_contains "$verifier_log" "Maven Central artifacts OK"
+assert_contains "$verifier_requests" "https://central.example/maven2/com/example/bom/1.2.3/bom-1.2.3.pom"
+assert_not_contains "$verifier_requests" 'com\/example'
+assert_not_contains "$verifier_requests" "bom-1.2.3.jar"
+
+run_verifier delayed $'api-1.2.3.jar|1|404|22|not found\n' 2
+[ "$verifier_status" -eq 0 ] || fail "404 then available case should pass"
+assert_contains "$verifier_log" "attempt 1/2"
+assert_contains "$verifier_log" "attempt 2/2"
+
+run_verifier permanent-missing $'api-1.2.3.jar|99|404|22|not found\n' 2
+[ "$verifier_status" -ne 0 ] || fail "permanently missing artifact should fail"
+assert_contains "$verifier_log" "timed out after 2 attempt(s)"
+assert_contains "$verifier_log" "Unavailable modules/artifacts: api"
+assert_contains "$verifier_log" "HTTP 404"
+
+run_verifier missing-companions $'api-1.2.3.jar.asc|99|404|22|signature missing\nbom-1.2.3.pom.sha1|99|404|22|checksum missing\n' 1
+[ "$verifier_status" -ne 0 ] || fail "missing signature/checksum should fail"
+assert_contains "$verifier_log" "api-1.2.3.jar.asc"
+assert_contains "$verifier_log" "bom-1.2.3.pom.sha1"
+assert_contains "$verifier_log" "Unavailable modules/artifacts: api,bom"
+
+run_verifier request-timeout $'knife4j-test-ui-1.2.3.jar.sha1|99|000|28|operation timed out\n' 1
+[ "$verifier_status" -ne 0 ] || fail "request timeout should fail"
+assert_contains "$verifier_log" "curl 28"
+assert_contains "$verifier_log" "operation timed out"
+
+run_verifier unreadable-ui "" 1 "knife4j-test-ui-1.2.3.jar"
+[ "$verifier_status" -ne 0 ] || fail "unreadable UI JAR should fail"
+assert_contains "$verifier_log" "downloaded UI JAR is unreadable"
+
+make_context_repo() {
+  local name="$1"
+  local pom_version="$2"
+  local note_version="$3"
+  local tag_kind="$4"
+  local context_root="$tmp_root/context-$name"
+
+  mkdir -p "$context_root/knife4j" "$context_root/docs/release-notes"
+  git -C "$context_root" init -q
+  git -C "$context_root" config user.name "Release Tool Test"
+  git -C "$context_root" config user.email "release-tool-test@example.invalid"
+  printf '%s\n' \
+    '<project>' \
+    '  <groupId>com.example</groupId>' \
+    '  <artifactId>parent</artifactId>' \
+    "  <version>$pom_version</version>" \
+    '</project>' > "$context_root/knife4j/pom.xml"
+  printf '%s\n' \
+    '# Release notes' \
+    '' \
+    "### $note_version" \
+    '' \
+    '- test release note' \
+    '' \
+    '---' > "$context_root/docs/release-notes/index.md"
+  git -C "$context_root" add knife4j/pom.xml docs/release-notes/index.md
+  git -C "$context_root" commit -q -m "test fixture"
+  if [ "$tag_kind" = "annotated" ]; then
+    git -C "$context_root" tag -a v1.2.3 -m "test release"
+  else
+    git -C "$context_root" tag v1.2.3
+  fi
+  printf '%s\n' "$context_root"
+}
+
+run_context() {
+  local name="$1"
+  local context_root="$2"
+  local tag="$3"
+  local output_file="$tmp_root/$name-notes.md"
+  local log_file="$tmp_root/$name-context.log"
+
+  set +e
+  env VERIFY_RELEASE_REPO_ROOT="$context_root" \
+    "$context_verifier" "$tag" "$output_file" > "$log_file" 2>&1
+  context_status=$?
+  set -e
+  context_log="$log_file"
+  context_output="$output_file"
+}
+
+context_root="$(make_context_repo success 1.2.3 1.2.3 annotated)"
+run_context context-success "$context_root" v1.2.3
+[ "$context_status" -eq 0 ] || fail "valid release context should pass"
+assert_contains "$context_output" "## 1.2.3"
+
+run_context context-missing-tag "$context_root" v9.9.9
+[ "$context_status" -ne 0 ] || fail "missing tag should fail"
+assert_contains "$context_log" "tag does not exist"
+
+context_mismatch="$(make_context_repo mismatch 2.0.0 1.2.3 annotated)"
+run_context context-mismatch "$context_mismatch" v1.2.3
+[ "$context_status" -ne 0 ] || fail "tag/POM version mismatch should fail"
+assert_contains "$context_log" "does not match POM version"
+
+context_missing_note="$(make_context_repo missing-note 1.2.3 9.9.9 annotated)"
+run_context context-missing-note "$context_missing_note" v1.2.3
+[ "$context_status" -ne 0 ] || fail "missing release note should fail"
+assert_contains "$context_log" "Release note section not found"
+
+context_regex_like_note="$(make_context_repo regex-like-note 1.2.3 1x2x3 annotated)"
+run_context context-regex-like-note "$context_regex_like_note" v1.2.3
+[ "$context_status" -ne 0 ] || fail "regex-like release note version should fail"
+assert_contains "$context_log" "Release note section not found"
+
+context_lightweight="$(make_context_repo lightweight 1.2.3 1.2.3 lightweight)"
+run_context context-lightweight "$context_lightweight" v1.2.3
+[ "$context_status" -ne 0 ] || fail "lightweight tag should fail"
+assert_contains "$context_log" "tag must be annotated"
+
+context_wrong_head="$(make_context_repo wrong-head 1.2.3 1.2.3 annotated)"
+printf 'after tag\n' > "$context_wrong_head/after-tag.txt"
+git -C "$context_wrong_head" add after-tag.txt
+git -C "$context_wrong_head" commit -q -m "move head"
+run_context context-wrong-head "$context_wrong_head" v1.2.3
+[ "$context_status" -ne 0 ] || fail "tag/HEAD mismatch should fail"
+assert_contains "$context_log" "does not match v1.2.3"
+
+module_root="$tmp_root/release-modules-root"
+mkdir -p \
+  "$module_root/tools" \
+  "$module_root/knife4j/knife4j-api" \
+  "$module_root/knife4j/knife4j-dependencies"
+printf '%s\n' \
+  '<project>' \
+  '  <modules><module>knife4j-api</module></modules>' \
+  '</project>' > "$module_root/knife4j/pom.xml"
+printf '%s\n' '<project><artifactId>knife4j-api</artifactId></project>' > "$module_root/knife4j/knife4j-api/pom.xml"
+printf '%s\n' \
+  '<project>' \
+  '  <dependencyManagement>' \
+  '    <dependencies>' \
+  '      <dependency>' \
+  '        <groupId>com.baizhukui</groupId>' \
+  '        <artifactId>knife4j-api</artifactId>' \
+  '      </dependency>' \
+  '    </dependencies>' \
+  '  </dependencyManagement>' \
+  '</project>' > "$module_root/knife4j/knife4j-dependencies/pom.xml"
+printf '%s\n' knife4j-api > "$module_root/tools/release-modules.txt"
+if ! env VERIFY_RELEASE_REPO_ROOT="$module_root" \
+  "$repo_root/tools/verify-release-modules.sh" > "$tmp_root/release-modules.log" 2>&1; then
+  sed -n '1,220p' "$tmp_root/release-modules.log" >&2
+  fail "release module verifier should read the overridden repository root"
+fi
+assert_contains "$tmp_root/release-modules.log" "Release module list OK (1 modules)."
+
+assert_contains "$workflow" "mode:"
+assert_contains "$workflow" "finalize-only"
+assert_contains "$workflow" "tag:"
+assert_contains "$workflow" "fetch-depth: 0"
+assert_contains "$workflow" "path: release-source"
+assert_contains "$workflow" "VERIFY_RELEASE_REPO_ROOT="
+assert_contains "$workflow" "VERIFY_MAVEN_REPO_ROOT="
+assert_contains "$workflow" "tools/verify-release-context.sh"
+assert_contains "$workflow" "tools/verify-maven-central.sh"
+assert_not_contains "$workflow" '\$RELEASE_ROOT/tools/verify-release-modules.sh'
+
+context_line="$(awk 'index($0, "tools/verify-release-context.sh") { print NR; exit }' "$workflow")"
+modules_line="$(awk 'index($0, "tools/verify-release-modules.sh") { print NR; exit }' "$workflow")"
+if [ -z "$context_line" ] || [ -z "$modules_line" ] || [ "$context_line" -ge "$modules_line" ]; then
+  fail "current tooling must verify the release tag before checking its module data"
+fi
+
+publish_block="$tmp_root/publish-block.txt"
+grep -A3 -F -- "- name: Publish to Maven Central" "$workflow" > "$publish_block"
+assert_contains "$publish_block" 'if: ${{ github.event_name == '\''push'\'' }}'
+deploy_count="$(grep -c -F -- 'mvn -B -ntp -Prelease deploy' "$workflow")"
+[ "$deploy_count" -eq 1 ] || fail "release workflow must contain exactly one Maven deploy command"
+
+central_line="$(awk 'index($0, "tools/verify-maven-central.sh") { print NR; exit }' "$workflow")"
+release_line="$(awk '/- name: Create GitHub Release/ { print NR; exit }' "$workflow")"
+if [ -z "$central_line" ] || [ -z "$release_line" ] || [ "$central_line" -ge "$release_line" ]; then
+  fail "public Maven Central verification must run before GitHub Release creation"
+fi
+
+wait_max="$(awk -F'[<>]' '/<waitMaxTime>/ { gsub(/[[:space:]]/, "", $3); print $3; exit }' "$pom_file")"
+poll_interval="$(awk -F'[<>]' '/<waitPollingInterval>/ { gsub(/[[:space:]]/, "", $3); print $3; exit }' "$pom_file")"
+job_timeout="$(awk '/timeout-minutes:/ { print $2; exit }' "$workflow")"
+[ -n "$wait_max" ] || fail "waitMaxTime must be configured explicitly"
+[ -n "$poll_interval" ] || fail "waitPollingInterval must be configured explicitly"
+[ -n "$job_timeout" ] || fail "release job timeout must be configured explicitly"
+if [ "$((job_timeout * 60))" -le "$wait_max" ]; then
+  fail "release job timeout must exceed the Central plugin waitMaxTime"
+fi
+
+printf 'release tooling tests passed\n'

--- a/tools/verify-maven-central.sh
+++ b/tools/verify-maven-central.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 2
+fi
+
+version="$1"
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must match X.Y.Z, got '$version'." >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${VERIFY_MAVEN_REPO_ROOT:-$(cd "$script_dir/.." && pwd)}"
+modules_file="${VERIFY_MAVEN_MODULES_FILE:-$repo_root/tools/release-modules.txt}"
+parent_pom="${VERIFY_MAVEN_PARENT_POM:-$repo_root/knife4j/pom.xml}"
+base_url="${MAVEN_CENTRAL_BASE_URL:-https://repo.maven.apache.org/maven2}"
+max_attempts="${MAVEN_CENTRAL_MAX_ATTEMPTS:-31}"
+retry_interval="${MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS:-60}"
+connect_timeout="${MAVEN_CENTRAL_CONNECT_TIMEOUT_SECONDS:-10}"
+request_timeout="${MAVEN_CENTRAL_REQUEST_TIMEOUT_SECONDS:-30}"
+curl_bin="${MAVEN_CENTRAL_CURL_BIN:-curl}"
+jar_bin="${MAVEN_CENTRAL_JAR_BIN:-jar}"
+
+require_non_negative_integer() {
+  local name="$1"
+  local value="$2"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$name must be a non-negative integer, got '$value'." >&2
+    exit 2
+  fi
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  require_non_negative_integer "$name" "$value"
+  if [ "$value" -eq 0 ]; then
+    echo "$name must be greater than zero." >&2
+    exit 2
+  fi
+}
+
+require_positive_integer "MAVEN_CENTRAL_MAX_ATTEMPTS" "$max_attempts"
+require_non_negative_integer "MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS" "$retry_interval"
+require_positive_integer "MAVEN_CENTRAL_CONNECT_TIMEOUT_SECONDS" "$connect_timeout"
+require_positive_integer "MAVEN_CENTRAL_REQUEST_TIMEOUT_SECONDS" "$request_timeout"
+
+if [ ! -x "$curl_bin" ] && ! command -v "$curl_bin" >/dev/null 2>&1; then
+  echo "curl executable is required: $curl_bin" >&2
+  exit 1
+fi
+if [ ! -x "$jar_bin" ] && ! command -v "$jar_bin" >/dev/null 2>&1; then
+  echo "jar executable is required to inspect UI archives: $jar_bin" >&2
+  exit 1
+fi
+if [ ! -f "$modules_file" ]; then
+  echo "Release module list not found: $modules_file" >&2
+  exit 1
+fi
+if [ ! -f "$parent_pom" ]; then
+  echo "Parent POM not found: $parent_pom" >&2
+  exit 1
+fi
+
+first_xml_value() {
+  local element="$1"
+  local file="$2"
+  awk -v start="<$element>" -v finish="</$element>" '
+    index($0, start) {
+      value = substr($0, index($0, start) + length(start))
+      value = substr(value, 1, index(value, finish) - 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+group_id="$(first_xml_value groupId "$parent_pom")"
+parent_artifact="$(first_xml_value artifactId "$parent_pom")"
+if [ -z "$group_id" ] || [ -z "$parent_artifact" ]; then
+  echo "Could not read groupId/artifactId from $parent_pom" >&2
+  exit 1
+fi
+
+group_path="$(printf '%s' "$group_id" | tr '.' '/')"
+base_url="${base_url%/}"
+
+expected_modules=()
+expected_files=()
+expected_urls=()
+ui_modules=()
+ui_files=()
+ui_urls=()
+
+add_primary_artifact() {
+  local artifact="$1"
+  local filename="$2"
+  local artifact_url="$base_url/$group_path/$artifact/$version/$filename"
+  local suffix
+
+  for suffix in "" ".asc" ".sha1"; do
+    expected_modules+=("$artifact")
+    expected_files+=("$filename$suffix")
+    expected_urls+=("$artifact_url$suffix")
+  done
+}
+
+add_primary_artifact "$parent_artifact" "$parent_artifact-$version.pom"
+
+release_modules=()
+while IFS= read -r line; do
+  line="${line%%#*}"
+  line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  if [ -n "$line" ]; then
+    release_modules+=("$line")
+  fi
+done < "$modules_file"
+
+if [ "${#release_modules[@]}" -eq 0 ]; then
+  echo "Release module list is empty: $modules_file" >&2
+  exit 1
+fi
+
+for module in "${release_modules[@]}"; do
+  module_pom="$repo_root/knife4j/$module/pom.xml"
+  if [ ! -f "$module_pom" ]; then
+    echo "Module POM not found: $module_pom" >&2
+    exit 1
+  fi
+
+  packaging="$(first_xml_value packaging "$module_pom")"
+  if [ -z "$packaging" ]; then
+    packaging="jar"
+  fi
+
+  add_primary_artifact "$module" "$module-$version.pom"
+  if [ "$packaging" != "pom" ]; then
+    primary_file="$module-$version.$packaging"
+    add_primary_artifact "$module" "$primary_file"
+    case "$module:$packaging" in
+      *-ui:jar)
+        ui_modules+=("$module")
+        ui_files+=("$primary_file")
+        ui_urls+=("$base_url/$group_path/$module/$version/$primary_file")
+        ;;
+    esac
+  fi
+done
+
+temporary_dir="$(mktemp -d)"
+trap 'rm -rf "$temporary_dir"' EXIT
+probe_error=""
+
+probe_url() {
+  local url="$1"
+  local error_file="$temporary_dir/curl-error"
+  local http_code=""
+  local curl_status=0
+  local error_text=""
+
+  if http_code="$("$curl_bin" \
+    --fail \
+    --location \
+    --silent \
+    --show-error \
+    --range 0-0 \
+    --connect-timeout "$connect_timeout" \
+    --max-time "$request_timeout" \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    "$url" 2> "$error_file")"; then
+    if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+      probe_error=""
+      return 0
+    fi
+    probe_error="HTTP ${http_code:-unknown}"
+    return 1
+  else
+    curl_status=$?
+  fi
+
+  if [ -s "$error_file" ]; then
+    error_text="$(tr '\n' ' ' < "$error_file" | sed 's/[[:space:]]*$//')"
+  fi
+  if [ -n "$http_code" ] && [ "$http_code" != "000" ]; then
+    probe_error="HTTP $http_code (curl $curl_status)"
+  else
+    probe_error="curl $curl_status"
+  fi
+  if [ -n "$error_text" ]; then
+    probe_error="$probe_error: $error_text"
+  fi
+  return 1
+}
+
+download_and_inspect_ui() {
+  local filename="$2"
+  local url="$3"
+  local target="$temporary_dir/$filename"
+  local error_file="$temporary_dir/curl-error"
+  local http_code=""
+  local curl_status=0
+  local error_text=""
+
+  if http_code="$("$curl_bin" \
+    --fail \
+    --location \
+    --silent \
+    --show-error \
+    --connect-timeout "$connect_timeout" \
+    --max-time "$request_timeout" \
+    --output "$target" \
+    --write-out '%{http_code}' \
+    "$url" 2> "$error_file")"; then
+    if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+      if "$jar_bin" tf "$target" >/dev/null 2>&1; then
+        probe_error=""
+        return 0
+      fi
+      probe_error="downloaded UI JAR is unreadable"
+      return 1
+    fi
+    probe_error="HTTP ${http_code:-unknown}"
+    return 1
+  else
+    curl_status=$?
+  fi
+
+  if [ -s "$error_file" ]; then
+    error_text="$(tr '\n' ' ' < "$error_file" | sed 's/[[:space:]]*$//')"
+  fi
+  if [ -n "$http_code" ] && [ "$http_code" != "000" ]; then
+    probe_error="HTTP $http_code (curl $curl_status)"
+  else
+    probe_error="curl $curl_status"
+  fi
+  if [ -n "$error_text" ]; then
+    probe_error="$probe_error: $error_text"
+  fi
+  return 1
+}
+
+attempt=1
+while [ "$attempt" -le "$max_attempts" ]; do
+  missing_modules=()
+  missing_files=()
+  missing_errors=()
+
+  for index in "${!expected_urls[@]}"; do
+    if ! probe_url "${expected_urls[$index]}"; then
+      missing_modules+=("${expected_modules[$index]}")
+      missing_files+=("${expected_files[$index]}")
+      missing_errors+=("$probe_error")
+    fi
+  done
+
+  if [ "${#missing_files[@]}" -eq 0 ]; then
+    for index in "${!ui_urls[@]}"; do
+      if ! download_and_inspect_ui "${ui_modules[$index]}" "${ui_files[$index]}" "${ui_urls[$index]}"; then
+        missing_modules+=("${ui_modules[$index]}")
+        missing_files+=("${ui_files[$index]} (readability)")
+        missing_errors+=("$probe_error")
+      fi
+    done
+  fi
+
+  if [ "${#missing_files[@]}" -eq 0 ]; then
+    echo "Maven Central artifacts OK: $group_id:$version (${#expected_files[@]} exact files, ${#ui_files[@]} UI JARs readable, attempt $attempt/$max_attempts)."
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    echo "::error::Maven Central verification timed out after $attempt attempt(s)." >&2
+    failed_modules="$(printf '%s\n' "${missing_modules[@]}" | sort -u | paste -sd, -)"
+    echo "::error::Unavailable modules/artifacts: $failed_modules" >&2
+    for index in "${!missing_files[@]}"; do
+      printf '  - %s: %s (%s)\n' \
+        "${missing_modules[$index]}" \
+        "${missing_files[$index]}" \
+        "${missing_errors[$index]}" >&2
+    done
+    exit 1
+  fi
+
+  echo "Maven Central not ready (attempt $attempt/$max_attempts): ${#missing_files[@]} file(s) unavailable; retrying in ${retry_interval}s." >&2
+  if [ "$retry_interval" -gt 0 ]; then
+    sleep "$retry_interval"
+  fi
+  attempt=$((attempt + 1))
+done

--- a/tools/verify-release-context.sh
+++ b/tools/verify-release-context.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <annotated-tag> [release-notes-output]" >&2
+  exit 2
+fi
+
+tag="$1"
+release_notes_output="${2:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${VERIFY_RELEASE_REPO_ROOT:-$(cd "$script_dir/.." && pwd)}"
+pom_file="${VERIFY_RELEASE_POM_FILE:-$repo_root/knife4j/pom.xml}"
+notes_file="${VERIFY_RELEASE_NOTES_FILE:-$repo_root/docs/release-notes/index.md}"
+
+fail() {
+  echo "Release context verification failed: $*" >&2
+  exit 1
+}
+
+if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  fail "tag must match vX.Y.Z, got '$tag'."
+fi
+
+if ! git -C "$repo_root" show-ref --verify --quiet "refs/tags/$tag"; then
+  fail "tag does not exist: $tag."
+fi
+
+tag_type="$(git -C "$repo_root" cat-file -t "refs/tags/$tag")"
+if [ "$tag_type" != "tag" ]; then
+  fail "tag must be annotated: $tag (object type: $tag_type)."
+fi
+
+tag_commit="$(git -C "$repo_root" rev-parse "refs/tags/$tag^{commit}")"
+head_commit="$(git -C "$repo_root" rev-parse HEAD)"
+if [ "$tag_commit" != "$head_commit" ]; then
+  fail "checked-out commit $head_commit does not match $tag ($tag_commit)."
+fi
+
+if [ ! -f "$pom_file" ]; then
+  fail "POM does not exist: $pom_file."
+fi
+
+version="${tag#v}"
+pom_version="$(awk '
+  index($0, "<version>") {
+    value = substr($0, index($0, "<version>") + length("<version>"))
+    value = substr(value, 1, index(value, "</version>") - 1)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+    print value
+    exit
+  }
+' "$pom_file")"
+if [ -z "$pom_version" ]; then
+  fail "could not read the project version from $pom_file."
+fi
+if [ "$pom_version" != "$version" ]; then
+  fail "tag version $version does not match POM version $pom_version."
+fi
+
+if [ -n "$release_notes_output" ]; then
+  output_dir="$(dirname "$release_notes_output")"
+  if [ ! -d "$output_dir" ]; then
+    fail "release notes output directory does not exist: $output_dir."
+  fi
+  temporary_output="${release_notes_output}.tmp.$$"
+  trap 'rm -f "$temporary_output"' EXIT
+  "$script_dir/extract-release-note.sh" "$version" "$notes_file" > "$temporary_output"
+  mv "$temporary_output" "$release_notes_output"
+  trap - EXIT
+else
+  "$script_dir/extract-release-note.sh" "$version" "$notes_file" >/dev/null
+fi
+
+echo "Release context OK: $tag -> $tag_commit (version $version)."

--- a/tools/verify-release-modules.sh
+++ b/tools/verify-release-modules.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${VERIFY_RELEASE_REPO_ROOT:-$(cd "$script_dir/.." && pwd)}"
 modules_file="$repo_root/tools/release-modules.txt"
 parent_pom="$repo_root/knife4j/pom.xml"
 bom_pom="$repo_root/knife4j/knife4j-dependencies/pom.xml"


### PR DESCRIPTION
Closes #697

## 契约快照

- 支持对象：稳定版 annotated `vX.Y.Z` tag、`knife4j` 父 POM、`tools/release-modules.txt` 中 16 个发布模块及 GitHub Release。
- 正常路径仍由 tag push 触发，保留 Central `autoPublish=true` / `waitUntil=published`，发布后先验证公共仓库再创建 GitHub Release。
- 恢复路径只有显式 `workflow_dispatch: finalize-only`：读取已有 tag 数据，验证公共构件后幂等创建或更新 GitHub Release，绝不执行 Maven deploy。
- 非目标：不发布新版本、不移动或重建 tag、不修改 Maven 坐标、secrets 或默认兼容承诺。

## 变更

- 将 Central 插件等待上限和轮询间隔显式设为 `7200s` / `15s`，Release job 上限设为 `180min`。
- 新增失败关闭的发布上下文校验：tag 格式、存在性、annotated 类型、checkout HEAD、POM 版本和精确 release note 小节必须一致。
- 新增公共 Maven Central 校验器：按精确 URL 检查父 POM、模块 POM/JAR、`.asc`、`.sha1`，并下载检查两个 UI JAR 可读性；支持有界重试和聚合错误摘要。
- `finalize-only` 先使用当前受审工具验证 tag，再由当前工具读取历史 tag checkout 数据；Central/GPG secrets 与唯一 Maven deploy 命令均只存在于 tag push 步骤。
- 增加全可用、先 404 后可用、永久缺失、签名/校验文件缺失、请求超时、POM-only、UI JAR 损坏、tag/POM/说明不一致等回归夹具，并接入 Java 门禁与 CI 路径分类。
- 补充正常发布、超时恢复和“禁止重复 deploy / 移动 tag”的维护文档。

## 复现证据

- [issue 复现记录](https://github.com/songxychn/knife4j-next/issues/697#issuecomment-5468187419)：历史 Release run `33084470302` 已上传 deployment，默认约 1800 秒等待超时，随后 GitHub Release 步骤被跳过；当前公共精确构件 URL 已可访问。

## 验证

- `./tools/test-java.sh`（Corretto JDK 17）：34 个 reactor 模块 `BUILD SUCCESS`，6 个配置元数据模块和 14 个 smoke 模块通过。
- `tools/test-release-tools.sh`
- `tools/test-ci-changes.sh`
- `tools/verify-release-modules.sh`：16 个发布模块通过。
- 历史 `v5.4.0` 隔离 checkout：发布上下文、模块清单通过。
- 真实 Maven Central `5.4.0`：96 个精确文件可用，2 个 UI JAR 可读。
- `./tools/test-knife4x-go.sh`
- `bash -n tools/*.sh tools/test-fixtures/*.sh`
- Release workflow YAML 解析通过。
- `git diff --check`

## 独立审查

- 一轮全量审查与一轮定向复核完成，结论 `approve`，无遗留 finding、验证缺口或范围漂移。
- 审查中发现的 release note 正则误匹配、恢复路径执行历史 ref 脚本两项问题已修复并补回归。

## 恢复边界

如果 Maven bundle 已上传并产生 deployment ID，即使 workflow 等待超时，也必须先检查 deployment 与公共精确 URL；禁止重新运行 `mvn deploy`、移动 tag 或重传同版本。Central 目录索引 404 不能单独作为构件缺失结论。
