### PR TITLE
docs: 收敛 OAS 3.1 路线图状态

### DIFF
--- a/docs/guide/openapi31-en.md
+++ b/docs/guide/openapi31-en.md
@@ -54,7 +54,7 @@ Unless a row says otherwise, “supported” below means the complete OpenAPI 3.
 | Single and multi-document loading | The entry document and controlled cross-document resources share one 3.1 parsing session | A 3.2 document does not enter the 3.1 workflow | [#682](https://github.com/songxychn/knife4j-next/pull/682), [#689](https://github.com/songxychn/knife4j-next/pull/689), [#727](https://github.com/songxychn/knife4j-next/pull/727) |
 | Document objects and Webhooks | Supports `paths`, `components`, `webhooks`, and 3.1 Reference Objects; at least one of the three fields must be declared | A Webhook is an inbound contract, not a regular Path request | [#717](https://github.com/songxychn/knife4j-next/pull/717) |
 | Schema dialect | OAS 3.1 Base Dialect and the standard JSON Schema Draft 2020-12 vocabularies | Arbitrary custom dialects are not assigned invented semantics | [#687](https://github.com/songxychn/knife4j-next/pull/687), [#689](https://github.com/songxychn/knife4j-next/pull/689) |
-| Field tree and models | Handles union types, boolean schemas, `const`, conditional/composition keywords, and dynamic references | Custom vocabularies are not executed; see [#740](https://github.com/songxychn/knife4j-next/issues/740) for the reserved-key pre-scan limitation in opaque payloads | [#692](https://github.com/songxychn/knife4j-next/pull/692), [#694](https://github.com/songxychn/knife4j-next/pull/694) |
+| Field tree and models | Handles union types, boolean schemas, `const`, conditional/composition keywords, and dynamic references | Custom vocabularies are not executed; ordinary unknown-keyword, example, and extension payloads remain opaque, so Schema control names do not enter resource-declaration pre-scan | [#692](https://github.com/songxychn/knife4j-next/pull/692), [#694](https://github.com/songxychn/knife4j-next/pull/694), [#743](https://github.com/songxychn/knife4j-next/pull/743) |
 | Examples | Keeps authored examples and diagnoses mismatches; can generate a deterministic, budgeted fallback | Not a general JSON Schema solver | [#715](https://github.com/songxychn/knife4j-next/pull/715) |
 | Parameter debugging | Validates Path, Query, Header, and Cookie logical instances before `style` / `explode` serialization | A parameter uses either `schema` or one `content` media type; Cookie reaches preview / cURL only and is blocked before a real browser request | [#716](https://github.com/songxychn/knife4j-next/pull/716) |
 | urlencoded / multipart bodies | Handles structured fields, `encoding`, JSON parts, and file metadata checks | Never reads or validates uploaded file bytes | [#728](https://github.com/songxychn/knife4j-next/pull/728), [#730](https://github.com/songxychn/knife4j-next/pull/730) |
@@ -90,12 +90,14 @@ vocabularies follow their dialect semantics. `format` is an annotation by defaul
 Unknown extension keywords and custom-vocabulary payloads remain intact in the source document. When the SchemaEngine session succeeds,
 copy and portable-export surfaces retain them as well, but Knife4j defines no validation, example-generation, or field-tree semantics for them.
 
-The current resource-declaration safety pre-scan still recursively inspects arbitrary object payloads. `$id`, `$anchor`, or `$dynamicAnchor` in ordinary
-data under an unknown keyword, example, or extension can be mistaken for Schema control data. An encountered `$id` also marks that object as a resource
-root and causes sibling `$schema` / `$vocabulary` declarations to be checked, which can fail the session. This is the known limitation tracked by
-[#740](https://github.com/songxychn/knife4j-next/issues/740). A real Schema resource root that selects
-an unsupported `$schema` or declares a custom `$vocabulary` also receives a resource-level unsupported-dialect diagnostic and blocks actions that
-require complete Schema semantics. Neither case falls back to an approximate dialect or executes the custom vocabulary.
+Resource-declaration safety pre-scan enters only known Schema-bearing locations: standalone JSON Schema roots, OAS Schema Objects,
+known Draft 2020-12 subschema applicators, and versioned Knife4j portable-resource containers. Ordinary data under an unknown keyword,
+example, or extension remains opaque. Its `$id`, `$anchor`, `$dynamicAnchor`, `$schema`, `$vocabulary`, `$ref`, and `$dynamicRef` values
+remain intact but do not participate in resource-identity, anchor, dialect, vocabulary, or reference-budget pre-scan.
+
+A real Schema resource root that selects an unsupported `$schema` or declares a custom `$vocabulary` still receives a resource-level
+unsupported-dialect diagnostic and blocks actions that require complete Schema semantics. That diagnostic never falls back to an approximate
+dialect or executes the custom vocabulary. The implementation and regression evidence for this pre-scan boundary is [#743](https://github.com/songxychn/knife4j-next/pull/743).
 
 ## External Schema resources
 

--- a/docs/guide/openapi31.md
+++ b/docs/guide/openapi31.md
@@ -51,7 +51,7 @@ Boot 2 / springdoc 1.8.0 仍生成 OAS 3.0，不能仅修改文档中的 `openap
 | 单文档与多文档加载 | 入口文档与受控跨文档资源使用同一 3.1 解析会话 | 3.2 文档拒绝进入 3.1 工作流 | [#682](https://github.com/songxychn/knife4j-next/pull/682)、[#689](https://github.com/songxychn/knife4j-next/pull/689)、[#727](https://github.com/songxychn/knife4j-next/pull/727) |
 | 文档对象与 Webhook | 支持 `paths`、`components`、`webhooks` 与 3.1 Reference Object；三者至少声明一个 | Webhook 是入站契约，不等同于普通 Path 请求 | [#717](https://github.com/songxychn/knife4j-next/pull/717) |
 | Schema 方言 | 使用 OAS 3.1 Base Dialect 与 JSON Schema Draft 2020-12 标准词汇 | 不把任意自定义方言解释为标准语义 | [#687](https://github.com/songxychn/knife4j-next/pull/687)、[#689](https://github.com/songxychn/knife4j-next/pull/689) |
-| 字段树与模型 | 支持 3.1 类型联合、布尔 Schema、`const`、条件与组合关键字、动态引用等 | 不执行自定义词汇；未知载荷内保留名的预扫描限制见 [#740](https://github.com/songxychn/knife4j-next/issues/740) | [#692](https://github.com/songxychn/knife4j-next/pull/692)、[#694](https://github.com/songxychn/knife4j-next/pull/694) |
+| 字段树与模型 | 支持 3.1 类型联合、布尔 Schema、`const`、条件与组合关键字、动态引用等 | 不执行自定义词汇；未知关键字、example 与 extension 的普通载荷保持 opaque，Schema 保留名不参与资源声明预扫描 | [#692](https://github.com/songxychn/knife4j-next/pull/692)、[#694](https://github.com/songxychn/knife4j-next/pull/694)、[#743](https://github.com/songxychn/knife4j-next/pull/743) |
 | 示例 | 保留作者示例并报告不一致；无作者示例时可在预算内生成确定性候选 | 不是通用 JSON Schema 求解器 | [#715](https://github.com/songxychn/knife4j-next/pull/715) |
 | 参数调试 | Path、Query、Header、Cookie 按 3.1 Schema 验证，再按 `style` / `explode` 序列化 | 一个参数使用 `schema` 或一个 `content` 媒体类型；Cookie 只进入预览 / cURL，浏览器真实发送前会阻断 | [#716](https://github.com/songxychn/knife4j-next/pull/716) |
 | urlencoded / multipart Body | 支持结构化字段、`encoding`、JSON part 与文件元数据检查 | 不读取或验证上传文件内容 | [#728](https://github.com/songxychn/knife4j-next/pull/728)、[#730](https://github.com/songxychn/knife4j-next/pull/730) |
@@ -87,10 +87,14 @@ Content 标准词汇按方言处理。`format` 默认是注解，不因浏览器
 未知扩展关键字和自定义词汇载荷会保留在原始文档中；SchemaEngine 会话成功时，复制与可移植导出也保留这些值，
 但 Knife4j 不为它们定义验证、示例生成或字段树语义。
 
-当前资源声明安全预扫描仍会递归检查任意对象载荷。未知关键字、example 或 extension 的普通数据里的 `$id`、`$anchor`、
-`$dynamicAnchor` 可能被误当成 Schema 控制关键字；其中 `$id` 还会把该对象标成资源根并继续检查同级 `$schema` / `$vocabulary`，从而使会话失败。
-这是 [#740](https://github.com/songxychn/knife4j-next/issues/740) 跟踪的已知限制。真正的 Schema 资源根显式选择不受支持的 `$schema` 或声明自定义 `$vocabulary` 时，也会给出资源级不受支持方言诊断，
-并阻止依赖完整 Schema 语义的动作。两种情况都不会回退到近似方言或执行自定义词汇。
+资源声明安全预扫描只进入已知会承载 Schema 的位置：独立 JSON Schema 根、OAS Schema Object、
+Draft 2020-12 已知 subschema applicator，以及带版本标记的 Knife4j 可移植资源容器。未知关键字、example 或 extension
+的普通数据保持 opaque；其中的 `$id`、`$anchor`、`$dynamicAnchor`、`$schema`、`$vocabulary`、`$ref` 与
+`$dynamicRef` 会原样保留，但不参与资源身份、anchor、方言、vocabulary 或引用预算预扫描。
+
+真正的 Schema 资源根显式选择不受支持的 `$schema` 或声明自定义 `$vocabulary` 时，仍会给出资源级不受支持方言诊断，
+并阻止依赖完整 Schema 语义的动作；该诊断不会回退到近似方言或执行自定义词汇。预扫描边界的实现与回归证据见
+[#743](https://github.com/songxychn/knife4j-next/pull/743)。
 
 ## 外部 Schema 资源
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -66,7 +66,7 @@ OpenAPI 3.1 按“文档加载 → SchemaEngine → 展示与调试 → 受控�
 | --- | --- | --- |
 | OpenAPI 3.1.x | ✅ | 各 patch 使用同一 feature set 与安全边界；离线导出复用统一版本判断 |
 | JSON Schema Draft 2020-12 | ✅ | OAS Base Dialect、标准词汇、字段树、示例与请求/响应诊断 |
-| 未知关键字 opaque 载荷 | ⚠️ | 资源声明预扫描仍可能解释载荷内保留名，等待 [#740](https://github.com/songxychn/knife4j-next/issues/740) 收敛 |
+| 未知关键字 opaque 载荷 | ✅ | 资源声明预扫描只进入已知 Schema 位置；普通载荷内保留名不参与资源或 anchor 注册（[#743](https://github.com/songxychn/knife4j-next/pull/743)） |
 | 外部 Schema 资源 | ✅ | 默认拒绝、精确 URI 授权、无凭据请求、固定预算、可撤销 |
 | 可移植交付 | ✅ | 单接口 JSON 闭包、变化指纹、HTML / Markdown / DOC / DOCX 离线快照 |
 | springdoc 端到端 | ✅ | Boot 3 WebMVC/WebFlux 显式 3.1；Boot 4 WebMVC 默认/显式 3.1；Boot 2 保持 3.0 |
@@ -74,7 +74,8 @@ OpenAPI 3.1 按“文档加载 → SchemaEngine → 展示与调试 → 受控�
 
 支持矩阵、浏览器限制、迁移示例和最小有效夹具统一收录在
 [OpenAPI 3.1 支持与迁移](../guide/openapi31)。这一里程碑是当前源码状态，不修改现有发布版本号。
-在 [#740](https://github.com/songxychn/knife4j-next/issues/740) 完成前，父路线图 #699 保持阻塞，不对 arbitrary custom vocabulary 作扩张承诺。
+父路线图 [#699](https://github.com/songxychn/knife4j-next/issues/699) 所列实现、端到端与文档子项已收敛；
+这不承诺 arbitrary custom vocabulary 的执行语义，也不将 OpenAPI 3.2 作为 3.1 处理。
 
 ---
 


### PR DESCRIPTION
## 关联

Closes #744

父路线图：#699。合并后回读 `master`、更新路线清单并关闭 #699。

## 背景

PR #743 已修复 SchemaEngine 资源声明预扫描误入未知关键字、example 与 extension 普通载荷的问题，但当前中英文 OAS 3.1 支持矩阵和 roadmap 仍把 #740 写成开放限制，并声明 #699 继续阻塞。

## 改动

- 中英文支持矩阵改为当前契约：opaque 普通载荷保留 Schema 控制名，但不让它们参与资源身份、anchor、方言、vocabulary 或引用预算预扫描。
- 保留真正 Schema 资源根上的不支持方言 / 自定义 vocabulary 诊断边界，不把 #740 的修复扩张为 arbitrary custom vocabulary 执行语义。
- roadmap 将 opaque 载荷项更新为完成，补充 PR #743 证据，并删除父路线图仍等待 #740 的过时说明。

## 非目标

- 不修改运行时代码、测试、Knife4x 生成物或发布版本号。
- 不增加 OAS 3.2 支持。
- 不放宽外部资源、URI、预算或凭据策略。

## 验证

- `./tools/test-docs.sh`
- `git diff --check`
- 搜索确认文档不再把 #740 写成开放限制或 #699 的阻塞项。

## 风险

仅修改当前 `master` 源码契约文档；具体发布版本仍由发布说明和版本参考决定。
