### PR TITLE
refactor(tools): 收敛 agent 任务看板查询

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -12,6 +12,7 @@
 | `test-vue3.sh` | Vue3 构建与产物检查 |
 | `test-docs.sh` | 文档站构建 |
 | `test-all.sh` | java + front-core + vue3 + docs |
+| `test-agent-status.sh` | 任务看板查询、过滤与失败路径 |
 
 ## 发布
 
@@ -24,10 +25,11 @@
 
 ## 任务看板
 
-`agent-status.sh` — 按 label 列 agent-task；`snapshot` 含 git / PR。
+`agent-status.sh` — 一次拉取 open `agent-task` 后按 status label 展示；`snapshot` 另含 git、当前 PR 与 checks。仓库依次取 `GH_REPO`、`GITHUB_REPOSITORY`、当前 `gh repo view`；查询失败时返回非零，不把失败显示为 `(none)`。
 
 ```bash
 ./tools/agent-status.sh snapshot
+./tools/test-agent-status.sh
 ```
 
 ## 截图上传

--- a/tools/agent-status.sh
+++ b/tools/agent-status.sh
@@ -78,9 +78,19 @@ print_git_snapshot() {
 }
 
 print_pr_snapshot() {
-  local branch head current_pr pr_jq
+  local branch checkout_head head current_pr pr_jq
   branch="${GITHUB_HEAD_REF:-$(git branch --show-current)}"
-  head="$(git rev-parse HEAD)"
+  checkout_head="$(git rev-parse HEAD)"
+  head="$checkout_head"
+
+  # GitHub pull_request workflows normally check out refs/pull/<n>/merge.
+  # Match the PR's source commit, not the synthetic merge commit in GITHUB_SHA.
+  if [[ "${GITHUB_REF:-}" =~ ^refs/pull/[0-9]+/merge$ ]] \
+    && [ -n "${GITHUB_HEAD_REF:-}" ] \
+    && [ -n "${GITHUB_SHA:-}" ] \
+    && [ "$checkout_head" = "$GITHUB_SHA" ]; then
+    head="$(git rev-parse HEAD^2)"
+  fi
 
   echo
   echo "=== github snapshot ==="

--- a/tools/agent-status.sh
+++ b/tools/agent-status.sh
@@ -89,7 +89,11 @@ print_pr_snapshot() {
     && [ -n "${GITHUB_HEAD_REF:-}" ] \
     && [ -n "${GITHUB_SHA:-}" ] \
     && [ "$checkout_head" = "$GITHUB_SHA" ]; then
-    head="$(git rev-parse HEAD^2)"
+    head="$(git cat-file -p HEAD | awk '$1 == "parent" { count++; if (count == 2) print $2 }')"
+    [ -n "$head" ] || {
+      echo "Unable to resolve pull request head from merge commit." >&2
+      exit 1
+    }
   fi
 
   echo

--- a/tools/agent-status.sh
+++ b/tools/agent-status.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# agent-status.sh — 查看 GitHub Issues 驱动的任务看板
 # 用法: ./tools/agent-status.sh [ready|in-progress|review|blocked|all|snapshot]
-# 仓库：GH_REPO / GITHUB_REPOSITORY → gh repo view → 默认 songxychn/knife4j-next
 
 set -euo pipefail
+
+mode="${1:-all}"
+case "$mode" in
+  ready|in-progress|review|blocked|all|snapshot) ;;
+  *)
+    echo "Usage: $0 [ready|in-progress|review|blocked|all|snapshot]" >&2
+    exit 2
+    ;;
+esac
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "GitHub CLI 'gh' is required." >&2
@@ -11,112 +18,103 @@ if ! command -v gh >/dev/null 2>&1; then
 fi
 
 if [ -n "${GH_REPO:-}" ]; then
-  REPO="$GH_REPO"
+  repo="$GH_REPO"
 elif [ -n "${GITHUB_REPOSITORY:-}" ]; then
-  REPO="$GITHUB_REPOSITORY"
+  repo="$GITHUB_REPOSITORY"
 else
-  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+  repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
 fi
-REPO="${REPO:-songxychn/knife4j-next}"
-STATUS="${1:-all}"
+[ -n "$repo" ] || { echo "Unable to resolve GitHub repository." >&2; exit 1; }
 
-# 颜色
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-RED='\033[0;31m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
-
-status_color() {
-  case "$1" in
-    ready)        echo -e "$GREEN" ;;
-    in-progress)  echo -e "$YELLOW" ;;
-    review)       echo -e "$BLUE" ;;
-    blocked)      echo -e "$RED" ;;
-    *)            echo -e "$CYAN" ;;
-  esac
-}
+issues_tsv="$(
+  gh issue list \
+    --repo "$repo" \
+    --label agent-task \
+    --state open \
+    --limit 1000 \
+    --json number,title,labels \
+    --jq '.[] | [.number, .title, ([.labels[].name | select(startswith("status:"))][0] // ""), ([.labels[].name | select(startswith("area:"))] | join(","))] | @tsv'
+)"
 
 print_status_group() {
-  local st="$1"
-  local color
-  color=$(status_color "$st")
-  echo -e "\n${color}━━━ status:${st} ━━━${NC}"
+  local status=$1
+  local found=false
+  local number title status_label area
 
-  local issues
-  issues=$(gh issue list --repo "$REPO" --label "agent-task" --label "status:${st}" --state open --json number,title,labels --jq '.[] | "\(.number)|\(.title)|\([.labels[].name | select(startswith("area:"))] | join(","))"' 2>/dev/null || true)
+  printf '\n=== status:%s ===\n' "$status"
+  while IFS=$'\t' read -r number title status_label area; do
+    [ -n "$number" ] || continue
+    [ "$status_label" = "status:$status" ] || continue
+    found=true
+    printf '  #%-4s %-20s %s\n' "$number" "[${area:-?}]" "$title"
+  done <<< "$issues_tsv"
 
-  if [ -z "$issues" ]; then
+  if [ "$found" = false ]; then
     echo "  (none)"
-    return
   fi
-
-  while IFS='|' read -r num title area; do
-    printf "  #%-4s %-8s %s\n" "$num" "[${area:-?}]" "$title"
-  done <<< "$issues"
 }
 
 print_git_snapshot() {
-  echo -e "${CYAN}━━━ git snapshot ━━━${NC}"
-  echo "repo: $REPO"
+  local branch head worktree
+  branch="$(git branch --show-current)"
+  head="$(git rev-parse --short HEAD)"
+  worktree="$(git status --short)"
 
-  local branch
-  branch=$(git branch --show-current 2>/dev/null || true)
-  if [ -z "$branch" ]; then
-    branch="(detached HEAD)"
-  fi
-  echo "branch: $branch"
-
-  local head
-  head=$(git rev-parse --short HEAD 2>/dev/null || true)
-  echo "head: ${head:-unknown}"
-
-  local status
-  status=$(git status --short 2>/dev/null || true)
-  if [ -z "$status" ]; then
+  echo "=== git snapshot ==="
+  echo "repo: $repo"
+  echo "branch: ${branch:-(detached HEAD)}"
+  echo "head: $head"
+  if [ -z "$worktree" ]; then
     echo "worktree: clean"
   else
     echo "worktree:"
-    echo "$status" | sed 's/^/  /'
+    printf '%s\n' "$worktree" | sed 's/^/  /'
   fi
 }
 
 print_pr_snapshot() {
-  echo -e "\n${CYAN}━━━ github snapshot ━━━${NC}"
+  local branch current_pr
+  branch="$(git branch --show-current)"
 
-  local current_pr
-  current_pr=$(gh pr view --repo "$REPO" --json number,title,state,url --jq '"#\(.number) \(.state) \(.title) \(.url)"' 2>/dev/null || true)
-  if [ -n "$current_pr" ]; then
-    echo "current PR: $current_pr"
-    echo "checks:"
-    gh pr checks --repo "$REPO" 2>/dev/null | sed 's/^/  /' || true
-  else
+  echo
+  echo "=== github snapshot ==="
+  if [ -z "$branch" ]; then
+    echo "current PR: (none for detached HEAD)"
+    return
+  fi
+
+  current_pr="$(
+    gh pr list \
+      --repo "$repo" \
+      --head "$branch" \
+      --state all \
+      --limit 1 \
+      --json number,title,state,url,statusCheckRollup \
+      --jq '.[0] | if . == null then empty else "#\(.number) \(.state) \(.title) \(.url)\n" + ((.statusCheckRollup // []) | map(if .__typename == "CheckRun" then "  \(.name): " + (if .status != "COMPLETED" then (.status | ascii_downcase) else ((.conclusion // "UNKNOWN") | ascii_downcase) end) else "  \(.context): \((.state // "UNKNOWN") | ascii_downcase)" end) | join("\n")) end'
+  )"
+
+  if [ -z "$current_pr" ]; then
     echo "current PR: (none for current branch)"
+  else
+    echo "current PR:"
+    printf '%s\n' "$current_pr" | sed 's/^/  /'
   fi
 }
 
-print_snapshot() {
-  print_git_snapshot
-  print_pr_snapshot
-  print_status_group "in-progress"
-  print_status_group "ready"
-}
-
-if [ "$STATUS" = "all" ]; then
-  echo -e "${CYAN}📋 knife4j-next Agent Task Board (${REPO})${NC}"
-  for st in ready in-progress review blocked; do
-    print_status_group "$st"
-  done
-  echo ""
-  echo "Quick commands:"
-  echo "  ./tools/agent-status.sh snapshot"
-  echo "  gh issue edit <N> --repo ${REPO} --remove-label status:ready --add-label status:in-progress --add-assignee @me"
-  echo "  gh issue edit <N> --repo ${REPO} --remove-label status:in-progress --add-label status:review"
-  echo "  gh issue comment <N> --repo ${REPO} --body 'progress update'"
-  echo "  gh issue close <N> --repo ${REPO}"
-elif [ "$STATUS" = "snapshot" ]; then
-  print_snapshot
-else
-  print_status_group "$STATUS"
-fi
+case "$mode" in
+  all)
+    echo "knife4j-next Agent Task Board ($repo)"
+    for status in ready in-progress review blocked; do
+      print_status_group "$status"
+    done
+    ;;
+  snapshot)
+    print_git_snapshot
+    print_pr_snapshot
+    print_status_group in-progress
+    print_status_group ready
+    ;;
+  *)
+    print_status_group "$mode"
+    ;;
+esac

--- a/tools/agent-status.sh
+++ b/tools/agent-status.sh
@@ -79,7 +79,7 @@ print_git_snapshot() {
 
 print_pr_snapshot() {
   local branch head current_pr pr_jq
-  branch="$(git branch --show-current)"
+  branch="${GITHUB_HEAD_REF:-$(git branch --show-current)}"
   head="$(git rev-parse HEAD)"
 
   echo

--- a/tools/agent-status.sh
+++ b/tools/agent-status.sh
@@ -3,6 +3,11 @@
 
 set -euo pipefail
 
+if [ "$#" -gt 1 ] || { [ "$#" -eq 1 ] && [ -z "$1" ]; }; then
+  echo "Usage: $0 [ready|in-progress|review|blocked|all|snapshot]" >&2
+  exit 2
+fi
+
 mode="${1:-all}"
 case "$mode" in
   ready|in-progress|review|blocked|all|snapshot) ;;
@@ -33,7 +38,7 @@ issues_tsv="$(
     --state open \
     --limit 1000 \
     --json number,title,labels \
-    --jq '.[] | [.number, .title, ([.labels[].name | select(startswith("status:"))][0] // ""), ([.labels[].name | select(startswith("area:"))] | join(","))] | @tsv'
+    --jq '.[] | . as $issue | ([.labels[].name | select(startswith("area:"))] | join(",")) as $areas | .labels[].name | select(startswith("status:")) | "\($issue.number)\u001f\($issue.title)\u001f\(.)\u001f\($areas)"'
 )"
 
 print_status_group() {
@@ -42,7 +47,7 @@ print_status_group() {
   local number title status_label area
 
   printf '\n=== status:%s ===\n' "$status"
-  while IFS=$'\t' read -r number title status_label area; do
+  while IFS=$'\x1f' read -r number title status_label area; do
     [ -n "$number" ] || continue
     [ "$status_label" = "status:$status" ] || continue
     found=true
@@ -73,8 +78,9 @@ print_git_snapshot() {
 }
 
 print_pr_snapshot() {
-  local branch current_pr
+  local branch head current_pr pr_jq
   branch="$(git branch --show-current)"
+  head="$(git rev-parse HEAD)"
 
   echo
   echo "=== github snapshot ==="
@@ -83,18 +89,19 @@ print_pr_snapshot() {
     return
   fi
 
+  pr_jq='map(select(.headRefOid == "'"$head"'")) | .[0] | if . == null then empty else "#\(.number) \(.state) \(.title) \(.url)\n" + ((.statusCheckRollup // []) | map(if .__typename == "CheckRun" then "  \(.name): " + (if .status != "COMPLETED" then (.status | ascii_downcase) else ((.conclusion // "UNKNOWN") | ascii_downcase) end) else "  \(.context): \((.state // "UNKNOWN") | ascii_downcase)" end) | join("\n")) end'
   current_pr="$(
     gh pr list \
       --repo "$repo" \
       --head "$branch" \
       --state all \
-      --limit 1 \
-      --json number,title,state,url,statusCheckRollup \
-      --jq '.[0] | if . == null then empty else "#\(.number) \(.state) \(.title) \(.url)\n" + ((.statusCheckRollup // []) | map(if .__typename == "CheckRun" then "  \(.name): " + (if .status != "COMPLETED" then (.status | ascii_downcase) else ((.conclusion // "UNKNOWN") | ascii_downcase) end) else "  \(.context): \((.state // "UNKNOWN") | ascii_downcase)" end) | join("\n")) end'
+      --limit 100 \
+      --json number,title,state,url,headRefOid,statusCheckRollup \
+      --jq "$pr_jq"
   )"
 
   if [ -z "$current_pr" ]; then
-    echo "current PR: (none for current branch)"
+    echo "current PR: (none for current head)"
   else
     echo "current PR:"
     printf '%s\n' "$current_pr" | sed 's/^/  /'

--- a/tools/ci-changes.sh
+++ b/tools/ci-changes.sh
@@ -37,7 +37,7 @@ while IFS= read -r path || [ -n "$path" ]; do
     .github/workflows/*|.bun-version|.editorconfig|.gitattributes|.nvmrc|tools/ci-changes.sh|tools/test-ci-changes.sh)
       full=true
       ;;
-    README.md|CONTRIBUTING.md|AGENTS.md|.agent/*|.gitignore|tools/README.md|tools/agent-status.sh|tools/claude/*|tools/test-all.sh|tools/verify-github-release.sh)
+    README.md|CONTRIBUTING.md|AGENTS.md|.agent/*|.gitignore|tools/README.md|tools/agent-status.sh|tools/test-agent-status.sh|tools/test-fixtures/agent-status/*|tools/claude/*|tools/test-all.sh|tools/verify-github-release.sh)
       ;;
     *)
       full=true

--- a/tools/test-agent-status.sh
+++ b/tools/test-agent-status.sh
@@ -12,6 +12,7 @@ ln -s "$fixture" "$tmp_dir/bin/gh"
 export PATH="$tmp_dir/bin:$PATH"
 export FAKE_GH_LOG="$tmp_dir/gh.log"
 export GH_REPO="test/repo"
+export GITHUB_HEAD_REF="fixture-branch"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -103,6 +104,7 @@ assert_contains "$output" "Working task"
 assert_contains "$output" "Ready task"
 assert_calls "issue list" 1
 assert_calls "pr list" 1
+assert_log_contains "--head fixture-branch"
 assert_log_contains "headRefOid"
 assert_log_contains "$(git rev-parse HEAD)"
 

--- a/tools/test-agent-status.sh
+++ b/tools/test-agent-status.sh
@@ -56,7 +56,7 @@ assert_log_contains() {
 
 reset_fake() {
   : > "$FAKE_GH_LOG"
-  unset FAKE_REPO_FAIL FAKE_ISSUE_FAIL FAKE_PR_FAIL FAKE_PR
+  unset FAKE_REPO_FAIL FAKE_ISSUE_FAIL FAKE_PR_FAIL FAKE_PR FAKE_EXPECT_PR_HEAD
 }
 
 assert_invalid() {
@@ -97,6 +97,7 @@ assert_calls "issue list" 1
 
 reset_fake
 export FAKE_PR=$'#42 OPEN Agent status PR https://example.test/pr/42\n  changes: success'
+export FAKE_EXPECT_PR_HEAD="$(git rev-parse HEAD)"
 output="$("$subject" snapshot)"
 assert_contains "$output" "git snapshot"
 assert_contains "$output" "#42 OPEN Agent status PR"
@@ -107,6 +108,38 @@ assert_calls "pr list" 1
 assert_log_contains "--head fixture-branch"
 assert_log_contains "headRefOid"
 assert_log_contains "$(git rev-parse HEAD)"
+
+detached_repo="$tmp_dir/detached-repo"
+git -C "$tmp_dir" init -q -b base detached-repo
+git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+  commit -q --allow-empty -m base
+git -C "$detached_repo" switch -q -c fixture-branch
+git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+  commit -q --allow-empty -m head
+pr_head="$(git -C "$detached_repo" rev-parse HEAD)"
+git -C "$detached_repo" switch -q base
+git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+  commit -q --allow-empty -m base-advance
+git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+  merge -q --no-ff fixture-branch -m synthetic-pr-merge
+merge_head="$(git -C "$detached_repo" rev-parse HEAD)"
+git -C "$detached_repo" switch -q --detach "$merge_head"
+
+reset_fake
+export FAKE_PR=$'#42 OPEN Detached PR https://example.test/pr/42\n  changes: success'
+export FAKE_EXPECT_PR_HEAD="$pr_head"
+output="$({
+  cd "$detached_repo"
+  GITHUB_HEAD_REF=fixture-branch \
+    GITHUB_REF=refs/pull/42/merge \
+    GITHUB_SHA="$merge_head" \
+    "$subject" snapshot
+})"
+assert_contains "$output" "branch: (detached HEAD)"
+assert_contains "$output" "#42 OPEN Detached PR"
+assert_log_contains "--head fixture-branch"
+assert_log_contains "$pr_head"
+assert_not_contains "$(cat "$FAKE_GH_LOG")" "$merge_head"
 
 reset_fake
 output="$("$subject" snapshot)"

--- a/tools/test-agent-status.sh
+++ b/tools/test-agent-status.sh
@@ -109,21 +109,28 @@ assert_log_contains "--head fixture-branch"
 assert_log_contains "headRefOid"
 assert_log_contains "$(git rev-parse HEAD)"
 
-detached_repo="$tmp_dir/detached-repo"
-git -C "$tmp_dir" init -q -b base detached-repo
-git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+merge_source="$tmp_dir/merge-source"
+git -C "$tmp_dir" init -q -b base merge-source
+git -C "$merge_source" -c user.name=Agent -c user.email=agent@example.test \
   commit -q --allow-empty -m base
-git -C "$detached_repo" switch -q -c fixture-branch
-git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+git -C "$merge_source" switch -q -c fixture-branch
+git -C "$merge_source" -c user.name=Agent -c user.email=agent@example.test \
   commit -q --allow-empty -m head
-pr_head="$(git -C "$detached_repo" rev-parse HEAD)"
-git -C "$detached_repo" switch -q base
-git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+pr_head="$(git -C "$merge_source" rev-parse HEAD)"
+git -C "$merge_source" switch -q base
+git -C "$merge_source" -c user.name=Agent -c user.email=agent@example.test \
   commit -q --allow-empty -m base-advance
-git -C "$detached_repo" -c user.name=Agent -c user.email=agent@example.test \
+git -C "$merge_source" -c user.name=Agent -c user.email=agent@example.test \
   merge -q --no-ff fixture-branch -m synthetic-pr-merge
-merge_head="$(git -C "$detached_repo" rev-parse HEAD)"
-git -C "$detached_repo" switch -q --detach "$merge_head"
+merge_head="$(git -C "$merge_source" rev-parse HEAD)"
+
+detached_repo="$tmp_dir/detached-repo"
+git init -q "$detached_repo"
+git -C "$detached_repo" fetch -q --depth=1 "file://$merge_source" "$merge_head"
+git -C "$detached_repo" switch -q --detach FETCH_HEAD
+if git -C "$detached_repo" rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+  fail "detached fixture should not resolve HEAD^2 in a depth-1 checkout"
+fi
 
 reset_fake
 export FAKE_PR=$'#42 OPEN Detached PR https://example.test/pr/42\n  changes: success'

--- a/tools/test-agent-status.sh
+++ b/tools/test-agent-status.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+subject="$repo_root/tools/agent-status.sh"
+fixture="$repo_root/tools/test-fixtures/agent-status/gh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+ln -s "$fixture" "$tmp_dir/bin/gh"
+export PATH="$tmp_dir/bin:$PATH"
+export FAKE_GH_LOG="$tmp_dir/gh.log"
+export GH_REPO="test/repo"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  case "$1" in
+    *"$2"*) ;;
+    *) fail "expected output to contain: $2" ;;
+  esac
+}
+
+assert_not_contains() {
+  case "$1" in
+    *"$2"*) fail "expected output not to contain: $2" ;;
+    *) ;;
+  esac
+}
+
+assert_calls() {
+  local prefix=$1
+  local expected=$2
+  local actual
+  actual="$(awk -v prefix="$prefix" 'index($0, prefix) == 1 { count++ } END { print count + 0 }' "$FAKE_GH_LOG")"
+  [ "$actual" = "$expected" ] || fail "expected $expected '$prefix' calls, got $actual"
+}
+
+reset_fake() {
+  : > "$FAKE_GH_LOG"
+  unset FAKE_REPO_FAIL FAKE_ISSUE_FAIL FAKE_PR_FAIL FAKE_PR
+}
+
+export FAKE_ISSUES=$'1\tReady task\tstatus:ready\tarea:java\n2\tWorking task\tstatus:in-progress\tarea:ui-react\n3\tBlocked task\tstatus:blocked\t'
+
+reset_fake
+output="$("$subject" all)"
+assert_contains "$output" "#1"
+assert_contains "$output" "Ready task"
+assert_contains "$output" "Working task"
+assert_contains "$output" "Blocked task"
+assert_contains "$output" "status:review"
+assert_calls "issue list" 1
+assert_calls "repo view" 0
+
+reset_fake
+output="$("$subject" ready)"
+assert_contains "$output" "Ready task"
+assert_not_contains "$output" "Blocked task"
+assert_calls "issue list" 1
+
+reset_fake
+export FAKE_PR=$'#42 OPEN Agent status PR https://example.test/pr/42\n  changes: success'
+output="$("$subject" snapshot)"
+assert_contains "$output" "git snapshot"
+assert_contains "$output" "#42 OPEN Agent status PR"
+assert_contains "$output" "Working task"
+assert_contains "$output" "Ready task"
+assert_calls "issue list" 1
+assert_calls "pr list" 1
+
+reset_fake
+set +e
+output="$("$subject" invalid 2>&1)"
+status=$?
+set -e
+[ "$status" = 2 ] || fail "invalid mode should exit 2, got $status"
+assert_contains "$output" "Usage:"
+assert_calls "issue list" 0
+
+reset_fake
+export FAKE_ISSUE_FAIL=true
+set +e
+output="$("$subject" all 2>&1)"
+status=$?
+set -e
+[ "$status" != 0 ] || fail "issue query failure should be non-zero"
+assert_contains "$output" "fake issue failure"
+assert_not_contains "$output" "(none)"
+
+reset_fake
+unset GH_REPO GITHUB_REPOSITORY
+export FAKE_REPO_FAIL=true
+set +e
+output="$("$subject" all 2>&1)"
+status=$?
+set -e
+[ "$status" != 0 ] || fail "repo resolution failure should be non-zero"
+assert_contains "$output" "fake repo failure"
+assert_calls "repo view" 1
+
+printf 'agent status tests passed\n'

--- a/tools/test-agent-status.sh
+++ b/tools/test-agent-status.sh
@@ -40,12 +40,38 @@ assert_calls() {
   [ "$actual" = "$expected" ] || fail "expected $expected '$prefix' calls, got $actual"
 }
 
+assert_occurrences() {
+  local text=$1
+  local needle=$2
+  local expected=$3
+  local actual
+  actual="$(printf '%s\n' "$text" | awk -v needle="$needle" 'index($0, needle) { count++ } END { print count + 0 }')"
+  [ "$actual" = "$expected" ] || fail "expected $expected '$needle' occurrences, got $actual"
+}
+
+assert_log_contains() {
+  assert_contains "$(cat "$FAKE_GH_LOG")" "$1"
+}
+
 reset_fake() {
   : > "$FAKE_GH_LOG"
   unset FAKE_REPO_FAIL FAKE_ISSUE_FAIL FAKE_PR_FAIL FAKE_PR
 }
 
-export FAKE_ISSUES=$'1\tReady task\tstatus:ready\tarea:java\n2\tWorking task\tstatus:in-progress\tarea:ui-react\n3\tBlocked task\tstatus:blocked\t'
+assert_invalid() {
+  local output status
+  reset_fake
+  set +e
+  output="$("$subject" "$@" 2>&1)"
+  status=$?
+  set -e
+  [ "$status" = 2 ] || fail "invalid arguments should exit 2, got $status"
+  assert_contains "$output" "Usage:"
+  assert_calls "repo view" 0
+  assert_calls "issue list" 0
+}
+
+export FAKE_ISSUES=$'1\x1fReady task\x1fstatus:ready\x1farea:java\n2\x1fWorking task\x1fstatus:in-progress\x1farea:ui-react\n3\x1fBlocked task\x1fstatus:blocked\x1f\n4\x1fDual status\x1fstatus:ready\x1farea:java\n4\x1fDual status\x1fstatus:blocked\x1farea:java\n5\x1fPath C:\\tmp\x1fstatus:review\x1farea:docs'
 
 reset_fake
 output="$("$subject" all)"
@@ -53,13 +79,18 @@ assert_contains "$output" "#1"
 assert_contains "$output" "Ready task"
 assert_contains "$output" "Working task"
 assert_contains "$output" "Blocked task"
+assert_occurrences "$output" "Dual status" 2
+assert_contains "$output" 'Path C:\tmp'
 assert_contains "$output" "status:review"
 assert_calls "issue list" 1
 assert_calls "repo view" 0
+assert_log_contains "--label agent-task"
+assert_log_contains "--state open"
 
 reset_fake
 output="$("$subject" ready)"
 assert_contains "$output" "Ready task"
+assert_contains "$output" "Dual status"
 assert_not_contains "$output" "Blocked task"
 assert_calls "issue list" 1
 
@@ -72,15 +103,27 @@ assert_contains "$output" "Working task"
 assert_contains "$output" "Ready task"
 assert_calls "issue list" 1
 assert_calls "pr list" 1
+assert_log_contains "headRefOid"
+assert_log_contains "$(git rev-parse HEAD)"
 
 reset_fake
+output="$("$subject" snapshot)"
+assert_contains "$output" "current PR: (none for current head)"
+assert_calls "pr list" 1
+
+reset_fake
+export FAKE_PR_FAIL=true
 set +e
-output="$("$subject" invalid 2>&1)"
+output="$("$subject" snapshot 2>&1)"
 status=$?
 set -e
-[ "$status" = 2 ] || fail "invalid mode should exit 2, got $status"
-assert_contains "$output" "Usage:"
-assert_calls "issue list" 0
+[ "$status" != 0 ] || fail "PR query failure should be non-zero"
+assert_contains "$output" "fake pr failure"
+assert_not_contains "$output" "none for current head"
+
+assert_invalid invalid
+assert_invalid ""
+assert_invalid ready unexpected
 
 reset_fake
 export FAKE_ISSUE_FAIL=true

--- a/tools/test-ci-changes.sh
+++ b/tools/test-ci-changes.sh
@@ -45,7 +45,7 @@ assert_case "vue3" "$vue3_and_java" $'front/vue3/src/App.vue\ntools/test-vue3.sh
 assert_case "knife4x go" "$knife4x_only" $'knife4x/go/README.md\nknife4x/examples/gin/main.go\ntools/sync-knife4x-ui.sh\ntools/test-knife4x-go.sh'
 assert_case "shared configuration" "$all" $'.github/workflows/build.yml\n.bun-version\n.editorconfig\n.gitattributes\n.nvmrc\ntools/ci-changes.sh\ntools/test-ci-changes.sh'
 assert_case "unknown path" "$all" "new-area/example.txt"
-assert_case "maintenance files" "$none" $'README.md\nCONTRIBUTING.md\nAGENTS.md\n.agent/PROJECT.md\n.gitignore\ntools/README.md\ntools/agent-status.sh\ntools/claude/run.sh\ntools/test-all.sh\ntools/verify-github-release.sh'
+assert_case "maintenance files" "$none" $'README.md\nCONTRIBUTING.md\nAGENTS.md\n.agent/PROJECT.md\n.gitignore\ntools/README.md\ntools/agent-status.sh\ntools/test-agent-status.sh\ntools/test-fixtures/agent-status/gh\ntools/claude/run.sh\ntools/test-all.sh\ntools/verify-github-release.sh'
 assert_case "empty input" "$all" "__EMPTY__"
 
 printf 'ci change classification tests passed\n'

--- a/tools/test-fixtures/agent-status/gh
+++ b/tools/test-fixtures/agent-status/gh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${FAKE_GH_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+fi
+
+case "${1:-} ${2:-}" in
+  "repo view")
+    if [ "${FAKE_REPO_FAIL:-false}" = true ]; then
+      echo "fake repo failure" >&2
+      exit 1
+    fi
+    printf '%s\n' "${FAKE_REPO:-test/repo}"
+    ;;
+  "issue list")
+    if [ "${FAKE_ISSUE_FAIL:-false}" = true ]; then
+      echo "fake issue failure" >&2
+      exit 1
+    fi
+    printf '%s' "${FAKE_ISSUES:-}"
+    ;;
+  "pr list")
+    if [ "${FAKE_PR_FAIL:-false}" = true ]; then
+      echo "fake pr failure" >&2
+      exit 1
+    fi
+    printf '%s' "${FAKE_PR:-}"
+    ;;
+  *)
+    echo "unexpected gh call: $*" >&2
+    exit 64
+    ;;
+esac

--- a/tools/test-fixtures/agent-status/gh
+++ b/tools/test-fixtures/agent-status/gh
@@ -25,6 +25,12 @@ case "${1:-} ${2:-}" in
       echo "fake pr failure" >&2
       exit 1
     fi
+    if [ -n "${FAKE_EXPECT_PR_HEAD:-}" ]; then
+      case "$*" in
+        *"$FAKE_EXPECT_PR_HEAD"*) ;;
+        *) exit 0 ;;
+      esac
+    fi
     printf '%s' "${FAKE_PR:-}"
     ;;
   *)


### PR DESCRIPTION
## 背景

维护者现场要求继续收敛仓库的 agent 基建；本 PR 聚焦 `tools/agent-status.sh`，没有关联 issue。

## 改动

- 有效运行只获取一次全部开放的 `agent-task` issue，再在本地按状态分组
- 保留 `ready|in-progress|review|blocked|all|snapshot` 与默认 `all`，非法空参数、多参数或未知参数在联网前以退出码 2 拒绝
- 查询仓库、issue、PR 或 checks 失败时原样失败，不再伪装为 `(none)`
- 去掉颜色和快捷命令噪声，保留纯文本输出
- `snapshot` 仅显示当前 git 状态、精确匹配源提交 SHA 的 PR/checks，以及 in-progress/ready 任务
- 兼容 GitHub `pull_request` 的 detached synthetic merge 与 depth-1 shallow checkout：从当前 merge commit 原始 header 取得第二 parent，不依赖父提交对象存在
- 新增 fake `gh`、真实 shallow detached 仓库回归测试，并纳入维护类 CI 分类

## 契约与非目标

保留既有任务状态和入口；不修改 labels、状态机、产品代码，不引入守护进程或新依赖。

## 验证

- `bash -n tools/agent-status.sh tools/test-agent-status.sh tools/test-fixtures/agent-status/gh tools/ci-changes.sh tools/test-ci-changes.sh`
- `./tools/test-agent-status.sh`
- `./tools/test-ci-changes.sh`
- `git diff --check origin/master...HEAD`
- 真实 GitHub `all` 查询成功
- 真实 PR #720 attached snapshot 精确命中当前 head
- synthetic merge + depth-1 shallow + detached checkout：先确认 `HEAD^2` 不可解析，再由脚本精确命中 PR #720 与源提交 `0f56bb22`

## 独立审查

- 旧 head 全量审查发现多状态 label、参数边界、历史 PR 误命中、反斜杠保真 4 项问题，均已修复
- rebase 后按当前基线重新审查，继续发现 detached synthetic merge 与 shallow checkout 两个边界，均以追加提交和真实回归场景闭合
- 独立 reviewer 最终结论：`approve`
- 审查结论仅绑定当前 head `0f56bb22cd9b721da7942e7a90be2935e3588aac`

## 当前状态

- base: `3210384f5acc0506e550466ff6d593e9332dbebc`
- head: `0f56bb22cd9b721da7942e7a90be2935e3588aac`
- CI：`changes`、`java-build-test`、`front-core-test`、`knife4x-go-test`、`vue3-test`、`docs-build` 全部成功
- merge state：`CLEAN`