### PR TITLE
release: 准备 5.5.0（OAS 3.1 支持）

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | 仓库来源 | fork 自 `xiaoymin/knife4j` |
 | 当前定位 | 社区维护分支，不是 upstream 官方仓库 |
 | Java 主坐标 | `com.baizhukui` |
-| 当前稳定版本 | `5.4.0` |
+| 当前稳定版本 | `5.5.0` |
 | 默认访问入口 | `http://ip:port/doc.html` |
 | 文档站 | [knife4jnext.com](https://knife4jnext.com) |
 
@@ -27,7 +27,7 @@
 
 ### 选择 Starter
 
-版本统一使用当前稳定版本 `5.4.0`。
+版本统一使用当前稳定版本 `5.5.0`。
 
 | 使用场景 | Maven `artifactId` |
 |---|---|
@@ -46,7 +46,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 

--- a/docs/guide/aggregation.md
+++ b/docs/guide/aggregation.md
@@ -24,7 +24,7 @@ Spring Boot 3（Jakarta）：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 
 <dependency>
@@ -41,7 +41,7 @@ Spring Boot 4 换成 `knife4j-aggregation-boot4-spring-boot-starter`：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-aggregation-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 
 <dependency>

--- a/docs/guide/demo.md
+++ b/docs/guide/demo.md
@@ -31,7 +31,7 @@ knife4j-next 提供两个并列的 demo 工程，分别覆盖两条独立的 UI 
 | 组件 | 版本 | 说明 |
 | --- | --- | --- |
 | Spring Boot | `4.0.7` | demo `pom.xml` 通过 Boot BOM 显式声明 |
-| knife4j starter | `knife4j-openapi3-boot4-spring-boot-starter` | 本仓库 `5.4.0` |
+| knife4j starter | `knife4j-openapi3-boot4-spring-boot-starter` | 本仓库 `5.5.0` |
 | JDK | 17 | Dockerfile base image `eclipse-temurin:17-jre-alpine` |
 | springdoc-openapi | `3.0.3` | 由 starter 管理 |
 
@@ -100,7 +100,7 @@ docker run --rm -p 8080:8080 \
 | 组件 | 版本 | 说明 |
 | --- | --- | --- |
 | Spring Boot | `2.7.18` | 由根 pom `knife4j-spring-boot.version` 管理 |
-| knife4j starter | `knife4j-openapi2-spring-boot-starter` | 本仓库 `5.4.0` |
+| knife4j starter | `knife4j-openapi2-spring-boot-starter` | 本仓库 `5.5.0` |
 | JDK | 8 | Dockerfile base image `eclipse-temurin:8-jre-alpine` |
 | springfox | `2.10.5` | Swagger 2 注解解析 |
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -32,7 +32,7 @@ Knife4j 的 `doc.html` 默认嵌入在 Spring Boot 应用中。在某些场景�
 # 在 Maven 仓库中找到 knife4j-openapi3-ui 的 jar
 # 解压 META-INF/resources/ 目录
 mkdir -p /opt/knife4j-static
-unzip -j ~/.m2/repository/com/baizhukui/knife4j-openapi3-ui/5.4.0/knife4j-openapi3-ui-5.4.0.jar \
+unzip -j ~/.m2/repository/com/baizhukui/knife4j-openapi3-ui/5.5.0/knife4j-openapi3-ui-5.5.0.jar \
   "META-INF/resources/*" -d /opt/knife4j-static/
 ```
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -22,17 +22,18 @@ title: 常见问题
 
 **大多数情况仍然有效**。upstream 文档 <https://doc.xiaominfo.com/> 上关于 `@ApiOperationSupport`、`knife4j.*` 配置、UI 行为的内容，本 fork 保持兼容。使用时需要注意以下边界：
 
-1. 版本发布节奏：upstream 最后一个 Maven Central 发布版本是 `4.5.0`（2024-01-08），fork 是 `5.4.0`（采用独立 SemVer 版本号）；fork 包含已确认并合入的兼容/安全修复和 React 新前端。
+1. 版本发布节奏：upstream 最后一个 Maven Central 发布版本是 `4.5.0`（2024-01-08），fork 是 `5.5.0`（采用独立 SemVer 版本号）；fork 包含已确认并合入的兼容/安全修复和 React 新前端。
 2. 新 React 前端覆盖范围：upstream Vue2 前端上有的 UI 功能（Postman 导出、afterScript 等）在本 fork 的新 React 前端中尚未全部覆盖；OAuth2、接口变化提示、离线导出、自定义 Markdown 文档、自定义 Footer 等能力则已在 React UI 中补齐或重做。这些历史功能在本仓库 `front/vue3`（`knife4j-openapi2-ui` 打包产物）中继续保留。详见下文 [React 配置不生效](#react-setting-not-effective)。
 3. Spring Security 注解展示：upstream 与本 fork 的实现都只位于 `knife4j-openapi2-spring-boot-starter`（OAS2 / Springfox）；OAS3 / springdoc 系列 starter 不会自动追加这些注解。详见 [Spring Security 注解展示](./features#spring-security-注解展示)。
 
 ### 本 fork 相比 upstream 多了哪些修复
 
-下表按**已发布版本**记录历史范围，不代表当前 `master` 的全部能力。当前源码的 OpenAPI 3.1 契约见
+下表按版本记录发布范围。Java `5.5.0` 的 OpenAPI 3.1 契约及其限制见
 [OpenAPI 3.1 支持与迁移](./openapi31)。
 
 | 版本 | 修复/新增内容 | 对应 upstream issue |
 | --- | --- | --- |
+| `5.5.0` | 次版本：OAS 3.1 / JSON Schema 2020-12、受控跨文档资源、示例与调试诊断、可移植/离线导出和变化提示；修复长类型名展示与聚合 Host 端口 | — |
 | `5.4.0` | 次版本：页签左右关闭、响应状态概要、本地数据安全清理、单接口 OpenAPI 3.0.x 下载与接口变化提示 | — |
 | `5.3.3` | 补丁修复：开启动态参数后，urlencoded / multipart Body 支持添加文档未声明的文本字段 | — |
 | `5.3.2` | 补丁修复：恢复 OAS3 离线 HTML、DOC、DOCX 与整篇 Markdown 中的请求示例和响应示例 | — |

--- a/docs/guide/gateway.md
+++ b/docs/guide/gateway.md
@@ -42,7 +42,7 @@ Gateway 主工程 `pom.xml`：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -59,7 +59,7 @@ Spring Cloud Gateway 5 使用新的 WebFlux starter 坐标：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -78,7 +78,7 @@ Server Web MVC 使用 Servlet 技术栈，不能引入上面的 WebFlux Gateway 
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -29,7 +29,7 @@ title: 快速开始
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -79,7 +79,7 @@ Controller 写法与 Boot 3.x Jakarta 版一致，annotation 使用 `io.swagger.
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -154,7 +154,7 @@ React 新前端会读取部分 `knife4j.setting.*` UI 默认值，例如 `langua
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -188,7 +188,7 @@ UI 同样是新 React 版本，注意覆盖范围提示。
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -17,7 +17,7 @@ title: 产品介绍
 | 访问入口（doc.html / v2 / v3 api-docs） | 保留 | 完全一致 |
 | 仓库 | `xiaoymin/knife4j` | [`songxychn/knife4j-next`](https://github.com/songxychn/knife4j-next) |
 | 发布渠道 | Maven Central | Maven Central |
-| 当前版本 | `4.5.0`（最后一个 Maven Central 发布版本） | `5.4.0` |
+| 当前版本 | `4.5.0`（最后一个 Maven Central 发布版本） | `5.5.0` |
 | 文档站 | [doc.xiaominfo.com](https://doc.xiaominfo.com/) | 本站（`knife4jnext.com`） |
 
 **迁移的最小单位是改 `groupId`，业务代码、配置键、访问路径都不必动。** 详见 [迁移指引](./migration)。
@@ -81,7 +81,7 @@ upstream 文档里列出的增强特性在本 fork 的实际实现状态，前�
 knife4j-next 从 `5.0.0` 起采用独立 [SemVer](https://semver.org/lang/zh-CN/) 版本号，与上游 knife4j 版本号无关：
 
 - **Patch**（`5.0.1`、`5.0.2`、`5.0.3`、`5.0.4`、`5.0.5`、`5.0.6`、`5.0.7`、`5.0.8`、`5.0.9`、`5.0.10`、`5.0.11`、`5.0.12`、`5.0.13`、`5.0.14`、`5.0.15`、`5.0.17`、`5.0.18`、`5.2.1`、`5.2.3`、`5.2.4`、`5.3.1`、`5.3.2`、`5.3.3`）：安全修复、Bug 修复与兼容体验改进。
-- **Minor**（`5.1.0`、`5.2.0`、`5.3.0`、`5.4.0`）：前端体验改动、新功能（向后兼容）。
+- **Minor**（`5.1.0`、`5.2.0`、`5.3.0`、`5.4.0`、`5.5.0`）：前端体验改动、新功能（向后兼容）。
 - **Major**（`6.0.0`）：破坏性变更。
 
 版本号表达变化类型，不代表固定发布日期或响应 SLA。哪些版本和模块仍受支持、哪些兼容面会被保留，以及什么才算一次完整发布，请以仓库的 [维护政策](https://github.com/songxychn/knife4j-next/blob/master/MAINTENANCE.md) 为准。安全问题请通过 [安全政策](https://github.com/songxychn/knife4j-next/blob/master/SECURITY.md) 中的私密入口报告，不要先在公开 issue 披露利用细节。

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -35,7 +35,7 @@ After：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -57,7 +57,7 @@ After：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -85,7 +85,7 @@ After：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi2-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -131,7 +131,7 @@ knife4j:
 ## 迁移步骤
 
 1. **更新 Maven 依赖坐标**：全部 `com.github.xiaoymin` → `com.baizhukui`。
-2. **确认版本**：升到 `5.4.0`（当前稳定版本）。
+2. **确认版本**：升到 `5.5.0`（当前稳定版本）。
 3. **刷新依赖**：`mvn -U clean verify` 或 `mvn dependency:tree | grep knife4j` 检查无残留旧坐标。
 4. **启动验证**：访问 `/doc.html`，确认能看到接口列表。
 5. **如切到 OpenAPI3 系列 starter**：额外检查是否用了 Springfox 专属注解（`@DynamicParameters` 等），必要时替换为 DTO 实体类方式（参考 [注解速查](../reference/annotations)）。

--- a/docs/guide/openapi31-en.md
+++ b/docs/guide/openapi31-en.md
@@ -8,9 +8,10 @@ lang: en-US
 
 [中文契约](./openapi31) · [Download minimal JSON](/examples/openapi-3.1-minimal.json) · [Download minimal YAML](/examples/openapi-3.1-minimal.yaml)
 
-This page describes the OpenAPI 3.1 contract of the current `master` source. Check the
-[release notes](../release-notes/) and [version reference](../reference/version-ref) before assuming that a released artifact contains these capabilities.
-This document does not change any starter, default setting, or release version.
+This page describes the OpenAPI 3.1 contract of Java `5.5.0`. See the
+[release notes](../release-notes/) and [version reference](../reference/version-ref) for version-specific capabilities.
+Knife4x Go is versioned independently; see the [Go release notes](../knife4x/).
+This document does not change any starter or default setting.
 
 ## Supported versions
 

--- a/docs/guide/openapi31.md
+++ b/docs/guide/openapi31.md
@@ -7,8 +7,9 @@ description: Knife4j Next 对 OpenAPI 3.1.x 的支持矩阵、JSON Schema 2020-1
 
 [English contract](./openapi31-en) · [下载最小 JSON](/examples/openapi-3.1-minimal.json) · [下载最小 YAML](/examples/openapi-3.1-minimal.yaml)
 
-本文描述当前 `master` 源码的 OpenAPI 3.1 契约。具体发布版本是否包含这些能力，请以
-[发布说明](../release-notes/)和 [版本参考](../reference/version-ref)为准；本文不改变任何 starter、默认配置或发布版本。
+本文描述 Java `5.5.0` 的 OpenAPI 3.1 契约，具体能力与版本归属见
+[发布说明](../release-notes/)和 [版本参考](../reference/version-ref)。Knife4x Go 使用独立版本，
+请查阅 [Go 发布说明](../knife4x/)。本文不改变任何 starter 或默认配置。
 
 ## 支持范围
 

--- a/docs/guide/springfox-migration.md
+++ b/docs/guide/springfox-migration.md
@@ -45,7 +45,7 @@ Swagger2 注解 (@Api, @ApiOperation…)  →  OpenAPI3 注解 (@Tag, @Operation
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -55,7 +55,7 @@ Swagger2 注解 (@Api, @ApiOperation…)  →  OpenAPI3 注解 (@Tag, @Operation
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -372,14 +372,14 @@ public class UserController {/* ... */}
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 
 <!-- Spring Boot 3.x Jakarta -->
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 

--- a/docs/guide/webflux.md
+++ b/docs/guide/webflux.md
@@ -51,7 +51,7 @@ title: WebFlux 接入
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -101,7 +101,7 @@ public class UserController {
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-webflux-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ features:
     link: /release-notes/
     linkText: 发布说明
   - title: OpenAPI 3.1 契约
-    details: 当前源码对 OpenAPI 3.1.x 使用同一 JSON Schema 2020-12、受控外部资源、调试诊断与可移植交付契约，并公开已知限制。
+    details: 5.5.0 对 OpenAPI 3.1.x 使用同一 JSON Schema 2020-12、受控外部资源、调试诊断与可移植交付契约，并公开已知限制。
     link: /guide/openapi31
     linkText: 支持与迁移
   - title: Gateway 与多服务聚合
@@ -64,7 +64,7 @@ UI、加载已有 OpenAPI 3 文档并提供调试控制台。[查看 Go 接入](
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -74,7 +74,7 @@ UI、加载已有 OpenAPI 3 文档并提供调试控制台。[查看 Go 接入](
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -93,14 +93,14 @@ knife4j:
 
 启动应用后访问 `http://localhost:8080/doc.html`。完整流程见 [快速开始](/guide/getting-started)。
 
-## 5.4.0 版本亮点 <Badge type="tip" text="最新" />
+## 5.5.0 版本亮点 <Badge type="tip" text="最新" />
 
-以下内容是已发布 `5.4.0` 的历史范围；当前源码后续增加的 OpenAPI 3.1 能力见
-[OpenAPI 3.1 支持与迁移](/guide/openapi31)，最终制品范围以未来发布说明为准。
+`5.5.0` 将 OpenAPI 3.1 能力纳入 Java 发布版本；具体支持范围、浏览器限制与开启方式见
+[OpenAPI 3.1 支持与迁移](/guide/openapi31)。
 
-- 🧭 页签左右关闭、响应状态概要与接口新增/变化标记
-- 🧹 边界清晰、可跨页签协调的 Knife4j 本地数据清理
-- 📦 下载当前接口的闭合 OpenAPI 3.0.x 文档
+- 🧩 OpenAPI 3.1 与 JSON Schema 2020-12 字段树、示例和请求/响应诊断
+- 🔒 默认拒绝、精确授权、无凭据的受控跨文档资源加载
+- 📦 OAS 3.1 单接口可移植下载、接口变化提示与多格式离线文档
 
 完整更新列表见 [发布说明](/release-notes/)。
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -13,15 +13,16 @@ title: 兼容矩阵
 
 | 维度 | 版本 |
 | --- | --- |
-| knife4j-next | `5.4.0` |
+| knife4j-next | `5.5.0` |
 | Java 最低版本 | `1.8`（openapi2 / openapi3 非 Jakarta）；`17`（Jakarta / Boot4） |
 | Springfox | `2.10.5`（openapi2 starter） |
 | springdoc-openapi | `1.8.0`（Boot 2.x）；`2.8.9`（Boot 3.x Jakarta）；`3.0.3`（Boot 4.x） |
 | 前端 UI | React（openapi3 starter，打包 `front/ui-react`）；Vue 3（openapi2 starter，打包本仓库 `front/vue3`） |
 
 ::: info 发布版本与源码能力
-上表的 `5.4.0` 是当前已发布依赖基线；OpenAPI 3.1 的完整能力矩阵描述当前 `master` 源码，
-不代表 `5.4.0` 已包含后续提交。使用已发布制品时仍应核对[发布说明](../release-notes/)。
+上表为 `5.5.0` 的依赖基线；本轮 OpenAPI 3.1 能力从 Java `5.5.0` 起提供，
+不应反向视为 `5.4.0` 等历史版本的能力。支持范围见 [OpenAPI 3.1 支持与迁移](../guide/openapi31)，
+各版本变更以[发布说明](../release-notes/)为准。
 :::
 
 ## Starter 兼容矩阵

--- a/docs/reference/version-ref.md
+++ b/docs/reference/version-ref.md
@@ -8,7 +8,8 @@ title: 版本对照
 
 | knife4j-next 版本 | Spring Boot 2.x | Spring Boot 3.x | Spring Boot 4.x | 说明 |
 | --- | --- | --- | --- | --- |
-| `5.4.0` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.16 | ✅ 4.0.7 | 当前版本，接口工作区、本地数据清理与单接口 OpenAPI 下载 |
+| `5.5.0` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.16 | ✅ 4.0.7 | 当前版本，OAS 3.1 / JSON Schema 2020-12、受控资源、调试诊断与导出 |
+| `5.4.0` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.16 | ✅ 4.0.7 | 接口工作区、本地数据清理与单接口 OpenAPI 3.0.x 下载 |
 | `5.3.3` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.16 | ✅ 4.0.7 | 动态表单参数补丁 |
 | `5.3.2` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.16 | ✅ 4.0.7 | 离线文档请求与响应示例补丁 |
 | `5.3.1` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.16 | ✅ 4.0.7 | 离线导出契约与请求参数批量选择补丁 |
@@ -40,11 +41,11 @@ title: 版本对照
 | `5.0.0` | ✅ 2.7.18 | ✅ 3.4.0 ~ 3.5.0 | ❌ | 首个正式稳定版本 |
 
 > knife4j-next 从 `5.0.0` 起采用独立 [SemVer](https://semver.org/lang/zh-CN/) 版本号，与上游 knife4j 版本号无关。
-> `5.4.0` 包含 Boot4 WebMVC starter、Boot4 Gateway starter、Boot4 独立聚合 starter，以及 Boot 3.5 Gateway Server Web MVC 聚合 starter；可直接使用 `com.baizhukui:knife4j-openapi3-boot4-spring-boot-starter:5.4.0`、`com.baizhukui:knife4j-gateway-boot4-spring-boot-starter:5.4.0`、`com.baizhukui:knife4j-aggregation-boot4-spring-boot-starter:5.4.0` 和 `com.baizhukui:knife4j-gateway-webmvc-spring-boot-starter:5.4.0`。
+> `5.5.0` 包含 Boot4 WebMVC starter、Boot4 Gateway starter、Boot4 独立聚合 starter，以及 Boot 3.5 Gateway Server Web MVC 聚合 starter；可直接使用 `com.baizhukui:knife4j-openapi3-boot4-spring-boot-starter:5.5.0`、`com.baizhukui:knife4j-gateway-boot4-spring-boot-starter:5.5.0`、`com.baizhukui:knife4j-aggregation-boot4-spring-boot-starter:5.5.0` 和 `com.baizhukui:knife4j-gateway-webmvc-spring-boot-starter:5.5.0`。
 
 ## 核心依赖版本
 
-以下为 `knife4j-next 5.4.0` 内部管理的依赖版本，用户一般不需要手动指定。
+以下为 `knife4j-next 5.5.0` 内部管理的依赖版本，用户一般不需要手动指定。
 
 ### Boot 2.x（非 Jakarta）线
 
@@ -95,7 +96,8 @@ title: 版本对照
 
 | upstream 版本 | knife4j-next 版本 | 说明 |
 | --- | --- | --- |
-| `4.5.0`（上游 Maven Central 最后发布版本） | `5.4.0` | 当前版本：包含全部 fork 安全修复 + Boot 3.4/3.5/4.0 兼容 + React UI 工作区与本地数据治理能力 |
+| `4.5.0`（上游 Maven Central 最后发布版本） | `5.5.0` | 当前版本：包含已合并兼容/安全修复、Boot 3.4/3.5/4.0 兼容及 OAS 3.1 支持 |
+| `4.5.0` | `5.4.0` | React UI 工作区与本地数据治理能力 |
 | `4.5.0` | `5.3.3` | React UI 动态表单参数补丁 |
 | `4.5.0` | `5.3.2` | React UI 离线文档请求与响应示例补丁 |
 | `4.5.0` | `5.3.1` | React UI 离线导出契约与请求参数批量选择补丁 |

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -12,7 +12,40 @@ title: 发布说明
 
 ## knife4j-next 版本
 
-### 5.4.0 <Badge type="tip" text="最新" />
+### 5.5.0 <Badge type="tip" text="最新" />
+
+`5.5.0` 是基于 `5.4.0` 的向后兼容次版本，重点发布 OpenAPI 3.1.x 的文档消费、JSON Schema 2020-12、受控跨文档资源、调试诊断与导出能力，并保持现有 OpenAPI 3.0.x、OAS2 兼容维护线和 Java 依赖矩阵。
+
+**OpenAPI 3.1 与 JSON Schema（React UI）**
+
+- 引入文档级 SchemaEngine 会话，支持 OAS 3.1 Base Dialect 与 JSON Schema Draft 2020-12，将布尔 Schema、类型联合、`const`、组合/条件关键字与动态引用接入数据模型和接口字段树（PR #682、#687、#689、#692、#694）。
+- 补齐 `paths`、`components`、`webhooks` 和 Reference Object 语义；规范扩展及未知关键字的普通载荷保持 opaque，不生成伪接口，也不将其中的 Schema 保留名误注册为资源（PR #717、#738、#743、#750）。
+- 受控加载跨文档资源，按 retrieval URI、`$id`、anchor 与方言构建固定资源图；默认拒绝外部请求，仅按用户授权的精确 URI 无凭据加载，保留累计预算、撤销与过期操作隔离（PR #727、#750）。
+
+**示例与接口调试（React UI）**
+
+- 保留作者示例并报告不一致，无作者示例时在预算内生成经过 SchemaEngine 验证的确定性候选；无法解析的作者示例引用明确告警，不以生成值静默替换（PR #715、#750）。
+- JSON 请求体、非 body Parameter、urlencoded 与 multipart Body 接入 Schema 诊断及规范序列化；修正 Header 字面值、结构化表单实际发送存在性和必填空值判断，保留针对当前请求快照的显式负向测试放行（PR #696、#716、#728、#730、#750）。
+- JSON 响应按状态码、媒体类型及其参数选择 Schema，提供非阻断诊断；已授权外部 Response 可用于文档字段、示例与响应诊断（PR #713、#750）。
+
+**单接口下载、变化提示与离线文档（React UI）**
+
+- 完整资源图下可下载 OAS 3.1 单接口 OpenAPI JSON，保留 Schema 资源基址、默认 Server、OAuth 相对地址与 Link 调用上下文，并支持编码 anchor 和导出后重新载入；无法等价闭合时明确阻止下载（PR #732、#733、#750）。
+- OAS 3.1 接口变化提示使用固定完整资源图生成语义指纹，并与 OAS 3.0 基线隔离；资源缺失或存在诊断时不建立错误基线（PR #736）。
+- HTML、Markdown、DOC、DOCX 统一使用不可变 OAS 3.1 快照，离线入口复用同一 3.1.x 版本判断；资源或作者示例无法完整消费时取消，或明确标记降级/不完整（PR #734、#742、#750）。
+
+**其他修复**
+
+- 修复长全限定类型名及悬浮说明挤压字段列、溢出视口的问题，保留完整类型信息（PR #731，issue #729）。
+- 独立聚合转发保留目标 Host 的端口，避免非默认端口场景下游识别错误（PR #680，issue #679）。
+
+**兼容范围与迁移**
+
+Boot 3 WebMVC/WebFlux + springdoc `2.8.9` 显式开启 3.1，以及 Boot 4 WebMVC + springdoc `3.0.3` 默认/显式 3.1，均有真实生成文档和端到端验证；Boot 2 + springdoc `1.8.0` 保持生成 OAS 3.0（PR #737）。支持矩阵、开启方式与迁移示例见 [OpenAPI 3.1 支持与迁移](https://knife4jnext.com/guide/openapi31)。
+
+> 本版本不支持 OpenAPI 3.2 或任意自定义方言/词汇执行。外部资源仍受精确授权、CORS 与预算约束；浏览器不能直接设置 Cookie Header 或由 JavaScript 注入 mutualTLS 客户端证书，Webhook 仅作入站契约展示，不主动发送。示例生成不是通用 JSON Schema 求解器，具体限制以支持矩阵为准。
+
+### 5.4.0
 
 `5.4.0` 是基于 `5.3.3` 的向后兼容次版本，补齐接口工作区、本地数据治理、单接口 OpenAPI 下载与接口变化提示。
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -8,7 +8,7 @@ title: 路线图
 
 ---
 
-## 当前阶段：5.4.0 已发布
+## 当前阶段：5.5.0 与 OpenAPI 3.1
 
 ### 已完成 ✅
 
@@ -57,7 +57,7 @@ title: 路线图
 
 ---
 
-## 当前 `master`：OpenAPI 3.1 里程碑与遗留边界
+## OpenAPI 3.1 里程碑与已知边界
 
 OpenAPI 3.1 按“文档加载 → SchemaEngine → 展示与调试 → 受控资源图 → 可移植交付 →
 真实 springdoc 验证”的顺序完成核心链路，保持 OpenAPI 3.0.x 与 OAS2 兼容路径不变。
@@ -73,7 +73,7 @@ OpenAPI 3.1 按“文档加载 → SchemaEngine → 展示与调试 → 受控�
 | OpenAPI 3.2.x | — | 非当前目标，不按 3.1 猜测处理 |
 
 支持矩阵、浏览器限制、迁移示例和最小有效夹具统一收录在
-[OpenAPI 3.1 支持与迁移](../guide/openapi31)。这一里程碑是当前源码状态，不修改现有发布版本号。
+[OpenAPI 3.1 支持与迁移](../guide/openapi31)。这一里程碑纳入 Java `5.5.0`，Knife4x Go 版本单独发布。
 父路线图 [#699](https://github.com/songxychn/knife4j-next/issues/699) 所列实现、端到端与文档子项已收敛；
 这不承诺 arbitrary custom vocabulary 的执行语义，也不将 OpenAPI 3.2 作为 3.1 处理。
 

--- a/knife4j/MIGRATION.md
+++ b/knife4j/MIGRATION.md
@@ -20,7 +20,7 @@ With:
 <dependency>
   <groupId>com.baizhukui</groupId>
   <artifactId>knife4j-openapi3-spring-boot-starter</artifactId>
-  <version>5.4.0</version>
+  <version>5.5.0</version>
 </dependency>
 ```
 

--- a/knife4j/README.md
+++ b/knife4j/README.md
@@ -12,7 +12,7 @@
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -49,7 +49,7 @@ Spring Boot 4.x 使用独立 starter，避免把现有 Spring Boot 3.x + springd
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -61,7 +61,7 @@ Spring Boot 4.x 的 Spring Cloud Gateway 5 聚合场景使用独立 gateway star
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-gateway-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 
@@ -71,7 +71,7 @@ Spring Boot 4.x 的独立聚合服务使用独立 aggregation starter：
 <dependency>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j-aggregation-boot4-spring-boot-starter</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
 </dependency>
 ```
 

--- a/knife4j/knife4j-aggregation-boot4-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-boot4-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
 
     <artifactId>knife4j-aggregation-boot4-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-jakarta-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-aggregation-jakarta-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-aggregation-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-aggregation-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-core/pom.xml
+++ b/knife4j/knife4j-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-demo-openapi2/pom.xml
+++ b/knife4j/knife4j-demo-openapi2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-demo-openapi3/pom.xml
+++ b/knife4j/knife4j-demo-openapi3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-dependencies/pom.xml
+++ b/knife4j/knife4j-dependencies/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-dependencies</artifactId>

--- a/knife4j/knife4j-gateway-boot4-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-boot4-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-gateway-webmvc-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
 
     <artifactId>knife4j-gateway-webmvc-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi2-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-openapi2-ui/pom.xml
+++ b/knife4j/knife4j-openapi2-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>knife4j-openapi2-ui</artifactId>

--- a/knife4j/knife4j-openapi3-boot4-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-boot4-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
 
     <artifactId>knife4j-openapi3-boot4-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-jakarta-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
 
     <artifactId>knife4j-openapi3-jakarta-spring-boot-starter</artifactId>

--- a/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/knife4j/knife4j-openapi3-ui/pom.xml
+++ b/knife4j/knife4j-openapi3-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>knife4j</artifactId>
         <groupId>com.baizhukui</groupId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-jakarta-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <artifactId>knife4j-openapi3-webflux-jakarta-spring-boot-starter</artifactId>
     <name>knife4j-openapi3-webflux-jakarta-spring-boot-starter</name>

--- a/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
+++ b/knife4j/knife4j-openapi3-webflux-spring-boot-starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
     </parent>
     <artifactId>knife4j-openapi3-webflux-spring-boot-starter</artifactId>
     <name>knife4j-openapi3-webflux-spring-boot-starter</name>

--- a/knife4j/knife4j-smoke-tests/aggregation-boot2-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/aggregation-boot2-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot2-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot2-openapi3-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-openapi3-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot2-webflux-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot2-webflux-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-aggregation-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-gateway-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-gateway-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot3-webflux-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-gateway-webmvc-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot35-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot4-aggregation-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot4-aggregation-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot4-gateway-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot4-gateway-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/boot4-jakarta-app/pom.xml
+++ b/knife4j/knife4j-smoke-tests/boot4-jakarta-app/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j-smoke-tests</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/knife4j-smoke-tests/pom.xml
+++ b/knife4j/knife4j-smoke-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.baizhukui</groupId>
         <artifactId>knife4j</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/knife4j/pom.xml
+++ b/knife4j/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baizhukui</groupId>
     <artifactId>knife4j</artifactId>
-    <version>5.4.0</version>
+    <version>5.5.0</version>
     <modules>
         <module>knife4j-core</module>
         <module>knife4j-dependencies</module>


### PR DESCRIPTION
## 关联与范围

Refs #752；OAS 3.1 总路线 #699 已按已合并证据完成收口。Go v0.6.0 由 #753 独立准备，本 PR 不更新 Go 版本或 tag。

基线：`40d0aaffc840489fe182b252b9973ecf3b8c9d1f`  
当前 head：`f88d75179ff98126e1088940b4da33b5d5e6d2c1`

- 34 个 Maven POM 的项目/父版本统一为 `5.5.0`；README、使用示例、版本对照和 OAS 3.1 文档同步版本归属。
- 新增 5.5.0 发布说明，仅覆盖 v5.4.0 后已合并的产品能力：OAS 3.1 / JSON Schema 2020-12、受控资源图、示例与调试诊断、可移植/离线导出、接口变化提示，以及长 FQN 展示和聚合 Host 端口修复。
- 保留 5.4.0 等历史说明，Central 兼容报告基线仍为 `5.4.0`。新发布正文中的支持矩阵使用绝对链接，兼容文档站与 GitHub Release。
- 总计 54 个版本/文档文件；不修改产品源码、Go、生成资产、依赖、Maven 坐标、CI / 发布逻辑或 secrets。

## 冻结契约

Java 发布版本为 `5.5.0`。沿用已合并 OAS 3.1.x 支持矩阵与 Java / Spring Boot 兼容线；不扩张 OAS 3.2、未知方言/自定义词汇执行、Cookie jar、主动 webhook / mutualTLS 等能力。不纳入未合并需求或 agent / CI 工具维护作为产品功能。

独立审查预算为一轮 full + 必要时一轮 focused，当前 head 的 full review 与 PR CI 均已通过。由维护者合并本 PR，不由 agent 代合并；只有合并后的确切提交 CI 全绿，才按维护者本次发布授权创建 annotated `v5.5.0`。

## 本地验证

- `./tools/verify-release-modules.sh`：16 个发布模块通过。
- `./tools/extract-release-note.sh 5.5.0`：正文抽取通过。
- Corretto JDK 17 `./tools/test-java.sh`：Spotless 通过，34 模块 `BUILD SUCCESS`；6 模块配置元数据通过；239 配置键、5 常量、2 资源契约通过；14 smoke 模块均有测试且零 failure / error，输出 `Smoke-tests evidence OK (14 modules)`。
- `./tools/java-compatibility-report.sh`：对 Central 5.4.0 比较当前 5.5.0，无兼容/不兼容 API 变化；15 个 JAR 为实现/资源差异，1 个 POM 模块。该报告使用 ignore-missing-classes，不能替代已执行的消费路径 smoke。
- `./tools/test-docs.sh`：最终文档构建通过。
- `git diff --check`、34 POM 仅版本行差异及禁止区域无差异检查通过。

环境说明：普通提交时本机已有旧 lefthook wrapper 输出 `Can't find lefthook in PATH` 后成功完成；未使用 `--no-verify`、未修改 hooks，所有指定门禁均已显式执行。本地 Java 构建中的非阻断 Javadoc link / invoker 提示来自未发布 5.5.0 依赖尚不可从 Central 获取；CI 的 Javadoc 辅助调用另有 VM 初始化提示。两处主 reactor、发布 JAR、配置和全部 smoke 均成功；未降低或跳过检查。

## 当前 head 审查与 CI

- 独立 reviewer 使用全新上下文，审查 `40d0aaffc840489fe182b252b9973ecf3b8c9d1f..f88d75179ff98126e1088940b4da33b5d5e6d2c1` 全部真实 diff，并读取 live #752 / #754 和 CI 日志。
- full 结论：`approve`；findings、准备阶段 validation gaps、scope drift 均无；没有追加代码提交或第二轮审查。
- [Build 33947784672](https://github.com/songxychn/knife4j-next/actions/runs/33947784672)：成功。changes、Java 与 docs 通过，未涉及的 front / Go / Vue3 jobs 按既有路径规则跳过。
- 已下载该 run 的 `java-compatibility-report` 复核：Central 5.4.0 对当前 5.5.0，0 不兼容 API / 0 兼容 API 变化、15 实现或资源差异、1 POM 模块；14 smoke 模块共 34 tests，failure/error/skipped 均为 0。
- 基线已有 Java `RELEASE.md` 的 Demo 触发说明滞后已记录为独立文档 follow-up #756，不改动当前冻结发布范围；实际发布以现有 workflow 和 RUNBOOK 为准。

## 发布完成条件（不由此 PR 的绿灯替代）

准备 PR 合并后的 master CI → annotated `v5.5.0` → Release 发布与公开构件核验 → GitHub Release 正文一致 → Demo 部署 → 全部 Central 模块与隔离 JDK 17 Central-only consumer 验证。#752 在制品验收完成前保持打开。
