### PR TITLE
ci: 正式发布成功后再部署 Demo

### DIFF
--- a/.agent/RUNBOOK.md
+++ b/.agent/RUNBOOK.md
@@ -95,8 +95,8 @@ PR 至少写清：关联 issue、范围、验证命令与结果、风险。
 须维护者明确确认后再 tag。完成条件同时满足：
 
 - `vX.Y.Z` tag 已推送
-- `Release` workflow 成功
-- `Build and Deploy Demo` workflow 成功
+- `Release` workflow 的发布与公开制品核验 job 成功
+- 由 `Release` workflow 在核验成功后调用的 `Build and Deploy Demo` workflow 成功
 - Maven Central 目标构件可访问
 - GitHub Release 存在且 body 与 `docs/release-notes/index.md` 对应小节一致
 

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,20 +1,55 @@
 name: Build and Deploy Demo
 
-# Demo 只跟已发布版本对齐：master 合并不自动部署，避免线上 demo 跑到
-# 用户尚未能通过 Maven Central 拿到的未发版 master 代码。
-# 紧急手动部署仍可用 workflow_dispatch。
+# Demo 只部署已经完成公开制品核验的正式版本。Release workflow 是正常入口；
+# workflow_dispatch 只用于重新部署当前 latest release。
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: "Published vX.Y.Z tag to deploy"
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Current latest published vX.Y.Z tag to redeploy"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-demo-${{ inputs.tag }}
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
+  RELEASE_TAG: ${{ inputs.tag }}
 
 jobs:
+  verify-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Verify published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERIFY_GITHUB_RELEASE_REQUIRE_LATEST: true
+        run: |
+          release_notes="$RUNNER_TEMP/github-release-notes.md"
+          tools/verify-release-context.sh "$RELEASE_TAG" "$release_notes"
+          tools/verify-maven-central.sh "${RELEASE_TAG#v}"
+          tools/verify-github-release.sh "$RELEASE_TAG" "$release_notes"
+
   build-and-push:
+    needs: verify-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,7 +67,11 @@ jobs:
             image: knife4j-next-demo-openapi2
             context: knife4j/knife4j-demo-openapi2
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout exact release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - uses: actions/setup-java@v5
         with:
@@ -67,7 +106,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
       - name: Extract metadata
         id: meta
@@ -75,7 +114,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image }}
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
             type=raw,value=latest
 
       - name: Build and push image

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -31,11 +31,19 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
+    env:
+      RELEASE_ROOT: ${{ github.workspace }}/release-source
     steps:
-      - name: Checkout exact release tag
+      - name: Checkout current deployment tooling
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Checkout exact release tag source
         uses: actions/checkout@v7
         with:
           ref: ${{ env.RELEASE_TAG }}
+          path: release-source
           fetch-depth: 0
 
       - name: Verify published release
@@ -44,8 +52,10 @@ jobs:
           VERIFY_GITHUB_RELEASE_REQUIRE_LATEST: true
         run: |
           release_notes="$RUNNER_TEMP/github-release-notes.md"
-          tools/verify-release-context.sh "$RELEASE_TAG" "$release_notes"
-          tools/verify-maven-central.sh "${RELEASE_TAG#v}"
+          VERIFY_RELEASE_REPO_ROOT="$RELEASE_ROOT" \
+            tools/verify-release-context.sh "$RELEASE_TAG" "$release_notes"
+          VERIFY_MAVEN_REPO_ROOT="$RELEASE_ROOT" \
+            tools/verify-maven-central.sh "${RELEASE_TAG#v}"
           tools/verify-github-release.sh "$RELEASE_TAG" "$release_notes"
 
   build-and-push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,9 @@ jobs:
             gh release edit "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$title" \
-              --notes-file "$GITHUB_RELEASE_NOTES"
+              --notes-file "$GITHUB_RELEASE_NOTES" \
+              --draft=false \
+              --prerelease=false
           else
             gh release create "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
@@ -154,3 +156,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: tools/verify-github-release.sh "$RELEASE_TAG" "$GITHUB_RELEASE_NOTES"
         working-directory: .
+
+  deploy-demo:
+    needs: publish
+    if: ${{ needs.publish.result == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/deploy-demo.yml
+    with:
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}

--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -13,7 +13,7 @@ knife4j-next 提供两个并列的 demo 工程，分别覆盖两条独立的 UI 
 | `knife4j-demo-openapi3` | Spring Boot 4.0 + springdoc + `knife4j-openapi3-boot4-spring-boot-starter` | React（`knife4j-openapi3-ui`） | [https://openapi3.demo.knife4jnext.com/doc.html](https://openapi3.demo.knife4jnext.com/doc.html) |
 | `knife4j-demo-openapi2` | Spring Boot 2.7 + springfox 2.10.5 + `knife4j-openapi2-spring-boot-starter` | Vue 3（`knife4j-openapi2-ui`） | [https://openapi2.demo.knife4jnext.com/doc.html](https://openapi2.demo.knife4jnext.com/doc.html) |
 
-两个站点都跟随 `master` 分支自动构建与刷新，建议直接打开比对，看看 OpenAPI 3 主线和 OpenAPI 2 兼容维护线在 UI 上的差异。
+两个站点都跟随已经完成正式发布的最新稳定版；`master` 合并不会直接刷新线上环境。建议打开比对 OpenAPI 3 主线和 OpenAPI 2 兼容维护线在 UI 上的差异。
 
 如果访问失败，优先在本地跑一遍，避免把预览环境问题当成功能问题。
 
@@ -155,7 +155,7 @@ docker run --rm -p 8081:8081 \
 
 ## 镜像发布
 
-两个 demo 镜像都由 `.github/workflows/deploy-demo.yml` 在推送 `v*` 发布 tag 时通过 matrix 构建并推送到 GitHub Container Registry（`master` 合并不自动部署，保证在线 demo 与已发布版本一致；紧急情况可 `workflow_dispatch` 手动跑）：
+正式 `.github/workflows/release.yml` 会先核验发布 tag、Maven Central 公开制品与已经发布的 GitHub Release，再调用 `.github/workflows/deploy-demo.yml`，通过 matrix 构建并推送两个 demo 镜像。Demo 不再独立响应 `v*` tag；手工恢复必须显式填写当前 latest release 的 tag，旧版本不能回滚 `latest`：
 
 - `ghcr.io/songxychn/knife4j-next/knife4j-next-demo-openapi3:latest`
 - `ghcr.io/songxychn/knife4j-next/knife4j-next-demo-openapi2:latest`

--- a/tools/test-fixtures/mock-gh-release.sh
+++ b/tools/test-fixtures/mock-gh-release.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ] || [ "$1" != "release" ] || [ "$2" != "view" ]; then
+  echo "mock gh only supports: release view" >&2
+  exit 2
+fi
+shift 2
+
+requested_tag=""
+if [ "$#" -gt 0 ] && [[ "$1" != --* ]]; then
+  requested_tag="$1"
+  shift
+fi
+
+json_fields=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      json_fields="$2"
+      shift 2
+      ;;
+    --repo|--jq|--template)
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+state="${MOCK_GH_RELEASE_STATE:-published}"
+if [ "$state" = "missing" ]; then
+  exit 1
+fi
+
+case "$json_fields" in
+  tagName,isDraft,isPrerelease)
+    actual_tag="${MOCK_GH_RELEASE_TAG:-$requested_tag}"
+    is_draft=false
+    is_prerelease=false
+    case "$state" in
+      published)
+        ;;
+      draft)
+        is_draft=true
+        ;;
+      prerelease)
+        is_prerelease=true
+        ;;
+      *)
+        echo "unsupported MOCK_GH_RELEASE_STATE: $state" >&2
+        exit 2
+        ;;
+    esac
+    printf '%s\t%s\t%s\n' "$actual_tag" "$is_draft" "$is_prerelease"
+    ;;
+  tagName)
+    printf '%s\n' "${MOCK_GH_LATEST_TAG:-${MOCK_GH_RELEASE_TAG:-$requested_tag}}"
+    ;;
+  body)
+    if [ -n "${MOCK_GH_RELEASE_BODY_FILE:-}" ]; then
+      /bin/cat "$MOCK_GH_RELEASE_BODY_FILE"
+    fi
+    ;;
+  *)
+    echo "unsupported --json fields: $json_fields" >&2
+    exit 2
+    ;;
+esac

--- a/tools/test-knife4x-go.sh
+++ b/tools/test-knife4x-go.sh
@@ -31,7 +31,18 @@ assert_java_tag_filter() {
 }
 
 assert_java_tag_filter "$repo_root/.github/workflows/release.yml"
-assert_java_tag_filter "$repo_root/.github/workflows/deploy-demo.yml"
+
+demo_workflow="$repo_root/.github/workflows/deploy-demo.yml"
+if grep -Eq '^  push:' "$demo_workflow"; then
+  echo "Demo workflow must be called by the verified Java release instead of matching tags directly" >&2
+  exit 1
+fi
+for expected in '  workflow_call:' '  workflow_dispatch:' '  RELEASE_TAG: ${{ inputs.tag }}'; do
+  if ! grep -Fq -- "$expected" "$demo_workflow"; then
+    printf 'Demo workflow is missing explicit release-tag contract: %s\n' "$expected" >&2
+    exit 1
+  fi
+done
 
 case "knife4x/go/v0.1.0" in
   v*)

--- a/tools/test-release-tools.sh
+++ b/tools/test-release-tools.sh
@@ -4,8 +4,11 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 central_verifier="$repo_root/tools/verify-maven-central.sh"
 context_verifier="$repo_root/tools/verify-release-context.sh"
+github_verifier="$repo_root/tools/verify-github-release.sh"
 mock_curl="$repo_root/tools/test-fixtures/mock-maven-central-curl.sh"
+mock_gh="$repo_root/tools/test-fixtures/mock-gh-release.sh"
 workflow="$repo_root/.github/workflows/release.yml"
+demo_workflow="$repo_root/.github/workflows/deploy-demo.yml"
 pom_file="$repo_root/knife4j/pom.xml"
 tmp_root="$(mktemp -d)"
 trap 'rm -rf "$tmp_root"' EXIT
@@ -245,6 +248,64 @@ if ! env VERIFY_RELEASE_REPO_ROOT="$module_root" \
 fi
 assert_contains "$tmp_root/release-modules.log" "Release module list OK (1 modules)."
 
+expected_github_body="$tmp_root/expected-github-body.md"
+different_github_body="$tmp_root/different-github-body.md"
+printf '%s\n' 'expected release body' > "$expected_github_body"
+printf '%s\n' 'different release body' > "$different_github_body"
+
+github_status=0
+github_log=""
+
+run_github_verifier() {
+  local name="$1"
+  local state="$2"
+  local actual_tag="$3"
+  local latest_tag="$4"
+  local require_latest="$5"
+  local body_file="$6"
+
+  github_log="$tmp_root/$name-github.log"
+  set +e
+  env \
+    GITHUB_RELEASE_GH_BIN="$mock_gh" \
+    MOCK_GH_RELEASE_STATE="$state" \
+    MOCK_GH_RELEASE_TAG="$actual_tag" \
+    MOCK_GH_LATEST_TAG="$latest_tag" \
+    MOCK_GH_RELEASE_BODY_FILE="$body_file" \
+    VERIFY_GITHUB_RELEASE_REQUIRE_LATEST="$require_latest" \
+    "$github_verifier" v1.2.3 "$expected_github_body" example/repo \
+    > "$github_log" 2>&1
+  github_status=$?
+  set -e
+}
+
+run_github_verifier github-published published v1.2.3 v1.2.3 false "$expected_github_body"
+[ "$github_status" -eq 0 ] || fail "published GitHub Release should pass"
+assert_contains "$github_log" "GitHub Release OK: example/repo@v1.2.3"
+
+run_github_verifier github-draft draft v1.2.3 v1.2.3 false "$expected_github_body"
+[ "$github_status" -ne 0 ] || fail "draft GitHub Release should fail"
+assert_contains "$github_log" "is still a draft"
+
+run_github_verifier github-prerelease prerelease v1.2.3 v1.2.3 false "$expected_github_body"
+[ "$github_status" -ne 0 ] || fail "prerelease GitHub Release should fail"
+assert_contains "$github_log" "is a prerelease"
+
+run_github_verifier github-wrong-tag published v9.9.9 v9.9.9 false "$expected_github_body"
+[ "$github_status" -ne 0 ] || fail "mismatched GitHub Release tag should fail"
+assert_contains "$github_log" "tag mismatch"
+
+run_github_verifier github-old-release published v1.2.3 v2.0.0 true "$expected_github_body"
+[ "$github_status" -ne 0 ] || fail "non-latest GitHub Release should fail the deployment gate"
+assert_contains "$github_log" "current latest GitHub Release is v2.0.0"
+
+run_github_verifier github-latest published v1.2.3 v1.2.3 true "$expected_github_body"
+[ "$github_status" -eq 0 ] || fail "current latest GitHub Release should pass the deployment gate"
+
+run_github_verifier github-body-mismatch published v1.2.3 v1.2.3 false "$different_github_body"
+[ "$github_status" -ne 0 ] || fail "mismatched GitHub Release body should fail"
+assert_contains "$github_log" "body differs"
+
 assert_contains "$workflow" "mode:"
 assert_contains "$workflow" "finalize-only"
 assert_contains "$workflow" "tag:"
@@ -255,6 +316,48 @@ assert_contains "$workflow" "VERIFY_MAVEN_REPO_ROOT="
 assert_contains "$workflow" "tools/verify-release-context.sh"
 assert_contains "$workflow" "tools/verify-maven-central.sh"
 assert_not_contains "$workflow" '\$RELEASE_ROOT/tools/verify-release-modules.sh'
+assert_contains "$workflow" "  deploy-demo:"
+assert_contains "$workflow" "    needs: publish"
+assert_contains "$workflow" "    if: \${{ needs.publish.result == 'success' }}"
+assert_contains "$workflow" "    uses: ./.github/workflows/deploy-demo.yml"
+assert_contains "$workflow" "      tag: \${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+assert_not_contains "$workflow" "    secrets: inherit"
+assert_contains "$workflow" "              --draft=false \\"
+assert_contains "$workflow" "              --prerelease=false"
+
+if grep -Eq '^  push:' "$demo_workflow"; then
+  fail "demo workflow must not trigger independently from a pushed tag"
+fi
+assert_contains "$demo_workflow" "  workflow_call:"
+assert_contains "$demo_workflow" "  workflow_dispatch:"
+assert_contains "$demo_workflow" "  RELEASE_TAG: \${{ inputs.tag }}"
+assert_contains "$demo_workflow" "          ref: \${{ env.RELEASE_TAG }}"
+assert_contains "$demo_workflow" "          fetch-depth: 0"
+assert_contains "$demo_workflow" "  verify-release:"
+assert_contains "$demo_workflow" "    timeout-minutes: 45"
+assert_contains "$demo_workflow" "          VERIFY_GITHUB_RELEASE_REQUIRE_LATEST: true"
+assert_contains "$demo_workflow" "          tools/verify-release-context.sh"
+assert_contains "$demo_workflow" "          tools/verify-maven-central.sh"
+assert_contains "$demo_workflow" "          tools/verify-github-release.sh"
+assert_contains "$demo_workflow" "    needs: verify-release"
+assert_contains "$demo_workflow" '            type=semver,pattern={{version}},value=${{ inputs.tag }}'
+assert_contains "$demo_workflow" "          password: \${{ github.token }}"
+assert_not_contains "$demo_workflow" "secrets.GITHUB_TOKEN"
+
+required_tag_inputs="$(grep -c -F -- '        required: true' "$demo_workflow")"
+[ "$required_tag_inputs" -eq 2 ] || fail "demo workflow must require a tag for both workflow_call and workflow_dispatch"
+
+demo_context_line="$(awk 'index($0, "tools/verify-release-context.sh") { print NR; exit }' "$demo_workflow")"
+demo_central_line="$(awk 'index($0, "tools/verify-maven-central.sh") { print NR; exit }' "$demo_workflow")"
+demo_github_line="$(awk 'index($0, "tools/verify-github-release.sh") { print NR; exit }' "$demo_workflow")"
+demo_build_line="$(awk '/^  build-and-push:/ { print NR; exit }' "$demo_workflow")"
+if [ -z "$demo_context_line" ] || [ -z "$demo_central_line" ] || \
+  [ -z "$demo_github_line" ] || [ -z "$demo_build_line" ] || \
+  [ "$demo_context_line" -ge "$demo_central_line" ] || \
+  [ "$demo_central_line" -ge "$demo_github_line" ] || \
+  [ "$demo_github_line" -ge "$demo_build_line" ]; then
+  fail "demo must verify tag, Central and published GitHub Release before building images"
+fi
 
 context_line="$(awk 'index($0, "tools/verify-release-context.sh") { print NR; exit }' "$workflow")"
 modules_line="$(awk 'index($0, "tools/verify-release-modules.sh") { print NR; exit }' "$workflow")"

--- a/tools/test-release-tools.sh
+++ b/tools/test-release-tools.sh
@@ -56,6 +56,8 @@ printf '%s\n' '<project>' '<artifactId>api</artifactId>' '</project>' > "$fixtur
 printf '%s\n' '<project>' '<artifactId>bom</artifactId>' '<packaging>pom</packaging>' '</project>' > "$fixture_root/knife4j/bom/pom.xml"
 printf '%s\n' '<project>' '<artifactId>knife4j-test-ui</artifactId>' '</project>' > "$fixture_root/knife4j/knife4j-test-ui/pom.xml"
 printf '%s\n' api bom knife4j-test-ui > "$fixture_root/tools/release-modules.txt"
+[ ! -e "$fixture_root/tools/verify-maven-central.sh" ] || \
+  fail "legacy release fixture must not contain the current Central verifier"
 
 jar_payload="$tmp_root/jar-payload"
 valid_jar="$tmp_root/valid.jar"
@@ -183,6 +185,8 @@ run_context() {
 }
 
 context_root="$(make_context_repo success 1.2.3 1.2.3 annotated)"
+[ ! -e "$context_root/tools/verify-release-context.sh" ] || \
+  fail "legacy release fixture must not contain the current context verifier"
 run_context context-success "$context_root" v1.2.3
 [ "$context_status" -eq 0 ] || fail "valid release context should pass"
 assert_contains "$context_output" "## 1.2.3"
@@ -331,11 +335,18 @@ fi
 assert_contains "$demo_workflow" "  workflow_call:"
 assert_contains "$demo_workflow" "  workflow_dispatch:"
 assert_contains "$demo_workflow" "  RELEASE_TAG: \${{ inputs.tag }}"
+assert_contains "$demo_workflow" "      RELEASE_ROOT: \${{ github.workspace }}/release-source"
+assert_contains "$demo_workflow" "      - name: Checkout current deployment tooling"
+assert_contains "$demo_workflow" "          ref: \${{ github.sha }}"
+assert_contains "$demo_workflow" "      - name: Checkout exact release tag source"
 assert_contains "$demo_workflow" "          ref: \${{ env.RELEASE_TAG }}"
+assert_contains "$demo_workflow" "          path: release-source"
 assert_contains "$demo_workflow" "          fetch-depth: 0"
 assert_contains "$demo_workflow" "  verify-release:"
 assert_contains "$demo_workflow" "    timeout-minutes: 45"
 assert_contains "$demo_workflow" "          VERIFY_GITHUB_RELEASE_REQUIRE_LATEST: true"
+assert_contains "$demo_workflow" "          VERIFY_RELEASE_REPO_ROOT=\"\$RELEASE_ROOT\" \\"
+assert_contains "$demo_workflow" "          VERIFY_MAVEN_REPO_ROOT=\"\$RELEASE_ROOT\" \\"
 assert_contains "$demo_workflow" "          tools/verify-release-context.sh"
 assert_contains "$demo_workflow" "          tools/verify-maven-central.sh"
 assert_contains "$demo_workflow" "          tools/verify-github-release.sh"
@@ -346,6 +357,19 @@ assert_not_contains "$demo_workflow" "secrets.GITHUB_TOKEN"
 
 required_tag_inputs="$(grep -c -F -- '        required: true' "$demo_workflow")"
 [ "$required_tag_inputs" -eq 2 ] || fail "demo workflow must require a tag for both workflow_call and workflow_dispatch"
+
+demo_verify_block="$tmp_root/demo-verify-block.txt"
+demo_build_block="$tmp_root/demo-build-block.txt"
+awk '/^  verify-release:/ { keep=1 } /^  build-and-push:/ { keep=0 } keep { print }' \
+  "$demo_workflow" > "$demo_verify_block"
+awk '/^  build-and-push:/ { keep=1 } keep { print }' \
+  "$demo_workflow" > "$demo_build_block"
+assert_contains "$demo_verify_block" "          ref: \${{ github.sha }}"
+assert_contains "$demo_verify_block" "          path: release-source"
+assert_contains "$demo_verify_block" "          VERIFY_RELEASE_REPO_ROOT=\"\$RELEASE_ROOT\" \\"
+assert_contains "$demo_verify_block" "          VERIFY_MAVEN_REPO_ROOT=\"\$RELEASE_ROOT\" \\"
+assert_contains "$demo_build_block" "          ref: \${{ env.RELEASE_TAG }}"
+assert_not_contains "$demo_build_block" "          ref: \${{ github.sha }}"
 
 demo_context_line="$(awk 'index($0, "tools/verify-release-context.sh") { print NR; exit }' "$demo_workflow")"
 demo_central_line="$(awk 'index($0, "tools/verify-maven-central.sh") { print NR; exit }' "$demo_workflow")"

--- a/tools/verify-github-release.sh
+++ b/tools/verify-github-release.sh
@@ -9,21 +9,61 @@ fi
 tag="$1"
 expected_body_file="${2:-}"
 repo="${3:-${GITHUB_REPOSITORY:-}}"
+gh_bin="${GITHUB_RELEASE_GH_BIN:-gh}"
+require_latest="${VERIFY_GITHUB_RELEASE_REQUIRE_LATEST:-false}"
 
 if [ -z "$repo" ]; then
   echo "Repository is required; pass owner/name or set GITHUB_REPOSITORY." >&2
   exit 2
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "GitHub CLI 'gh' is required to verify GitHub Release." >&2
+if [ ! -x "$gh_bin" ] && ! command -v "$gh_bin" >/dev/null 2>&1; then
+  echo "GitHub CLI is required to verify GitHub Release: $gh_bin" >&2
   exit 1
 fi
 
-if ! gh release view "$tag" --repo "$repo" --json tagName,name >/dev/null; then
+release_metadata=""
+if ! release_metadata="$("$gh_bin" release view "$tag" \
+  --repo "$repo" \
+  --json tagName,isDraft,isPrerelease \
+  --jq '[.tagName, .isDraft, .isPrerelease] | @tsv')"; then
   echo "GitHub Release does not exist for tag $tag in $repo." >&2
   exit 1
 fi
+
+IFS=$'\t' read -r actual_tag is_draft is_prerelease <<< "$release_metadata"
+if [ "$actual_tag" != "$tag" ]; then
+  echo "GitHub Release tag mismatch: expected $tag, got ${actual_tag:-<empty>}." >&2
+  exit 1
+fi
+if [ "$is_draft" = "true" ]; then
+  echo "GitHub Release for $tag is still a draft." >&2
+  exit 1
+fi
+if [ "$is_prerelease" = "true" ]; then
+  echo "GitHub Release for $tag is a prerelease." >&2
+  exit 1
+fi
+
+case "$require_latest" in
+  true)
+    latest_tag=""
+    if ! latest_tag="$("$gh_bin" release view --repo "$repo" --json tagName --jq '.tagName')"; then
+      echo "Could not resolve the current latest GitHub Release in $repo." >&2
+      exit 1
+    fi
+    if [ "$latest_tag" != "$tag" ]; then
+      echo "Refusing to deploy $tag because the current latest GitHub Release is ${latest_tag:-<empty>}." >&2
+      exit 1
+    fi
+    ;;
+  false)
+    ;;
+  *)
+    echo "VERIFY_GITHUB_RELEASE_REQUIRE_LATEST must be true or false, got '$require_latest'." >&2
+    exit 2
+    ;;
+esac
 
 if [ -n "$expected_body_file" ]; then
   if [ ! -f "$expected_body_file" ]; then
@@ -32,11 +72,14 @@ if [ -n "$expected_body_file" ]; then
   fi
 
   actual_body="$(mktemp)"
-  gh release view "$tag" --repo "$repo" --json body --template '{{.body}}' > "$actual_body"
+  trap 'rm -f "$actual_body"' EXIT
+  "$gh_bin" release view "$tag" --repo "$repo" --json body --template '{{.body}}' > "$actual_body"
   if ! diff -u "$expected_body_file" "$actual_body"; then
     echo "GitHub Release body differs from expected release notes for $tag." >&2
     exit 1
   fi
+  rm -f "$actual_body"
+  trap - EXIT
 fi
 
 echo "GitHub Release OK: $repo@$tag"


### PR DESCRIPTION
## 变更

- 移除 Demo workflow 对 `v*` tag 的独立触发；由正式 Release job 在 Central 制品和 GitHub Release 核验成功后调用。
- Demo 接收显式 tag，先 checkout 该 tag，再复核 release context、Maven Central、GitHub Release 正文及 latest 身份，之后才进入镜像 matrix。
- 手工恢复必须填写当前 latest 的正式 tag；Docker semver 标签显式取该输入，不再依赖手工事件的 `github.ref`。
- GitHub Release 校验新增 tag、draft、prerelease、可选 latest 检查；恢复已存在 Release 时会明确发布 draft 并清除 prerelease 状态。
- 不使用 `secrets: inherit`；被调用 workflow 只获得 `contents: read`、`packages: write` 的 `GITHUB_TOKEN`。
- 增加 published/draft/prerelease/错误 tag/旧 latest/正文不一致等故障用例，并更新 Demo 文档和发布 runbook。

## 非目标

- 不改变 Maven Central 发布方式、Maven 坐标、tag 规则或 Docker 镜像名称。
- 不自动创建 tag，不移除受控的手工恢复入口，不引入新的 registry、签名或 SBOM 流程。
- Demo 仍从经过核验的精确 tag 构建；本 PR 不把示例工程改造成只消费 Central 的独立项目。

## 验证

- `./tools/test-release-tools.sh`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.parse_file(file) }' .github/workflows/release.yml .github/workflows/deploy-demo.yml`
- `VERIFY_GITHUB_RELEASE_REQUIRE_LATEST=true ./tools/verify-github-release.sh v5.4.0 '' songxychn/knife4j-next`（真实公开 Release，只读）
- `JAVA_HOME=.../corretto-17.0.16/Contents/Home ./tools/test-all.sh`：Java reactor 34/34、配置元数据、14 个 smoke 模块通过；随后因默认环境没有 Node 22 按门禁退出。
- 使用工作区 Node `v24.19.0` 继续执行并通过：
  - `./tools/test-front-core.sh`（core 372 tests；React 464 tests）
  - `./tools/test-vue3.sh`
  - `./tools/test-docs.sh`
  - `./tools/test-knife4x-go.sh`
  - `./tools/sync-knife4x-ui.sh --check`
- `/usr/bin/git diff --cached --check`

## 风险

PR 事件不会真实发布 Maven 或 GHCR；本地通过 mock 和静态调用关系锁定失败路径，实际 workflow 语义继续以当前 head 的 GitHub Actions 解析与 CI 为最终依据。任何新 push 都需要重新核验。

Closes #722
