### PR TITLE
release(knife4x): 准备 Go v0.6.0（OAS 3.1 支持）

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ http://ip:port/doc.html
 |---|---|
 | `knife4j/` | Java 主工程（starter、UI webjar、聚合、Gateway、WebFlux、smoke 与 demo） |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3 workspace）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.5.0` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
+| `knife4x/` | 嵌入式控制台：Go `v0.6.0` 已发布，Rust 后置；与 `front/ui-react` 共用 UI |
 | `docs/` | VitePress 文档站 |
 | `tools/` | 验证与发布辅助脚本（原 `scripts/`） |
 | `legacy/` | 冻结参考：`vue2`、`insight`、`sandbox`（不参与主线构建） |
@@ -94,7 +94,7 @@ http://ip:port/doc.html
 | OAS3 主线 UI | `front/ui-react` | `knife4j-openapi3-ui` webjar；Knife4x embed | 承接新功能、UX 改进和调试器增强 |
 | OAS3 解析核心 | `front/core` | React UI 内部依赖 | 服务于 OAS3 主线，不为 OAS2 扩展 |
 | OAS2 兼容 UI | `front/vue3` | `knife4j-openapi2-ui` webjar | 只接收回归修复、安全补丁与显示层 bug |
-| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.5.0` 已发布；Rust 后置；UI 不另开工程 |
+| Knife4x | `knife4x/` | Go / Rust 宿主壳 | Go `v0.6.0` 已发布；Rust 后置；UI 不另开工程 |
 | 历史代码 | `legacy/` | 无发布目标 | 仅参考，勿接常规功能任务 |
 | 文档站 | `docs/` | [knife4jnext.com](https://knife4jnext.com) | 当前对外文档主入口 |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ features:
     linkText: 网关接入
 ---
 
-::: tip Knife4x Go v0.5.0
+::: tip Knife4x Go v0.6.0
 Go 服务现在也能嵌入同一套 React UI，通过标准库 `net/http` Handler 挂载
 UI、加载已有 OpenAPI 3 文档并提供调试控制台。[查看 Go 接入](/knife4x/)。
 :::

--- a/docs/knife4x/index.md
+++ b/docs/knife4x/index.md
@@ -6,13 +6,13 @@ description: 在 Go 服务中嵌入 Knife4j React UI，加载已有 OpenAPI 3 �
 # Knife4x Go
 
 Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试控制台。
-当前已发布 Go `v0.5.0`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
+当前已发布 Go `v0.6.0`，Rust 后置。它复用 Knife4j Next 的 React UI，但 module、
 版本和发布流程独立于 Java `5.x`。
 
 ::: info OpenAPI 3.1 与发布版本
-当前 `master` 的共享 React UI 已对 OpenAPI 3.1.x 提供加载、Schema、调试诊断、导出与变化提示契约，
-详见 [OpenAPI 3.1 支持与迁移](/guide/openapi31)。下方 `v0.5.0` 小节是已发布版本的历史记录；
-不要据此推断 `v0.5.0` 已包含后续 OAS 3.1 提交，实际制品能力以 Go 发布说明为准。
+Go `v0.6.0` 将共享 React UI 的 OpenAPI 3.1.x 加载、Schema、调试诊断、导出与变化提示纳入发布，
+完整边界见 [OpenAPI 3.1 支持与迁移](/guide/openapi31)。入口仍只接受 OpenAPI 3.0.x / 3.1.x JSON，
+不支持 YAML 入口或 OAS 3.2；下方 `v0.5.0` 及更早小节保留各自历史范围，不包含这些后续 OAS 3.1 改动。
 :::
 
 ## 安装
@@ -20,8 +20,33 @@ Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 UI 与调试�
 Go module 需要 Go 1.22 或更高版本：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.5.0
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.6.0
 ```
+
+## v0.6.0
+
+Go 1.22 基线、module 路径、`Config`、`NewHandler` 与路由语义保持不变。
+内嵌 React UI 新增以下能力，已有 OAS 3.0.x 路径继续保留：
+
+- OAS 3.1 与 JSON Schema 2020-12 字段树和模型，保留作者示例，并在预算内生成经校验的候选示例。
+- 参数与 JSON、urlencoded、multipart 请求体的 Schema 校验和编码，以及非阻断的 JSON 响应诊断。
+- 对已发现的精确 URI 授权后加载跨文档资源，以同一不可变资源图支持解析、诊断、导出和变化提示。
+- 在完整资源图下导出可移植的单接口 OpenAPI JSON；HTML、Markdown、DOC、DOCX 使用同一离线快照；`paths` 操作的变化指纹与 OAS 3.0 基线隔离。
+- 修复长 FQN 类型挤压字段列及悬浮预览溢出，并补齐资源消费、编码锚点导出和示例缺失诊断。
+
+外部资源默认拒绝，SchemaEngine 只使用已登记的资源，不自行联网；不执行未知方言或自定义词汇。
+显式 Cookie 参数仅支持预览和 cURL，浏览器真实发送前阻断；不提供 Cookie jar 写入、主动 Webhook 调用
+或 `mutualTLS` 客户端证书注入。完整能力与浏览器限制见 [OpenAPI 3.1 支持与迁移](/guide/openapi31)。
+
+已合并改动包括示例 [#715](https://github.com/songxychn/knife4j-next/pull/715)、
+资源图 [#727](https://github.com/songxychn/knife4j-next/pull/727)、
+表单 [#728](https://github.com/songxychn/knife4j-next/pull/728) / [#730](https://github.com/songxychn/knife4j-next/pull/730)、
+单接口导出 [#732](https://github.com/songxychn/knife4j-next/pull/732) / [#733](https://github.com/songxychn/knife4j-next/pull/733)、
+离线导出 [#734](https://github.com/songxychn/knife4j-next/pull/734)、
+变化提示 [#736](https://github.com/songxychn/knife4j-next/pull/736)、
+FQN 展示 [#731](https://github.com/songxychn/knife4j-next/pull/731)，以及
+Schema 预扫描 [#743](https://github.com/songxychn/knife4j-next/pull/743) 和
+后续语义修复 [#750](https://github.com/songxychn/knife4j-next/pull/750)。
 
 ## v0.5.0
 
@@ -106,7 +131,7 @@ func main() {
 
 ## 使用边界
 
-- 只消费已有的 OpenAPI 3 JSON，不生成 spec，不支持 OAS2 / Swagger 2。
+- 只消费已有的 OpenAPI 3.0.x / 3.1.x JSON，不生成 spec，不支持 OAS2 / Swagger 2 或 OAS 3.2。
 - 只提供 `{BasePath}/doc.html` 入口，不为 `/` 或 `index.html` 增加重定向或 SPA fallback。
 - Go 核心只依赖标准库 `net/http`；Gin 是可运行示例，不是库依赖。
 - Go Handler 将配置注入 UI，Knife4x 不请求 Java 的 `/knife4j/config`。

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -10,7 +10,7 @@ title: 模块说明
 | --- | --- |
 | `knife4j/` | Java 主工程——用户实际引入的 starter 和 webjar 都在这里构建 |
 | `front/` | 活跃前端：`core` + `ui-react`（OAS3）、`vue3`（OAS2 兼容） |
-| `knife4x/` | 嵌入式控制台：Go `v0.5.0` 已发布，Rust 后置；UI 共用 `front/ui-react` |
+| `knife4x/` | 嵌入式控制台：Go `v0.6.0` 已发布，Rust 后置；UI 共用 `front/ui-react` |
 | `docs/` | 当前 VitePress 文档站 |
 | `tools/` | 验证、发布与任务看板脚本 |
 | `legacy/` | 冻结参考（`vue2`、`insight`、`sandbox`），不参与主线构建 |

--- a/knife4x/README.md
+++ b/knife4x/README.md
@@ -5,7 +5,7 @@ Knife4x 是面向 Go / Rust 宿主的进程内嵌入式 OpenAPI 3 文档与调�
 
 ## 定位
 
-- 只消费标准 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2
+- 只消费标准 OpenAPI 3.0.x / 3.1.x JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2 或 OAS 3.2
 - Go 核心只依赖标准库 `net/http`，不绑定 Gin、Echo、Chi 等 Web 框架
 - 与 Java 线 `knife4j-next` 同仓并共用 `front/ui-react` 与 `front/core`，但 module、版本和发布流程独立于 Java `5.x`
 - 宿主壳只负责嵌入静态 UI、注入配置和挂载路由，不复制前端业务逻辑
@@ -16,9 +16,13 @@ Go module 路径为：
 github.com/songxychn/knife4j-next/knife4x/go
 ```
 
-Go 当前公开版本为 `v0.5.0`，对应仓库 tag `knife4x/go/v0.5.0`；首个公开版本为
+Go 当前公开版本为 `v0.6.0`，对应仓库 tag `knife4x/go/v0.6.0`；首个公开版本为
 `v0.1.0`。tag 发布前可从仓库 checkout 直接运行 [Gin example](examples/gin/README.md)；
 发布状态与完整验收步骤见 [Go 发布清单](go/RELEASE.md)。
+
+`v0.6.0` 在保持 Go Handler API 与路由语义的基础上，将共享 React UI 的 OAS 3.1、
+JSON Schema 2020-12、受控资源图、调试诊断与导出能力纳入 Go 发布。
+具体能力和限制见 [Go 版本说明](../docs/knife4x/index.md)；`v0.5.0` 的历史说明不包含这些后续改动。
 
 ## 快速开始
 
@@ -43,7 +47,7 @@ go run . -base-path /internal
 
 从 `gin-swagger` 切换前，请先阅读
 [迁移说明](go/MIGRATING_FROM_GIN_SWAGGER.md)：Knife4x 只接受 JSON 顶层
-`openapi: 3.x` 的文档，不能直接加载 Swagger 2 / OAS2。
+`openapi: 3.0.x` 或 `openapi: 3.1.x` 的文档，不能直接加载 Swagger 2 / OAS2。
 
 ## 当前目录
 

--- a/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+++ b/knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
@@ -12,14 +12,19 @@ Knife4x 替换的是嵌入式文档与调试 UI，不替代 OpenAPI 生成器。
 }
 ```
 
-只有 `openapi: 3.x` JSON 可以继续。若文档使用 `swagger: "2.0"`，请先升级生成器或转换
-spec；OAS2 不能直接迁移到 Knife4x。
+只有 `openapi: 3.0.x` 或 `openapi: 3.1.x` JSON 可以继续；入口不接受 YAML 或 OAS 3.2。
+若文档使用 `swagger: "2.0"`，请先升级生成器或转换 spec；OAS2 不能直接迁移到 Knife4x。
 
-Knife4x Go 当前公开版本为 `v0.5.0`：
+Knife4x Go 当前公开版本为 `v0.6.0`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.5.0
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.6.0
 ```
+
+从 `v0.5.0` 升级不需要修改 `Config`、`NewHandler` 或挂载路径。OAS 3.1 支持从
+`v0.6.0` 纳入 Go 发布；请让生成器输出有效的 3.1 文档，不要只替换版本字符串。
+外部资源仍需按精确 URI 授权，未知方言与浏览器调试限制见
+[OpenAPI 3.1 支持与迁移](../../docs/guide/openapi31.md)。
 
 ## 替换挂载代码
 
@@ -72,7 +77,7 @@ handler, err := knife4x.NewHandler(knife4x.Config{
 
 ## 核对清单
 
-- spec 顶层是 `openapi: 3.x`
+- spec 为 JSON，顶层是 `openapi: 3.0.x` 或 `openapi: 3.1.x`
 - 宿主实际提供 `SpecURL` 指向的文档
 - 根路径打开 `/doc.html`，或在子路径打开 `${BasePath}/doc.html`
 - Try-it 请求命中预期业务 URL

--- a/knife4x/go/README.md
+++ b/knife4x/go/README.md
@@ -6,14 +6,26 @@ Go module：
 github.com/songxychn/knife4j-next/knife4x/go
 ```
 
-Knife4x 只消费 OpenAPI 3 JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2。核心只依赖
+Knife4x 只消费 OpenAPI 3.0.x / 3.1.x JSON 文档，不生成 spec，不支持 OAS2 / Swagger 2 或 OAS 3.2。核心只依赖
 标准库 `net/http`；Gin 只是可运行的组合示例，不是库依赖。
 
-当前公开版本为 `v0.5.0`，对应仓库 tag `knife4x/go/v0.5.0`：
+当前公开版本为 `v0.6.0`，对应仓库 tag `knife4x/go/v0.6.0`：
 
 ```bash
-go get github.com/songxychn/knife4j-next/knife4x/go@v0.5.0
+go get github.com/songxychn/knife4j-next/knife4x/go@v0.6.0
 ```
+
+`v0.6.0` 保持 Go 1.22 基线、`Config`、`NewHandler` 与路由语义不变，内嵌 React UI
+新增 OAS 3.1 与 JSON Schema 2020-12 字段树、示例、参数和请求体校验、响应诊断、
+受控跨文档资源加载、单接口可移植 JSON 与离线文档导出，以及接口变化提示；同时修复长 FQN 类型展示。
+OAS 3.0.x 继续沿用既有路径。版本明细见 [Go 版本说明](../../docs/knife4x/index.md)。
+
+外部资源默认拒绝，须对已发现的精确 URI 授权；SchemaEngine 只使用已登记的资源，不自行联网。
+不执行未知方言或自定义词汇，不提供 Cookie jar 写入、主动 Webhook 调用或客户端证书注入。
+显式 Cookie 参数可预览或生成 cURL，浏览器真实发送前会阻断；完整边界见
+[OpenAPI 3.1 支持与迁移](../../docs/guide/openapi31.md)。
+
+### v0.5.0（历史版本）
 
 `v0.5.0` 保持 `Config`、`NewHandler` 与路由语义不变，内嵌 React UI 新增页签左右
 关闭、响应状态概要、Knife4j 本地数据安全清理、单接口 OpenAPI 3.0.x 下载，以及按
@@ -60,7 +72,7 @@ func servePing(w http.ResponseWriter, _ *http.Request) {
 }
 ```
 
-把顶层为 `openapi: 3.x` 的 JSON 保存为当前目录的 `openapi.json`。启动后打开
+把顶层为 `openapi: 3.0.x` 或 `openapi: 3.1.x` 的 JSON 保存为当前目录的 `openapi.json`。启动后打开
 <http://localhost:8080/doc.html>。
 
 `Config` 只有两个字段：

--- a/knife4x/go/RELEASE.md
+++ b/knife4x/go/RELEASE.md
@@ -8,15 +8,27 @@
 |---|---|
 | Go module | `github.com/songxychn/knife4j-next/knife4x/go` |
 | 首个版本 | `v0.1.0` |
-| 当前版本 | `v0.5.0` |
-| 当前 tag | `knife4x/go/v0.5.0` |
+| 当前版本 | `v0.6.0` |
+| 当前 tag | `knife4x/go/v0.6.0` |
 | 许可证 | Apache-2.0 |
 
 Go module 位于仓库子目录，因此按
 [Go Modules Reference](https://go.dev/ref/mod#mapping-versions-to-commits)，tag 必须带
-`knife4x/go/` 前缀。Knife4x 版本独立于 Java `5.x`；现有 Java Release 与 Demo
-workflow 的自动 tag 触发器只接收根级 `v*` tag，不接收 `knife4x/go/v*`。
+`knife4x/go/` 前缀。Knife4x 版本独立于 Java `5.x`；现有 Java Release
+workflow 的自动 tag 触发器只接收根级 `v*` tag，不接收 `knife4x/go/v*`；Demo
+由 Java Release 完成公开制品核验后调用，不由 Go tag 触发。
 `./tools/test-knife4x-go.sh` 会以无副作用断言保护这条边界。
+
+## v0.6.0 发布范围
+
+相较于 `knife4x/go/v0.5.0`，本次将已合入的共享 React UI OAS 3.1、JSON Schema
+2020-12、受控资源图、示例、调试诊断、导出、接口变化提示与 FQN 展示修复纳入 Go 发布。
+具体变更与已合并 PR 见 [Go 版本说明](../../docs/knife4x/index.md)。
+
+Go 1.22 基线、module、`Config`、`NewHandler` 与路由语义保持不变。入口只消费已有的
+OpenAPI 3.0.x / 3.1.x JSON；OAS 3.2、未知方言与自定义词汇执行、Cookie jar 写入、
+主动 Webhook 调用和客户端证书注入不在范围内。外部资源保持默认拒绝、精确 URI 授权与
+registry-only 解析，完整限制见 [OpenAPI 3.1 支持与迁移](../../docs/guide/openapi31.md)。
 
 ## 发布前门禁
 
@@ -41,18 +53,18 @@ git diff --check
 Java tag 路由隔离。再检查将进入 module 下载包的许可证与 UI 资产：
 
 ```bash
-test -f knife4x/go/LICENSE
-test -f knife4x/go/internal/ui/static/index.html
-test -f knife4x/go/internal/ui/static/assets/index.js
-test -f knife4x/go/internal/ui/static/assets/index.css
+test -s knife4x/go/LICENSE
+test -s knife4x/go/internal/ui/static/index.html
+test -s knife4x/go/internal/ui/static/assets/index.js
+test -s knife4x/go/internal/ui/static/assets/index.css
 ```
 
 最后核对用户入口与迁移文档：
 
 ```bash
 grep -Fq 'github.com/songxychn/knife4j-next/knife4x/go' knife4x/README.md
-grep -Fq 'knife4x/go/v0.5.0' knife4x/README.md knife4x/go/README.md
-grep -Fq 'go@v0.5.0' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
+grep -Fq 'knife4x/go/v0.6.0' knife4x/README.md knife4x/go/README.md
+grep -Fq 'go@v0.6.0' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 grep -Fq 'OAS2 不能直接迁移' knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md
 test -z "$(git status --porcelain)"
 ```
@@ -62,11 +74,11 @@ test -z "$(git status --porcelain)"
 以下命令不属于 ready-to-tag 工作项。只有维护者明确授权发布后才执行：
 
 ```bash
-git tag -a knife4x/go/v0.5.0 -m "Knife4x Go v0.5.0"
-git push origin knife4x/go/v0.5.0
+git tag -a knife4x/go/v0.6.0 -m "Knife4x Go v0.6.0"
+git push origin knife4x/go/v0.6.0
 ```
 
-不要同时创建根级 `v0.5.0` tag，不要运行 Java Maven Release，不要为本次发布新增
+不要同时创建根级 `v0.6.0` tag，不要运行 Java Maven Release，不要为本次发布新增
 registry、OIDC、secret 或 GitHub Release。
 
 ## 发布后公共消费验证
@@ -76,7 +88,7 @@ proxy 记录的 origin hash 与 annotated tag 指向的 commit 一致，且 ref 
 
 ```bash
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.5.0
+version=v0.6.0
 tag="knife4x/go/${version}"
 tag_commit="$(git rev-list -n 1 "$tag")"
 proxy_info="$(curl -fsS "https://proxy.golang.org/${module}/@v/${version}.info")"
@@ -92,14 +104,14 @@ test "$proxy_ref" = "refs/tags/$tag"
 
 ```bash
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.5.0
+version=v0.6.0
 sum_response="$(curl -fsS "https://sum.golang.org/lookup/${module}@${version}")"
 printf '%s\n' "$sum_response"
 printf '%s\n' "$sum_response" | grep -F "${module} ${version} h1:"
 printf '%s\n' "$sum_response" | grep -F "${module} ${version}/go.mod h1:"
 ```
 
-最后用全新 consumer 下载、编译并挂载 Handler。`GONOPROXY=none` 强制该公开 module
+最后用全新 consumer 下载、编译并运行 Handler。`GONOPROXY=none` 强制该公开 module
 仍通过公共 proxy 下载；临时 `GOMODCACHE` 避免复用本机缓存：
 
 ```bash
@@ -107,7 +119,7 @@ consumer_dir="$(mktemp -d)"
 trap 'rm -rf "$consumer_dir"' EXIT
 
 module=github.com/songxychn/knife4j-next/knife4x/go
-version=v0.5.0
+version=v0.6.0
 export GOPROXY=https://proxy.golang.org
 export GONOPROXY=none
 export GOMODCACHE="$consumer_dir/modcache"
@@ -120,7 +132,9 @@ cat > main.go <<'EOF'
 package main
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 
 	knife4x "github.com/songxychn/knife4j-next/knife4x/go"
 )
@@ -133,7 +147,14 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	_ = &http.Server{Addr: ":8080", Handler: handler}
+	for _, path := range []string{"/doc.html", "/assets/index.js", "/assets/index.css"} {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+		if recorder.Code != http.StatusOK || recorder.Body.Len() == 0 {
+			panic(fmt.Sprintf("empty or unsuccessful Handler response for %s: %d", path, recorder.Code))
+		}
+	}
+	fmt.Println("knife4x-consumer-ok")
 }
 EOF
 
@@ -143,17 +164,18 @@ if grep -Eq '^[[:space:]]*replace([[:space:](])' go.mod; then
 fi
 
 go build ./...
+go run .
 go list -m all | grep -Fx "$module $version"
 
 module_dir="$(go list -m -f '{{.Dir}}' "$module")"
-test -f "$module_dir/LICENSE"
-test -f "$module_dir/internal/ui/static/index.html"
-test -f "$module_dir/internal/ui/static/assets/index.js"
-test -f "$module_dir/internal/ui/static/assets/index.css"
+test -s "$module_dir/LICENSE"
+test -s "$module_dir/internal/ui/static/index.html"
+test -s "$module_dir/internal/ui/static/assets/index.js"
+test -s "$module_dir/internal/ui/static/assets/index.css"
 ```
 
 只有公共 proxy 的 origin hash / ref、`sum.golang.org` checksum、无 `replace` consumer
-编译和下载内容检查都通过后，才可宣布 Knife4x Go `v0.5.0` 发布完成。
+编译、Handler 运行和下载内容检查都通过后，才可宣布 Knife4x Go `v0.6.0` 发布完成。
 
 ## 补丁原则
 

--- a/knife4x/go/RELEASE.md
+++ b/knife4x/go/RELEASE.md
@@ -56,6 +56,7 @@ Java tag 路由隔离。再检查将进入 module 下载包的许可证与 UI �
 test -s knife4x/go/LICENSE
 test -s knife4x/go/internal/ui/static/index.html
 test -s knife4x/go/internal/ui/static/assets/index.js
+test -s knife4x/go/internal/ui/static/assets/index2.js
 test -s knife4x/go/internal/ui/static/assets/index.css
 ```
 
@@ -147,7 +148,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	for _, path := range []string{"/doc.html", "/assets/index.js", "/assets/index.css"} {
+	for _, path := range []string{"/doc.html", "/assets/index.js", "/assets/index2.js", "/assets/index.css"} {
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
 		if recorder.Code != http.StatusOK || recorder.Body.Len() == 0 {
@@ -171,6 +172,7 @@ module_dir="$(go list -m -f '{{.Dir}}' "$module")"
 test -s "$module_dir/LICENSE"
 test -s "$module_dir/internal/ui/static/index.html"
 test -s "$module_dir/internal/ui/static/assets/index.js"
+test -s "$module_dir/internal/ui/static/assets/index2.js"
 test -s "$module_dir/internal/ui/static/assets/index.css"
 ```
 


### PR DESCRIPTION
## 目标与冻结契约

Refs #753，关联 #699 / #750。维护者已明确授权本次同时发布 Go；Java 5.5.0 在 #752 / #754 独立准备。

本 PR 只准备 Knife4x Go `v0.6.0` 的当前版本入口和发布说明，不等同于 tag 已推送或公共版本已可消费。

- module 不变：`github.com/songxychn/knife4j-next/knife4x/go`；唯一新 tag 为 `knife4x/go/v0.6.0`。
- 保持 Go 1.22 基线、`Config`、`NewHandler` 与路由语义，只将已经合入的共享 React UI OAS 3.1 能力纳入下一次 Go 发布。
- 入口只消费现有 OAS 3.0.x / 3.1.x JSON；保留 registry-only / default-deny、精确 URI 授权及浏览器限制。
- 非目标：OAS 3.2、OAS2、YAML 入口、未知方言或自定义词汇执行、Cookie jar 写入、主动 Webhook 调用、客户端证书注入、Rust 发布。
- 不修改运行时代码、依赖、module、生成资产、CI/workflow 或 secrets；不创建根级 `v0.6.0`、Go GitHub Release，也不由 Go tag 触发 Java Release / Demo。

## 变更

- 更新 README、文档站、模块表和 gin-swagger 迁移入口为 v0.6.0，保留 v0.5.0 及更早版本历史。
- 单列 v0.6.0 已合并产品变化：Schema/示例、参数与请求体、响应诊断、受控资源图、导出、变化提示及 FQN 展示修复，链接原始 PR 与 OAS 3.1 支持矩阵。
- 补齐发布清单中的非空资源检查，覆盖 `index2.js` SchemaEngine chunk；公共消费者从只编译加强为运行 Handler 并验证 HTML、两份 JS 和 CSS 响应。
- 纠正清单中的现有 Demo 调用关系：由 Java Release 完成公开制品验证后调用，而非由 Go tag 触发。没有修改 workflow。

实际变更仅 8 个 Markdown 文件：`README.md`、`docs/index.md`、`docs/knife4x/index.md`、`docs/reference/modules.md`、`knife4x/README.md`、`knife4x/go/README.md`、`knife4x/go/MIGRATING_FROM_GIN_SWAGGER.md`、`knife4x/go/RELEASE.md`。

## 精确提交与本地验证

- base：`40d0aaffc840489fe182b252b9973ecf3b8c9d1f`
- head：`e9e33a758fc747cf1d5cda1230f1ca5d8139218d`
- 主 module 与 Gin example 的 `go mod tidy -diff`：通过，无变更。
- `./tools/test-knife4x-go.sh`：通过（格式、vet、测试、Gin 根路径/子路径及 Java tag 路由隔离）。
- `./tools/sync-knife4x-ui.sh --check`：通过，生成资源与共享源码一致，无资产 diff。
- `./tools/test-ci-changes.sh`：通过。
- `./tools/test-docs.sh`：通过，最终文档提交后重跑成功。
- `git diff --check`：通过；工作区干净。
- module 下载包候选文件均非空：LICENSE 10,251 bytes、HTML 457 bytes、index.js 4,074,839 bytes、index2.js 105,121 bytes、CSS 6,985 bytes。
- 本地工具 Go 1.25.5 / Node 24.19 / Bun 1.4；`go.mod` 的 Go 1.22 声明不变。

环境记录：缓存/临时目录写入曾被沙箱拒绝，同一标准命令在受控权限下重试通过，未修改门禁。普通提交有共享旧 hook 的 `Can't find lefthook in PATH` 提示但退出 0；未使用 `--no-verify`、未改 hook，已显式执行标准验证。

## 审查、CI 与发布检查点

当前 head 的独立 full 审查和 PR CI 均已通过；一轮 full + 必要时一轮 focused，不扩大到已合并 OAS 实现的第三轮审查。

- 独立 reviewer 使用全新上下文，自行读取 live #753 / #755、全部实际 diff、当前实现的 Handler 路径与发布 workflow，并独立执行 `test-ci-changes.sh` 和 `git diff --check`。
- reviewed base / head 为本 PR 上列的 `40d0aaffc840489fe182b252b9973ecf3b8c9d1f..e9e33a758fc747cf1d5cda1230f1ca5d8139218d`；结论 `approve`，无 findings / scope drift / scope follow-ups。未修改产品 API 或生成资产。
- reviewer 返回时 Java CI 仍在运行；主 agent 随后核实 [Build 33947954688](https://github.com/songxychn/knife4j-next/actions/runs/33947954688) 已在同一 head 全部成功：changes、Java、front、Go（含 UI sync）、Vue3、docs 共 6 项。
- 两条发布分支仅以 `git merge-tree` 计算合并结果，未发现共享文档冲突；没有实际合并分支或 PR。
- 尚未创建或推送新 tag；公共 Go Proxy / checksum / 隔离 consumer 验收保留为发布阶段门禁，不以准备 PR 的通过结论替代。

维护者合并准备 PR 后，需核对最终 master SHA 与 CI，再创建 annotated `knife4x/go/v0.6.0`。随后独立验证公共 Go Proxy 的 Origin.Hash / Origin.Ref、sum.golang.org 的 module / go.mod 两条记录，以及全新隔离缓存、无 replace、无 direct fallback 的下载、编译、Handler 运行和打包资源完整性。

以上公开验收全部通过后再关闭 #753；本 PR 不自动关闭发布 issue。
