### PR TITLE
fix(ci): 优化 Central 制品校验的重试与诊断

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -41,7 +41,17 @@ Spring Boot 配置 key 或关键公开入口漂移会失败。japicmp 按单模�
 - `verify-maven-central.sh`：按精确 URL 有界轮询公共 POM/JAR、签名和 SHA-1，并检查 UI JAR 可读取。
 - `extract-release-note.sh`、`verify-github-release.sh`：生成并核对幂等 GitHub Release。
 
-`verify-maven-central.sh` 默认最多检查 31 次、每次间隔 60 秒；测试或故障排查可通过 `MAVEN_CENTRAL_MAX_ATTEMPTS`、`MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS` 和 `MAVEN_CENTRAL_BASE_URL` 收紧边界。
+`verify-maven-central.sh` 默认最多检查 31 轮，每轮只重试尚未通过的精确 URL 或 UI JAR
+可读性检查。成功记录只保留在本次进程内，不跨版本、进程或 job 复用；新一次执行仍须
+检查完整清单，URL 探测成功不能替代 UI JAR 的完整下载和归档检查。
+
+仅剩网络传输错误（例如连接重置、DNS / 连接失败、超时或不完整传输）时，默认 2 秒后
+重试；404、其他 HTTP 错误、证书验证失败或不可读归档等使用原有的 60 秒间隔，混合错误
+也使用该常规间隔。每轮立即输出失败文件及具体原因，全部失败路径仍受总轮数和请求超时限制。
+测试或故障排查可配置 `MAVEN_CENTRAL_MAX_ATTEMPTS`、`MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS`、
+`MAVEN_CENTRAL_NETWORK_RETRY_INTERVAL_SECONDS` 和 `MAVEN_CENTRAL_BASE_URL`；两种间隔均允许
+设为 `0`；网络等待取两种间隔的较小值，因此原有只设置常规间隔为 `0` 的调用仍不会等待。
+这些设置不会改变制品完整性要求，本优化不会重发 Maven 制品或触发 Demo / Release。
 
 ## 任务看板
 

--- a/tools/test-fixtures/mock-maven-central-curl.sh
+++ b/tools/test-fixtures/mock-maven-central-curl.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 output_file="/dev/null"
 is_head=false
+request_kind=probe
 url=""
 
 while [ "$#" -gt 0 ]; do
@@ -41,10 +42,14 @@ if [ -z "$url" ]; then
   exit 2
 fi
 
-mkdir -p "$MOCK_CURL_STATE_DIR"
-printf '%s\t%s\n' "$is_head" "$url" >> "$MOCK_CURL_STATE_DIR/requests.log"
+if [ "$is_head" = false ] && [ "$output_file" != "/dev/null" ]; then
+  request_kind=download
+fi
 
-key="$(printf '%s' "$url" | cksum | awk '{print $1}')"
+mkdir -p "$MOCK_CURL_STATE_DIR"
+printf '%s\t%s\t%s\n' "$is_head" "$url" "$request_kind" >> "$MOCK_CURL_STATE_DIR/requests.log"
+
+key="$(printf '%s' "$request_kind:$url" | cksum | awk '{print $1}')"
 count_file="$MOCK_CURL_STATE_DIR/$key.count"
 count=0
 if [ -f "$count_file" ]; then
@@ -53,11 +58,13 @@ fi
 count=$((count + 1))
 printf '%s\n' "$count" > "$count_file"
 
-while IFS='|' read -r pattern failure_count http_code exit_status message; do
+while IFS='|' read -r pattern failure_count http_code exit_status message kind first_failure; do
   if [ -z "$pattern" ]; then
     continue
   fi
-  if [[ "$url" == *"$pattern"* ]] && [ "$count" -le "$failure_count" ]; then
+  if [ "${url##*/}" = "$pattern" ] && \
+    { [ "${kind:-any}" = any ] || [ "$kind" = "$request_kind" ]; } && \
+    [ "$count" -ge "${first_failure:-1}" ] && [ "$count" -le "$failure_count" ]; then
     printf '%s' "$http_code"
     if [ -n "$message" ]; then
       printf '%s\n' "$message" >&2

--- a/tools/test-release-tools.sh
+++ b/tools/test-release-tools.sh
@@ -43,7 +43,8 @@ mkdir -p \
   "$fixture_root/tools" \
   "$fixture_root/knife4j/api" \
   "$fixture_root/knife4j/bom" \
-  "$fixture_root/knife4j/knife4j-test-ui"
+  "$fixture_root/knife4j/knife4j-test-ui" \
+  "$fixture_root/knife4j/knife4j-other-ui"
 
 printf '%s\n' \
   '<project>' \
@@ -55,7 +56,8 @@ printf '%s\n' \
 printf '%s\n' '<project>' '<artifactId>api</artifactId>' '</project>' > "$fixture_root/knife4j/api/pom.xml"
 printf '%s\n' '<project>' '<artifactId>bom</artifactId>' '<packaging>pom</packaging>' '</project>' > "$fixture_root/knife4j/bom/pom.xml"
 printf '%s\n' '<project>' '<artifactId>knife4j-test-ui</artifactId>' '</project>' > "$fixture_root/knife4j/knife4j-test-ui/pom.xml"
-printf '%s\n' api bom knife4j-test-ui > "$fixture_root/tools/release-modules.txt"
+printf '%s\n' '<project>' '<artifactId>knife4j-other-ui</artifactId>' '</project>' > "$fixture_root/knife4j/knife4j-other-ui/pom.xml"
+printf '%s\n' api bom knife4j-test-ui knife4j-other-ui > "$fixture_root/tools/release-modules.txt"
 [ ! -e "$fixture_root/tools/verify-maven-central.sh" ] || \
   fail "legacy release fixture must not contain the current Central verifier"
 
@@ -65,29 +67,43 @@ mkdir -p "$jar_payload/META-INF/resources"
 printf '<!doctype html>\n' > "$jar_payload/META-INF/resources/doc.html"
 jar cf "$valid_jar" -C "$jar_payload" .
 
+# Record requested waits without making the offline suite wait for real time.
+mkdir -p "$tmp_root/mock-bin"
+printf '%s\n' '#!/usr/bin/env bash' \
+  'printf "%s\n" "$1" >> "${MOCK_SLEEP_LOG:?}"' > "$tmp_root/mock-bin/sleep"
+chmod +x "$tmp_root/mock-bin/sleep"
+
 verifier_status=0
 verifier_log=""
 verifier_requests=""
+verifier_sleeps=""
 
 run_verifier() {
   local name="$1"
   local plan_content="$2"
   local attempts="$3"
   local invalid_jar_pattern="${4:-}"
+  local retry_interval="${5:-60}"
+  local network_retry_interval="${6-}"
   local case_root="$tmp_root/$name"
   local plan_file="$case_root/plan"
 
   mkdir -p "$case_root/state"
-  printf '%s' "$plan_content" > "$plan_file"
+  printf '%s\n' "$plan_content" > "$plan_file"
   verifier_log="$case_root/output.log"
   verifier_requests="$case_root/state/requests.log"
+  verifier_sleeps="$case_root/sleeps.log"
+  : > "$verifier_sleeps"
 
   set +e
   env \
+    PATH="$tmp_root/mock-bin:$PATH" \
+    MOCK_SLEEP_LOG="$verifier_sleeps" \
     VERIFY_MAVEN_REPO_ROOT="$fixture_root" \
     MAVEN_CENTRAL_BASE_URL="https://central.example/maven2" \
     MAVEN_CENTRAL_MAX_ATTEMPTS="$attempts" \
-    MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS=0 \
+    MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS="$retry_interval" \
+    MAVEN_CENTRAL_NETWORK_RETRY_INTERVAL_SECONDS="$network_retry_interval" \
     MAVEN_CENTRAL_CONNECT_TIMEOUT_SECONDS=1 \
     MAVEN_CENTRAL_REQUEST_TIMEOUT_SECONDS=1 \
     MAVEN_CENTRAL_CURL_BIN="$mock_curl" \
@@ -100,12 +116,35 @@ run_verifier() {
   set -e
 }
 
+assert_request_count() {
+  local filename="$1"
+  local kind="$2"
+  local expected="$3"
+  local actual
+  actual="$(awk -F '\t' -v filename="$filename" -v kind="$kind" '
+    { count = split($2, parts, "/") }
+    parts[count] == filename && $3 == kind { matches++ }
+    END { print matches + 0 }
+  ' "$verifier_requests")"
+  [ "$actual" -eq "$expected" ] || \
+    fail "$filename $kind requests: expected $expected, got $actual"
+}
+
+assert_sleeps() {
+  local expected="$1"
+  local actual
+  actual="$(paste -sd, "$verifier_sleeps")"
+  [ "$actual" = "$expected" ] || fail "retry waits: expected '$expected', got '$actual'"
+}
+
 run_verifier all-available "" 1
 [ "$verifier_status" -eq 0 ] || fail "all available case should pass"
 assert_contains "$verifier_log" "Maven Central artifacts OK"
 assert_contains "$verifier_requests" "https://central.example/maven2/com/example/bom/1.2.3/bom-1.2.3.pom"
 assert_not_contains "$verifier_requests" 'com\/example'
 assert_not_contains "$verifier_requests" "bom-1.2.3.jar"
+assert_contains "$verifier_log" "24 exact files, 2 UI JARs readable"
+assert_sleeps ""
 
 run_verifier delayed $'api-1.2.3.jar|1|404|22|not found\n' 2
 [ "$verifier_status" -eq 0 ] || fail "404 then available case should pass"
@@ -132,6 +171,126 @@ assert_contains "$verifier_log" "operation timed out"
 run_verifier unreadable-ui "" 1 "knife4j-test-ui-1.2.3.jar"
 [ "$verifier_status" -ne 0 ] || fail "unreadable UI JAR should fail"
 assert_contains "$verifier_log" "downloaded UI JAR is unreadable"
+
+run_verifier transient-network $'api-1.2.3.jar|1|000|35|Recv failure: Connection reset by peer\n' 2
+[ "$verifier_status" -eq 0 ] || fail "transient TLS reset should recover"
+assert_sleeps "2"
+assert_contains "$verifier_log" "curl 35"
+assert_contains "$verifier_log" "Recv failure: Connection reset by peer"
+assert_contains "$verifier_log" "network/transfer failures"
+assert_not_contains "$verifier_log" "Central not ready"
+assert_request_count api-1.2.3.jar probe 2
+assert_request_count parent-1.2.3.pom probe 1
+assert_request_count api-1.2.3.jar.asc probe 1
+[ "$(wc -l < "$verifier_requests")" -eq 27 ] || \
+  fail "one transient failure should need 24 probes + 1 retry + 2 UI downloads"
+
+# If an already successful URL is checked again, it fails from its second call.
+run_verifier rotating-network $'api-1.2.3.jar|1|000|35|reset\nbom-1.2.3.pom|99|000|35|reset|probe|2\n' 3
+[ "$verifier_status" -eq 0 ] || fail "successful URLs must survive rotating network failures"
+assert_sleeps "2"
+assert_request_count bom-1.2.3.pom probe 1
+assert_request_count api-1.2.3.jar probe 2
+
+run_verifier persistent-network $'api-1.2.3.jar|99|000|35|reset\n' 3
+[ "$verifier_status" -ne 0 ] || fail "persistent TLS failure must remain bounded and fail"
+assert_sleeps "2,2"
+assert_request_count api-1.2.3.jar probe 3
+assert_request_count parent-1.2.3.pom probe 1
+assert_request_count knife4j-test-ui-1.2.3.jar download 0
+assert_contains "$verifier_log" "timed out after 3 attempt(s)"
+
+run_verifier early-diagnostics $'api-1.2.3.jar|1|404|22|not found\n' 2
+[ "$verifier_status" -eq 0 ] || fail "delayed publication should still recover"
+assert_sleeps "60"
+assert_contains "$verifier_log" "HTTP 404"
+assert_request_count api-1.2.3.jar probe 2
+assert_request_count api-1.2.3.jar.asc probe 1
+diagnostic_line="$(awk '/HTTP 404/ { print NR; exit }' "$verifier_log")"
+retry_line="$(awk '/retrying in/ { print NR; exit }' "$verifier_log")"
+[ "$diagnostic_line" -lt "$retry_line" ] || fail "failure details must precede the first wait"
+
+run_verifier mixed-errors $'api-1.2.3.jar|1|000|35|reset\nbom-1.2.3.pom|1|404|22|not found\n' 2
+[ "$verifier_status" -eq 0 ] || fail "mixed network and publication failures should recover"
+assert_sleeps "60"
+assert_contains "$verifier_log" "curl 35"
+assert_contains "$verifier_log" "HTTP 404"
+assert_request_count parent-1.2.3.pom probe 1
+
+run_verifier http-error $'api-1.2.3.jar|1|503|22|unavailable\n' 2
+[ "$verifier_status" -eq 0 ] || fail "HTTP response failures should retain the normal interval"
+assert_sleeps "60"
+assert_contains "$verifier_log" "HTTP 503"
+
+for code in 5 6 7 16 52 55 92; do
+  run_verifier "network-code-$code" "$(printf 'api-1.2.3.jar|1|000|%s|transport failure\n' "$code")" 2
+  [ "$verifier_status" -eq 0 ] || fail "curl $code should recover through network retries"
+  assert_sleeps "2"
+  assert_contains "$verifier_log" "curl $code"
+done
+
+for code in 23 47 60; do
+  run_verifier "non-network-code-$code" "$(printf 'api-1.2.3.jar|1|000|%s|non-transport failure\n' "$code")" 2
+  [ "$verifier_status" -eq 0 ] || fail "curl $code should preserve the normal retry path"
+  assert_sleeps "60"
+  assert_not_contains "$verifier_log" "network/transfer failures"
+done
+
+run_verifier custom-network-interval $'api-1.2.3.jar|1|000|28|timeout\n' 2 "" 60 1
+[ "$verifier_status" -eq 0 ] || fail "custom network retry interval should recover"
+assert_sleeps "1"
+
+run_verifier zero-network-interval $'api-1.2.3.jar|1|000|35|reset\n' 2 "" 0 0
+[ "$verifier_status" -eq 0 ] || fail "zero retry interval should be supported"
+assert_sleeps ""
+
+run_verifier legacy-zero-interval $'api-1.2.3.jar|1|000|35|reset\n' 2 "" 0
+[ "$verifier_status" -eq 0 ] || fail "existing callers setting only the normal interval to zero must not wait"
+assert_sleeps ""
+
+run_verifier tighter-normal-interval $'api-1.2.3.jar|1|000|35|reset\n' 2 "" 1 5
+[ "$verifier_status" -eq 0 ] || fail "network retry must not exceed the normal interval"
+assert_sleeps "1"
+
+run_verifier ui-download-network $'knife4j-other-ui-1.2.3.jar|1|000|56|receive failed|download\n' 2
+[ "$verifier_status" -eq 0 ] || fail "UI download network failure should recover"
+assert_sleeps "2"
+assert_request_count knife4j-test-ui-1.2.3.jar download 1
+assert_request_count knife4j-other-ui-1.2.3.jar download 2
+assert_request_count knife4j-other-ui-1.2.3.jar probe 1
+assert_contains "$verifier_log" "(readability)"
+assert_contains "$verifier_log" "curl 56"
+
+run_verifier ui-download-partial $'knife4j-other-ui-1.2.3.jar|1|200|18|partial transfer|download\n' 2
+[ "$verifier_status" -eq 0 ] || fail "partial 200 UI transfer must be retried, not accepted"
+assert_sleeps "2"
+assert_request_count knife4j-other-ui-1.2.3.jar download 2
+assert_contains "$verifier_log" "HTTP 200 (curl 18)"
+
+run_verifier ui-download-missing $'knife4j-other-ui-1.2.3.jar|99|404|22|not found|download\n' 2
+[ "$verifier_status" -ne 0 ] || fail "successful Range GET cannot replace a full UI download"
+assert_sleeps "60"
+assert_request_count knife4j-test-ui-1.2.3.jar download 1
+assert_request_count knife4j-other-ui-1.2.3.jar download 2
+assert_request_count knife4j-other-ui-1.2.3.jar probe 1
+
+run_verifier cached-ui-not-unreadable "" 2 "knife4j-other-ui-1.2.3.jar"
+[ "$verifier_status" -ne 0 ] || fail "unreadable UI archives must never enter the success cache"
+assert_sleeps "60"
+assert_request_count knife4j-test-ui-1.2.3.jar download 1
+assert_request_count knife4j-other-ui-1.2.3.jar download 2
+assert_contains "$verifier_log" "downloaded UI JAR is unreadable"
+
+run_verifier new-process-no-cache $'parent-1.2.3.pom.asc|99|404|22|signature missing\n' 1
+[ "$verifier_status" -ne 0 ] || fail "each invocation must independently verify all exact files"
+assert_request_count parent-1.2.3.pom.asc probe 1
+assert_request_count api-1.2.3.jar probe 1
+assert_contains "$verifier_log" "parent-1.2.3.pom.asc"
+
+run_verifier invalid-network-interval "" 1 "" 60 invalid
+[ "$verifier_status" -ne 0 ] || fail "invalid retry interval must fail before requesting artifacts"
+assert_contains "$verifier_log" "MAVEN_CENTRAL_NETWORK_RETRY_INTERVAL_SECONDS must be a non-negative integer"
+[ ! -e "$verifier_requests" ] || fail "invalid configuration must not send requests"
 
 make_context_repo() {
   local name="$1"

--- a/tools/verify-maven-central.sh
+++ b/tools/verify-maven-central.sh
@@ -19,6 +19,7 @@ parent_pom="${VERIFY_MAVEN_PARENT_POM:-$repo_root/knife4j/pom.xml}"
 base_url="${MAVEN_CENTRAL_BASE_URL:-https://repo.maven.apache.org/maven2}"
 max_attempts="${MAVEN_CENTRAL_MAX_ATTEMPTS:-31}"
 retry_interval="${MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS:-60}"
+network_retry_interval="${MAVEN_CENTRAL_NETWORK_RETRY_INTERVAL_SECONDS:-2}"
 connect_timeout="${MAVEN_CENTRAL_CONNECT_TIMEOUT_SECONDS:-10}"
 request_timeout="${MAVEN_CENTRAL_REQUEST_TIMEOUT_SECONDS:-30}"
 curl_bin="${MAVEN_CENTRAL_CURL_BIN:-curl}"
@@ -45,6 +46,7 @@ require_positive_integer() {
 
 require_positive_integer "MAVEN_CENTRAL_MAX_ATTEMPTS" "$max_attempts"
 require_non_negative_integer "MAVEN_CENTRAL_RETRY_INTERVAL_SECONDS" "$retry_interval"
+require_non_negative_integer "MAVEN_CENTRAL_NETWORK_RETRY_INTERVAL_SECONDS" "$network_retry_interval"
 require_positive_integer "MAVEN_CENTRAL_CONNECT_TIMEOUT_SECONDS" "$connect_timeout"
 require_positive_integer "MAVEN_CENTRAL_REQUEST_TIMEOUT_SECONDS" "$request_timeout"
 
@@ -154,13 +156,38 @@ done
 temporary_dir="$(mktemp -d)"
 trap 'rm -rf "$temporary_dir"' EXIT
 probe_error=""
+probe_network_error=false
+
+record_curl_failure() {
+  local http_code="$1"
+  local curl_status="$2"
+  local error_file="$3"
+  local error_text=""
+
+  # Keep HTTP errors, certificate validation and local/configuration failures on
+  # the normal interval. Only transport failures qualify for the shorter wait.
+  case "$curl_status" in
+    5|6|7|16|18|28|35|52|55|56|92) probe_network_error=true ;;
+  esac
+  if [ -s "$error_file" ]; then
+    error_text="$(tr '\n' ' ' < "$error_file" | sed 's/[[:space:]]*$//')"
+  fi
+  if [ -n "$http_code" ] && [ "$http_code" != "000" ]; then
+    probe_error="HTTP $http_code (curl $curl_status)"
+  else
+    probe_error="curl $curl_status"
+  fi
+  if [ -n "$error_text" ]; then
+    probe_error="$probe_error: $error_text"
+  fi
+}
 
 probe_url() {
   local url="$1"
   local error_file="$temporary_dir/curl-error"
   local http_code=""
   local curl_status=0
-  local error_text=""
+  probe_network_error=false
 
   if http_code="$("$curl_bin" \
     --fail \
@@ -183,17 +210,7 @@ probe_url() {
     curl_status=$?
   fi
 
-  if [ -s "$error_file" ]; then
-    error_text="$(tr '\n' ' ' < "$error_file" | sed 's/[[:space:]]*$//')"
-  fi
-  if [ -n "$http_code" ] && [ "$http_code" != "000" ]; then
-    probe_error="HTTP $http_code (curl $curl_status)"
-  else
-    probe_error="curl $curl_status"
-  fi
-  if [ -n "$error_text" ]; then
-    probe_error="$probe_error: $error_text"
-  fi
+  record_curl_failure "$http_code" "$curl_status" "$error_file"
   return 1
 }
 
@@ -204,7 +221,7 @@ download_and_inspect_ui() {
   local error_file="$temporary_dir/curl-error"
   local http_code=""
   local curl_status=0
-  local error_text=""
+  probe_network_error=false
 
   if http_code="$("$curl_bin" \
     --fail \
@@ -230,40 +247,51 @@ download_and_inspect_ui() {
     curl_status=$?
   fi
 
-  if [ -s "$error_file" ]; then
-    error_text="$(tr '\n' ' ' < "$error_file" | sed 's/[[:space:]]*$//')"
-  fi
-  if [ -n "$http_code" ] && [ "$http_code" != "000" ]; then
-    probe_error="HTTP $http_code (curl $curl_status)"
-  else
-    probe_error="curl $curl_status"
-  fi
-  if [ -n "$error_text" ]; then
-    probe_error="$probe_error: $error_text"
-  fi
+  record_curl_failure "$http_code" "$curl_status" "$error_file"
   return 1
 }
 
+# This evidence is local to this invocation/version/URL, never persisted or
+# shared between jobs. A successful probe does not verify UI JAR readability.
+verified_files=()
+verified_ui=()
 attempt=1
 while [ "$attempt" -le "$max_attempts" ]; do
   missing_modules=()
   missing_files=()
   missing_errors=()
+  only_network_errors=true
 
   for index in "${!expected_urls[@]}"; do
-    if ! probe_url "${expected_urls[$index]}"; then
+    if [ "${verified_files[$index]:-false}" = true ]; then
+      continue
+    fi
+    if probe_url "${expected_urls[$index]}"; then
+      verified_files[$index]=true
+    else
       missing_modules+=("${expected_modules[$index]}")
       missing_files+=("${expected_files[$index]}")
       missing_errors+=("$probe_error")
+      if [ "$probe_network_error" != true ]; then
+        only_network_errors=false
+      fi
     fi
   done
 
   if [ "${#missing_files[@]}" -eq 0 ]; then
     for index in "${!ui_urls[@]}"; do
-      if ! download_and_inspect_ui "${ui_modules[$index]}" "${ui_files[$index]}" "${ui_urls[$index]}"; then
+      if [ "${verified_ui[$index]:-false}" = true ]; then
+        continue
+      fi
+      if download_and_inspect_ui "${ui_modules[$index]}" "${ui_files[$index]}" "${ui_urls[$index]}"; then
+        verified_ui[$index]=true
+      else
         missing_modules+=("${ui_modules[$index]}")
         missing_files+=("${ui_files[$index]} (readability)")
         missing_errors+=("$probe_error")
+        if [ "$probe_network_error" != true ]; then
+          only_network_errors=false
+        fi
       fi
     done
   fi
@@ -273,22 +301,33 @@ while [ "$attempt" -le "$max_attempts" ]; do
     exit 0
   fi
 
+  wait_seconds="$retry_interval"
+  failure_kind="artifacts unavailable or unreadable"
+  if [ "$only_network_errors" = true ]; then
+    # Preserve an existing caller's tighter normal interval (including zero).
+    if [ "$network_retry_interval" -lt "$wait_seconds" ]; then
+      wait_seconds="$network_retry_interval"
+    fi
+    failure_kind="network/transfer failures"
+  fi
+  echo "Maven Central verification incomplete (attempt $attempt/$max_attempts): ${#missing_files[@]} file(s); $failure_kind." >&2
+  for index in "${!missing_files[@]}"; do
+    printf '  - %s: %s (%s)\n' \
+      "${missing_modules[$index]}" \
+      "${missing_files[$index]}" \
+      "${missing_errors[$index]}" >&2
+  done
+
   if [ "$attempt" -eq "$max_attempts" ]; then
     echo "::error::Maven Central verification timed out after $attempt attempt(s)." >&2
     failed_modules="$(printf '%s\n' "${missing_modules[@]}" | sort -u | paste -sd, -)"
     echo "::error::Unavailable modules/artifacts: $failed_modules" >&2
-    for index in "${!missing_files[@]}"; do
-      printf '  - %s: %s (%s)\n' \
-        "${missing_modules[$index]}" \
-        "${missing_files[$index]}" \
-        "${missing_errors[$index]}" >&2
-    done
     exit 1
   fi
 
-  echo "Maven Central not ready (attempt $attempt/$max_attempts): ${#missing_files[@]} file(s) unavailable; retrying in ${retry_interval}s." >&2
-  if [ "$retry_interval" -gt 0 ]; then
-    sleep "$retry_interval"
+  echo "Maven Central: retrying in ${wait_seconds}s (pending files only)." >&2
+  if [ "$wait_seconds" -gt 0 ]; then
+    sleep "$wait_seconds"
   fi
   attempt=$((attempt + 1))
 done


### PR DESCRIPTION
## 关联与冻结范围

Closes #758

维护者在排查 Demo 33 分 47 秒校验后明确要求优化。本 PR 仅修改公共 Central 校验脚本、既有离线测试 / mock 与使用说明，不修改 workflow、Maven 版本 / 坐标、secrets、tag 或产品代码；不触发发布或 Demo，不包含 #756。

Base：`1b56b1b229a793fbe727bdfb34c94087351417a4`；Head：`3df96cab9447f58c48dfff0e4e2f2869229ba273`。

## 变化

- 精确 URL / UI JAR 可读性分别记录本次进程内的成功结果，后续轮次只补查失败项；新进程重新执行完整清单，探测成功不能替代 UI 完整下载与归档检查。
- 仅剩网络传输故障时默认 2 秒后重试；404、其他 HTTP 错误、不可读归档和混合错误保留 60 秒常规间隔。实际网络间隔不超过调用方配置的常规间隔，兼容旧的零等待调用。
- 每轮直接报告失败模块、文件和具体错误，纯网络故障不再统一显示为 Central 未就绪。
- 新增 `MAVEN_CENTRAL_NETWORK_RETRY_INTERVAL_SECONDS`；轮数、连接 / 请求超时和完整性门禁保持有界且不降低，保持 Bash 3.2+。

## 复现与验证

- [基线红灯证据](https://github.com/songxychn/knife4j-next/issues/758#issuecomment-5550146969)：实现未改时，瞬时连接重置场景期待 2 秒等待，实际为 60 秒。
- `./tools/test-release-tools.sh` 通过：离线记录 sleep / 请求次数，不实际等待；单个瞬时失败的 24 URL / 2 UI 夹具只请求 27 次（24 次初检 + 1 次补查 + 2 次 UI 下载）。覆盖轮换 / 持续网络故障、404 / 混合错误、签名 / 校验缺失、curl 状态码、UI 部分传输 / 损坏 / 缺失、成功缓存隔离及旧参数兼容。
- `./tools/test-ci-changes.sh`、`./tools/verify-release-modules.sh`（16 模块）、修改脚本的 `bash -n` 和 `git diff --check` 通过。
- 显式 Corretto JDK 17 的真实只读 `MAVEN_CENTRAL_MAX_ATTEMPTS=3 ./tools/verify-maven-central.sh 5.5.0` 首轮通过：96 个精确文件，2 个 UI JAR 可读；已在上述固定 head 上再次首轮验收通过。
- 独立 full review 对上述精确 head 给出 approve，findings / scope drift / scope follow-ups 均为 none；独立重跑本地离线、路径分类、模块、Shell 语法与 diff 门禁通过，审查记录已评论到本 PR。
- 当前 head [Build CI 33951695550](https://github.com/songxychn/knife4j-next/actions/runs/33951695550) 整体 success：`changes` 和 `java-build-test` 成功，其余四项按既有路径规则 skipped。Java 构建、兼容报告与 smoke 门禁均通过。#758 已完成交付验收，等待维护者合并。

## 风险与非目标

成功记录是当前执行内对同一发布版本的逐项证据，不保证所有 URL 在同一瞬间可用，不跨 job 复用证明；缺任一必需项仍会失败。持续网络故障会更早耗尽同样的轮数，404 / 混合错误仍保留常规发布等待策略。本次不重传任何已发布制品，不移动 tag，不跳过 Demo 验收。

本地提交的遗留 hook 提示未找到 lefthook，未使用 `--no-verify`；已显式执行上述测试，并由 PR CI 再次验收。独立审查预算为一轮 full + 必要时一轮 focused。
