### PR TITLE
fix(vue3): 网关头拼写、Tag 搜索对齐 Vue2，并按 Vue2 基线重写缺口文档

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -23,7 +23,7 @@ title: 常见问题
 **大多数情况仍然有效**。upstream 文档 <https://doc.xiaominfo.com/> 上关于 `@ApiOperationSupport`、`knife4j.*` 配置、UI 行为的内容，本 fork 保持兼容。使用时需要注意以下边界：
 
 1. 版本发布节奏：upstream 最后一个 Maven Central 发布版本是 `4.5.0`（2024-01-08），fork 是 `5.7.1`（采用独立 SemVer 版本号）；fork 包含已确认并合入的兼容/安全修复和 React 新前端。
-2. 新 React 前端覆盖范围：upstream Vue2 前端上有的 UI 功能（Postman 导出、afterScript 等）在本 fork 的新 React 前端中尚未全部覆盖；OAuth2、接口变化提示、离线导出、自定义 Markdown 文档、自定义 Footer 等能力则已在 React UI 中补齐或重做。这些历史功能在本仓库 `front/vue3`（`knife4j-openapi2-ui` 打包产物）中继续保留。详见下文 [React 配置不生效](#react-setting-not-effective)。
+2. 新前端覆盖范围：能力基线是 upstream Vue2（本仓库 `legacy/vue2`），不是本仓库的 Vue3 重写。Vue3（`front/vue3` / `knife4j-openapi2-ui`）与 React（`front/ui-react` / `knife4j-openapi3-ui`）都是维护者重写，各自可能漏掉 Vue2 能力。React 已补齐或重做 OAuth2、接口变化提示（NEW / 变化标记，UX 不同于 Vue2 小蓝点）、请求参数缓存、离线导出、自定义 Markdown 文档、自定义 Footer 等。Vue2 / Vue3 仍有、React 尚未覆盖的典型能力是 afterScript 与调试后刷新变量（`enable-reload-cache-parameter`）。三端都没有独立的 Postman Collection 导出器，真实能力是 OpenAPI 复制/下载（React 另外支持 YAML 与单接口闭包）。Vue3 相对 Vue2 的网关路由头拼写（`knife4j-gateway-request`）与 Tag 名称搜索展开回归已在本仓库修复。详见下文 [React 配置不生效](#react-setting-not-effective) 和 [路线图](../roadmap/#react-ui-coverage)。
 3. Spring Security 注解展示：upstream 与本 fork 的实现都只位于 `knife4j-openapi2-spring-boot-starter`（OAS2 / Springfox）；OAS3 / springdoc 系列 starter 不会自动追加这些注解。详见 [Spring Security 注解展示](./features#spring-security-注解展示)。
 
 ### 本 fork 相比 upstream 多了哪些修复
@@ -208,17 +208,18 @@ connect-src 'self';
 
 `enable-dynamic-parameter=true` 在 React UI 中允许为 `application/x-www-form-urlencoded` 和 `multipart/form-data` Body 添加 OpenAPI 文档未声明的文本字段。它不控制现有的自定义 Query、Header、Cookie 参数能力；这些能力始终可用。Path 参数必须与 URL 模板一致，JSON/raw Body 可直接编辑，动态 file part 暂不在这个开关的支持范围内。
 
-以下 UI 配置暂不生效：
+以下 UI 配置在 React 中暂不生效（Vue2 与 Vue3 端口均已提供）：
 
-- `knife4j.setting.enable-version=true`
 - `knife4j.setting.enable-after-script`
 - `knife4j.setting.enable-reload-cache-parameter`
 
-原因：这些字段对应的 Vue 版能力尚未在 React 新前端里实现，或还没有接到实际行为上。后端 `ProductionSecurityFilter`、`knife4j.basic`、`knife4j.documents` 等服务端侧能力不受影响。
+`enable-version` 已在 React 接通：新增接口显示绿色 `NEW`，已有接口变化显示橙色标记；Vue2 / Vue3 仍使用侧边栏小蓝点，交互不同，但都受该开关控制。`enable-request-cache` 也已在 React 接通。
+
+后端 `ProductionSecurityFilter`、`knife4j.basic`、`knife4j.documents` 等服务端侧能力不受影响。
 
 过渡方案：
 
-- 如果你重度依赖这些 UI 能力，暂时使用 `knife4j-openapi2-spring-boot-starter`（前端为本仓库 `front/vue3`），或 upstream `com.github.xiaoymin` 的同名依赖（前端为 upstream Vue 2 webjar）。
+- 如果重度依赖 afterScript 或调试后刷新变量，使用 `knife4j-openapi2-spring-boot-starter`（本仓库 `front/vue3`），或 upstream `com.github.xiaoymin` 的同名依赖（upstream Vue2 webjar）。
 - 或者在 [路线图](../roadmap/#react-ui-coverage) 跟进覆盖进度。
 
 ### `knife4j.enable=true` 了但 UI 上看不到接口

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -199,6 +199,7 @@ connect-src 'self';
 - `knife4j.setting.enable-footer`
 - `knife4j.setting.enable-footer-custom` / `footer-custom-content`
 - `knife4j.setting.enable-request-cache`
+- `knife4j.setting.enable-version`
 - `knife4j.setting.enable-response-code`
 - `knife4j.setting.enable-dynamic-parameter`
 - `knife4j.setting.enable-home-custom` / `home-custom-location`

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -47,7 +47,7 @@ Knife4j Next 围绕"文档更清晰、调试更顺手、聚合更简单、交付
 
 ## 主要能力
 
-- **接口分组与搜索**：让大型项目中的接口更容易查找、定位和理解。
+- **接口分组与搜索**：当前分组内查找接口。Vue2 / Vue3 在 Tag 名称命中时展开该 Tag 下全部子接口；React 搜索当前分组的 path / summary / tag。跨分组搜索不是 Vue2 能力。
 - **请求参数增强**：支持全局参数、参数缓存、请求过滤，以及 urlencoded / multipart Body 的动态文本字段。
 - **鉴权调试**：覆盖 Basic Auth、OAuth2 等常见接口调试场景。
 - **模型展示增强**：更友好地展示请求体、响应体和嵌套模型结构。
@@ -67,9 +67,11 @@ Knife4j Next 围绕"文档更清晰、调试更顺手、聚合更简单、交付
 
 ## 功能详解
 
-> 以下功能按**前端 UI 可用性**标注状态。✅ = React + Vue3 均可用；🔲 = 部分实现；⬜ = 未实现；❌ = 均暂不可用。
+> 以下功能按**前端 UI 可用性**标注。能力基线是 upstream Vue2（`legacy/vue2`）。Vue3 与 React 都是维护者重写，各自可能漏掉 Vue2 能力。
 >
-> 这里的 Vue3 指本仓库 `front/vue3`，打包进 `knife4j-openapi2-ui` webjar，面向 OAS2 starter；React 指 `front/ui-react`，打包进 `knife4j-openapi3-ui` webjar，面向 OAS3 starter。Vue3 处于兼容维护状态，React 为主线。
+> ✅ = 该前端可用；🔲 = 部分实现；⬜ = 未实现；❌ = 均暂不可用。
+>
+> Vue3 指本仓库 `front/vue3`，打包进 `knife4j-openapi2-ui`，面向 OAS2 兼容维护；React 指 `front/ui-react`，打包进 `knife4j-openapi3-ui`，面向 OAS3 主线。下文表格对比的是当前交付的两条线，不以 Vue3 代替 Vue2 基线。
 
 ### 离线文档导出
 
@@ -78,7 +80,7 @@ Knife4j Next 围绕"文档更清晰、调试更顺手、聚合更简单、交付
 | Markdown | ✅ | ✅ | 当前分组的完整 Markdown 文档 |
 | HTML | ✅ | ✅ | 当前分组的 HTML 离线文档 |
 | Word | ✅ | ✅ | 当前分组的 Word 文档 |
-| OpenAPI JSON | ✅ | ✅ | 当前分组的原始 OpenAPI 规范 JSON |
+| OpenAPI JSON | ✅ | ✅ | 当前分组的原始 OpenAPI 规范 JSON；React 另有 YAML 与单接口闭包 |
 | PDF | ❌ | ❌ | 暂未实现 |
 
 在 UI 界面中进入**文档管理 → 离线文档**，选择格式后点击下载即可。
@@ -188,7 +190,7 @@ Knife4j 提供 UI 端临时设置全局参数的功能，适用于后台全局 T
 AfterScript 功能允许在每个接口调试 Tab 中编写一段 JavaScript 脚本，当接口调用成功后自动执行。最典型的场景是**登录后自动设置全局 Token**。
 
 ::: warning ⚠️ React UI 暂不支持
-AfterScript 功能仅在 Vue3 UI（`knife4j-openapi2-spring-boot-starter` 打包的 `front/vue3`）中可用。React 新前端暂不支持。跟进进度见 [路线图](../roadmap/#react-ui-coverage)。
+AfterScript 存在于 Vue2 基线，并已移植到 Vue3 UI（`knife4j-openapi2-spring-boot-starter` 打包的 `front/vue3`）。React 新前端暂不支持。跟进进度见 [路线图](../roadmap/#react-ui-coverage)。
 :::
 
 #### 全局对象
@@ -296,7 +298,7 @@ knife4j:
 ```
 
 ::: warning React UI
-以上三项配置在 Vue3 UI（OAS2 starter）中生效。React 新前端也会读取后端注入的默认值并隐藏对应入口，但这只是 UI 开关，不是安全控制。
+以上三项配置在 Vue2 / Vue3（OAS2）中生效。React 新前端也会读取后端注入的默认值并隐藏对应入口，但这只是 UI 开关，不是安全控制。
 :::
 
 ### 请求参数缓存
@@ -313,13 +315,15 @@ knife4j:
 - 后端 `@Schema(example = "张飞")` 提供了 example 的字段，**始终使用 example 值**，不使用缓存。
 - 未提供 example 的字段，使用上次调试时填写的缓存值。
 
-::: warning ⚠️ React UI 暂不支持
-此配置仅在 Vue3 UI（OAS2 starter）中生效。React 新前端暂不读取。
+::: tip React UI
+`enable-request-cache` 在 Vue2 / Vue3 与 React 中均会生效。React 读取后端注入的默认值，用户在设置面板中的本地选择会覆盖该默认值。
 :::
 
 ### 接口版本控制
 
 Knife4j 使用浏览器 localStorage 记录接口基线，接口稳定身份为 HTTP Method + Path，不依赖可能变化或缺失的 `operationId`。
+
+Vue2 / Vue3（OAS2）开启 `enable-version` 后，侧边栏用小蓝点提示新增或变化接口。React 已实现同一配置，但 UX 不同：新增显示绿色 `NEW`，变化显示橙色标记。
 
 React UI 在 OpenAPI 3.0.x、3.1.x 以及 3.2.x 中提供以下行为：
 
@@ -381,10 +385,9 @@ Knife4j 支持将 JSR303（Bean Validation）注解（如 `@NotNull`、`@Size`�
 
 此功能在所有 starter 中均生效。
 
-### 导出 Postman
+### OpenAPI 复制 / 下载
 
-Vue3 UI（OAS2 starter）中每个接口详情页有 **Open** 选项卡，展示当前接口的 OpenAPI 规范结构，可一键复制后导入 Postman。
+Vue2 / Vue3 与 React 都没有独立的 Postman Collection 导出器。真实能力是复制或下载 OpenAPI 文档，再由 Postman 等工具自行导入。
 
-::: warning ❌ React UI 暂不支持
-导出 Postman 功能在 React 新前端中暂不可用。可替代方案：导出 OpenAPI JSON 后手动导入 Postman。
-:::
+- Vue2 / Vue3（OAS2）：接口详情页的 Open / OpenAPI 选项卡可复制或下载当前接口的 OpenAPI JSON。
+- React（OAS3）：同样支持 OpenAPI 复制/下载，并额外提供 YAML，以及单接口引用闭包导出。

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -178,8 +178,8 @@ UI 同样是新 React 版本，注意覆盖范围提示。
 
 ::: info 何时选这条
 - 项目深度依赖 Springfox 专属注解（`@ApiOperationSupport(ignoreParameters/includeParameters)`、`@DynamicParameters`、`@DynamicResponseParameters`）。
-- 需要 upstream knife4j 文档上提到的完整 UI 能力（自定义首页、Postman 导出、版本小蓝点、afterScript）。
-- 这些特性在本 fork 的新 React 前端中尚未覆盖，但在本仓库 `front/vue3`（`knife4j-openapi2-ui` 打包产物）中完整保留。
+- 需要 Vue2 基线里的 afterScript 或调试后刷新变量（`enable-reload-cache-parameter`）。这两项已移植到本仓库 `front/vue3`，React 尚未覆盖。
+- 自定义首页、接口变化提示和 OpenAPI 复制/下载不是选这条的理由：React 已覆盖（变化提示是 NEW / 变化标记，不是 Vue2 小蓝点）。三端都没有独立的 Postman Collection 导出器。
 :::
 
 ### 依赖

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -135,7 +135,7 @@ public class UserController {
 3. `http://localhost:8080/v3/api-docs` 返回原始 OpenAPI JSON。
 
 ::: warning 新前端配置覆盖范围
-React 新前端会读取部分 `knife4j.setting.*` UI 默认值，例如 `language`、`enable-debug`、`enable-search`、`enable-open-api`、`enable-host`、`enable-group`、`enable-footer`、`enable-footer-custom`、`footer-custom-content`、`enable-request-cache`、`enable-home-custom`、`home-custom-location`、`swagger-model-name`。`enable-version`、`enable-after-script` 等 Vue 时代能力仍暂不生效；`home-custom-path` 仍只由后端读取并注入 Markdown 内容。详见 [FAQ / 为什么我的 knife4j.setting 配置不生效](./faq#react-setting-not-effective) 与 [路线图 / 新前端覆盖范围](../roadmap/#react-ui-coverage)。
+React 新前端会读取部分 `knife4j.setting.*` UI 默认值，例如 `language`、`enable-debug`、`enable-search`、`enable-open-api`、`enable-host`、`enable-group`、`enable-footer`、`enable-footer-custom`、`footer-custom-content`、`enable-request-cache`、`enable-version`、`enable-home-custom`、`home-custom-location`、`swagger-model-name`。`enable-version` 已接通，UX 是 NEW / 变化标记，不同于 Vue2 小蓝点。仍缺 afterScript 与调试后刷新变量（`enable-reload-cache-parameter`）。`home-custom-path` 仍只由后端读取并注入 Markdown 内容。详见 [FAQ / 为什么我的 knife4j.setting 配置不生效](./faq#react-setting-not-effective) 与 [相对 Vue2 的覆盖范围](../roadmap/#react-ui-coverage)。
 :::
 
 ---

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -58,7 +58,7 @@ upstream 文档里列出的增强特性在本 fork 的实际实现状态，前�
 | Springfox 专属增强在 OAS3 中不处理 | `@DynamicParameters`、`@DynamicResponseParameters`、`@ApiOperationSupport(ignoreParameters/includeParameters)` 等 | 迁到 OpenAPI3 时改用实体类或标准 OpenAPI 注解替代 |
 | 后端实现，新 React 前端已读取部分默认值 | `knife4j.setting.language`、`enable-debug`、`enable-search`、`enable-open-api`、`enable-host`、`enable-group`、`enable-footer`、`enable-footer-custom`、`footer-custom-content`、`enable-request-cache`、`enable-home-custom`、`home-custom-location`、`swagger-model-name` 等 | 这些是 UI 开关，不替代后端安全控制；本地设置面板选择优先 |
 | React UI 已补齐或重做 | OAuth2 四种 flow 基础鉴权、HTML/Word/Markdown/OpenAPI JSON 离线导出、`tags-sorter` / `operations-sorter`、`x-openapi.x-markdownFiles` 自定义文档、自定义 Footer、自定义首页、基础 JS/TS 代码片段 | 优先以本仓库文档和实际 demo 为准 |
-| 仍未覆盖 | Postman 导出、afterScript 等 | 等待后续迭代；重度依赖这些能力时暂时使用 openapi2 starter + 本仓库 Vue 3 UI |
+| 仍未覆盖 | afterScript、调试后刷新变量（`enable-reload-cache-parameter`） | 这些能力在 Vue2 基线与 Vue3 端口中存在，React 尚未覆盖。三端都没有独立的 Postman Collection 导出器；OpenAPI 复制/下载才是真实能力 |
 
 完整对应关系见 [路线图 / 新前端覆盖范围](../roadmap/#react-ui-coverage)。
 
@@ -68,12 +68,12 @@ upstream 文档里列出的增强特性在本 fork 的实际实现状态，前�
 
 | UI webjar | 打包的前端 | 对应 starter |
 | --- | --- | --- |
-| `knife4j-openapi2-ui` | 本仓库 `front/vue3` 构建产物（兼容维护，功能较完整） | `knife4j-openapi2-spring-boot-starter`、`knife4j-aggregation-spring-boot-starter` |
+| `knife4j-openapi2-ui` | 本仓库 `front/vue3` 构建产物（兼容维护；能力对齐 Vue2，不是新的功能基线） | `knife4j-openapi2-spring-boot-starter`、`knife4j-aggregation-spring-boot-starter` |
 | `knife4j-openapi3-ui` | React 新前端（从 Preview 起集成，为主线） | `knife4j-openapi3-spring-boot-starter`、`knife4j-openapi3-jakarta-spring-boot-starter`、`knife4j-openapi3-boot4-spring-boot-starter`、`knife4j-aggregation-jakarta-spring-boot-starter`、`knife4j-aggregation-boot4-spring-boot-starter`、`knife4j-gateway-spring-boot-starter`、`knife4j-gateway-webmvc-spring-boot-starter`、`knife4j-gateway-boot4-spring-boot-starter` |
 
 所以：
 
-- 用 **Springfox + OpenAPI2** 走 `openapi2-starter`，UI 是本仓库 `front/vue3` 的构建产物（兼容维护），继续提供 upstream 已有功能。
+- 用 **Springfox + OpenAPI2** 走 `openapi2-starter`，UI 是本仓库 `front/vue3` 的构建产物（兼容维护），目标是对齐 upstream Vue2 已有能力，而不是扩张新功能。
 - 用 **springdoc-openapi + OpenAPI3** 走 `openapi3-starter`、`openapi3-jakarta-starter` 或 Boot4 专用 starter，UI 是 **新 React 版本**（覆盖见上表），不熟悉行为请同时参考 [FAQ](./faq)。
 
 ## 版本规则与维护节奏

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -179,5 +179,5 @@ curl -I http://localhost:8080/doc.html   # 403 即正确
 
 - **找不到 `com.baizhukui` 坐标**：刷新 Maven 中央仓库镜像；企业私服需要手动同步（Central 已发布）。
 - **doc.html 404**：见 [FAQ / SpringBoot 访问 doc.html 404](./faq#doc-html-404)。
-- **`enable-version` / `enable-debug` 等开关对新前端无效**：见 [FAQ / 为什么我的 knife4j.setting 配置不生效](./faq#react-setting-not-effective)。
+- **部分 `knife4j.setting.*` 在 React 中仍不生效**：`enable-after-script` 与 `enable-reload-cache-parameter` 仍只在 Vue2 / Vue3；`enable-version` 与 `enable-debug` 已接通。详见 [FAQ / 为什么我的 knife4j.setting 配置不生效](./faq#react-setting-not-effective)。
 - **Gateway context-path 下聚合出错**：升级到 `5.0.0` 或更高版本即可包含该修复（[#954](https://github.com/xiaoymin/knife4j/issues/954)）。

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,7 @@ knife4j:
 完整更新列表见 [发布说明](/release-notes/)。
 
 ::: warning 关于新前端覆盖范围
-新 React 前端当前**仅覆盖部分** upstream 增强特性。它会读取部分 `knife4j.setting.*` UI 默认值，包括自定义 Footer、接口变化提示与后端注入的自定义首页 Markdown；但如果你依赖的是 `enable-after-script`、Postman 导出等 Vue 时代能力，请在切换到新前端前先查阅 [新前端覆盖范围](/roadmap/#react-ui-coverage)。`home-custom-path` 仍由后端读取，不是前端读取文件的入口。`knife4j-openapi2-ui` 由本仓库 `front/vue3` 构建，处于兼容维护状态，upstream 已有特性继续可用。
+能力基线是 upstream Vue2（`legacy/vue2`）。Vue3 与 React 都是维护者重写，各自可能漏掉 Vue2 能力。React 已读取部分 `knife4j.setting.*`（含自定义 Footer、接口变化提示、请求参数缓存与后端注入的自定义首页 Markdown）；仍缺 afterScript 与调试后刷新变量。三端都没有独立的 Postman Collection 导出器，请使用 OpenAPI 复制/下载。切换前端前先查阅 [相对 Vue2 的覆盖范围](/roadmap/#react-ui-coverage)。`home-custom-path` 仍由后端读取，不是前端读取文件的入口。`knife4j-openapi2-ui` 由本仓库 `front/vue3` 构建，处于 OAS2 兼容维护状态。
 :::
 
 ## 文档导航

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -107,7 +107,7 @@ Boot 2 / springdoc 1.8.0 继续生成 OpenAPI 3.0，不能只改文档版本字�
 | `knife4j.setting.enableResponseCode` | `boolean` | `true` | 显示响应状态概要（状态码、说明、Schema 和 Media Type） | ✅ |
 | `knife4j.setting.customCode` | `Integer` | `200` | 生产环境屏蔽时的自定义 HTTP 状态码 | ✅ |
 
-> React 新前端会读取后端注入到 OpenAPI JSON 的 `x-openapi.x-setting`，但只消费表中标 ✅ 的 UI 字段；用户在前端设置面板中的本地选择会覆盖后端默认值。标 ⚠️ 的配置仍会由后端写入 extension，但 React 暂不消费。详见 [FAQ](../guide/faq#react-setting-not-effective)。
+> React 新前端会读取后端注入到 OpenAPI JSON 的 `x-openapi.x-setting`，但只消费表中标 ✅ 的 UI 字段；用户在前端设置面板中的本地选择会覆盖后端默认值。标 ⚠️ 的 `enableAfterScript` / `enableReloadCacheParameter` 仍会由后端写入 extension，React 暂不消费；这两项存在于 Vue2 基线，并已移植到 Vue3。`enableVersion` 与 `enableRequestCache` 已在 React 接通。详见 [FAQ](../guide/faq#react-setting-not-effective)。
 
 > `enableDynamicParameter` 在 React UI 中只控制 `application/x-www-form-urlencoded` 和 `multipart/form-data` 请求体的未声明文本字段。Query、Header、Cookie 的自定义参数能力始终可用，不受该开关控制；Path 参数、JSON/raw Body 和动态 file part 不在该开关的支持范围内。
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -92,47 +92,49 @@ Java `5.7.0` 与 Knife4x Go `v0.8.0` 接入 OpenAPI 3.2.x 完整消费。真实 
 
 ---
 
-## React UI 对齐 Vue3 功能缺口清单
+## React / Vue3 相对 Vue2 的功能缺口 {#react-ui-coverage}
 
-以下表格对比本仓库 `front/vue3`（Vue 3，OAS2 starter 前端）与 `knife4j-ui-react`（React，OAS3 starter 前端）的功能覆盖。⬜ = 未实现，🔲 = 部分实现，✅ = 已实现。
+能力基线是 upstream Vue2（本仓库 `legacy/vue2`），不是本仓库的 Vue3 重写。`front/vue3`（OAS2 兼容维护）与 `front/ui-react`（OAS3 主线）都是维护者重写，各自可能漏掉 Vue2 能力。⬜ = 未实现，🔲 = 部分实现，✅ = 已实现。
 
-> 注：`front/vue3` 的功能基线与 upstream `legacy/vue2`（Vue 2）基本一致，下面 Vue3 列的状态等同于 upstream Vue2 的功能覆盖。
+Vue3 相对 Vue2 已确认并修复的回归：聚合路由头曾误写为 `knfie4j-gateway-request`（现已改回 `knife4j-gateway-request`）；侧边栏搜索曾失去 Tag 名称命中后展开全部子接口的行为（现已对齐 Vue2）。
 
 ### 核心功能
 
-| 功能 | Vue3 | React | 缺口说明 |
-| --- | --- | --- | --- |
-| 接口文档展示 | ✅ | ✅ | — |
-| 接口调试 | ✅ | ✅ | — |
-| 数据模型展示 | ✅ | ✅ | — |
-| 分组切换 | ✅ | ✅ | — |
-| 接口搜索 | ✅ | ✅ | — |
-| Authorize 鉴权 | ✅ | ✅ | React 支持 securitySchemes 动态渲染 + OAuth2 四种 flow 基础 token 获取/注入 |
-| 全局参数 | ✅ | ✅ | — |
-| 离线文档导出 | ✅ | 🔲 | React 支持 HTML/Word/Markdown/OpenAPI JSON，缺少 Word 模板自定义 |
-| 首页统计 | ✅ | ✅ | — |
+| 功能 | Vue2 基线 | Vue3 | React | 缺口说明 |
+| --- | --- | --- | --- | --- |
+| 接口文档展示 | ✅ | ✅ | ✅ | — |
+| 接口调试 | ✅ | ✅ | ✅ | — |
+| 数据模型展示 | ✅ | ✅ | ✅ | — |
+| 分组切换 | ✅ | ✅ | ✅ | — |
+| 接口搜索 | ✅ 当前分组；Tag 名称命中则展开全部子接口 | ✅ 已对齐 Vue2 | ✅ 当前分组 | 跨分组搜索不是 Vue2 能力 |
+| Authorize 鉴权 | ✅ | ✅ | ✅ | React 支持 securitySchemes 动态渲染 + OAuth2 四种 flow 基础 token 获取/注入 |
+| 全局参数 | ✅ | ✅ | ✅ | — |
+| 离线文档导出 | ✅ | ✅ | 🔲 | React 支持 HTML/Word/Markdown/OpenAPI JSON / YAML，缺少 Word 模板自定义 |
+| 首页统计 | ✅ | ✅ | ✅ | — |
 
 ### 调试页详细缺口
 
-| 功能 | Vue3 | React | 缺口说明 |
-| --- | --- | --- | --- |
-| multipart/form-data 文件上传 | ✅ | 🔲 | 基础表单可用，完整文件上传待优化 |
-| OAuth2 password/client_credentials | ✅ | ✅ | 基础 `tokenUrl` 换取 token 已实现 |
-| afterScript（请求后脚本） | ✅ | ⬜ | — |
+| 功能 | Vue2 基线 | Vue3 | React | 缺口说明 |
+| --- | --- | --- | --- | --- |
+| multipart/form-data 文件上传 | ✅ | ✅ | 🔲 | 基础表单可用，完整文件上传待优化 |
+| OAuth2 password/client_credentials | ✅ | ✅ | ✅ | 基础 `tokenUrl` 换取 token 已实现 |
+| afterScript（请求后脚本） | ✅ | ✅ | ⬜ | Vue2 / Vue3 有，React 暂无 |
+| 调试后刷新变量 | ✅ | ✅ | ⬜ | 对应 `enable-reload-cache-parameter` |
 
 ### 增强功能
 
-| 功能 | Vue3 | React | 缺口说明 |
-| --- | --- | --- | --- |
-| `@ApiSupport.order` Tag 排序 | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
-| `@ApiSupport.author/authors` 展示 | ✅ | ✅ | 类级作者由后端回退写入 operation `x-author`，React 在接口详情页展示，不做 Tag 级聚合 |
-| `@ApiOperationSupport.order` 操作排序 | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
-| `@ApiOperationSupport.author/authors` 展示 | ✅ | ✅ | 后端合并为 operation `x-author`，React 展示非空作者字符串 |
-| 自定义 Markdown 文档 | ✅ | ✅ | React 读取 `x-openapi.x-markdownFiles` 并在侧边栏渲染 |
-| 自定义 Footer | ✅ | ✅ | React 读取 `enableFooterCustom` / `footerCustomContent` 并按 Markdown 安全渲染 |
-| 全局搜索（跨分组） | ✅ | 🔲 | React 仅搜索当前分组 |
-| TypeScript 代码生成 | ✅ | ✅ | React 操作页提供基础 JS / TypeScript 请求函数片段 |
-| Postman 导出 | ✅ | ⬜ | — |
+| 功能 | Vue2 基线 | Vue3 | React | 缺口说明 |
+| --- | --- | --- | --- | --- |
+| `@ApiSupport.order` Tag 排序 | ✅ | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
+| `@ApiSupport.author/authors` 展示 | ✅ | ✅ | ✅ | 类级作者由后端回退写入 operation `x-author`，React 在接口详情页展示，不做 Tag 级聚合 |
+| `@ApiOperationSupport.order` 操作排序 | ✅ | ✅ | ✅ | React 按 spec 中的 `x-order` 排序，缺失时保持原有排序策略 |
+| `@ApiOperationSupport.author/authors` 展示 | ✅ | ✅ | ✅ | 后端合并为 operation `x-author`，React 展示非空作者字符串 |
+| 自定义 Markdown 文档 | ✅ | ✅ | ✅ | React 读取 `x-openapi.x-markdownFiles` 并在侧边栏渲染 |
+| 自定义 Footer | ✅ | ✅ | ✅ | React 读取 `enableFooterCustom` / `footerCustomContent` 并按 Markdown 安全渲染 |
+| 接口变化提示 | ✅ 侧边栏小蓝点 | ✅ 同 Vue2 | ✅ NEW / 变化标记 | React 已实现，UX 不同于 Vue2 |
+| 请求参数缓存 | ✅ | ✅ | ✅ | React 已读取 `enable-request-cache` |
+| TypeScript 代码生成 | ✅ | ✅ | ✅ | React 操作页提供基础 JS / TypeScript 请求函数片段 |
+| OpenAPI 复制/下载 | ✅ 接口页 JSON | ✅ 同 Vue2 | ✅ JSON / YAML / 单接口闭包 | 三端都没有独立的 Postman Collection 导出器 |
 
 ### knife4j-core 已抽取模块
 
@@ -150,7 +152,7 @@ Java `5.7.0` 与 Knife4x Go `v0.8.0` 接入 OpenAPI 3.2.x 完整消费。真实 
 ## 优先级排序原则
 
 1. **稳定性优先**：Bug 修复和兼容性回归永远优先于新功能
-2. **调试能力对齐**：Vue3（OAS2 starter）能做的调试流程，React 也必须能做
+2. **调试能力对齐**：Vue2 基线能做的调试流程，React 也必须能做；Vue3 只作为 OAS2 兼容端口，不能单独充当能力基线
 3. **核心层先行**：knife4j-core 抽取完成后，UI 层改动才可控
 4. **小步快跑**：一个 PR 只做一件事，可独立验证和回滚
 5. **不破坏现有体验**：任何改动不能让 `doc.html` 用户降级
@@ -169,8 +171,7 @@ Java `5.7.0` 与 Knife4x Go `v0.8.0` 接入 OpenAPI 3.2.x 完整消费。真实 
 
 ## 下一步
 
-1. **继续补齐 `knife4j.setting.*` UI 开关联动**：React 前端已读取部分 `x-openapi.x-setting` 字段，剩余字段按功能逐项接入
-2. **补齐 Postman 导出**
-3. **补齐 multipart/form-data 文件上传细节**
+1. **继续补齐 `knife4j.setting.*` UI 开关联动**：React 前端已读取部分 `x-openapi.x-setting` 字段；仍缺 afterScript 与调试后刷新变量
+2. **补齐 multipart/form-data 文件上传细节**
 
 如果你想参与某个任务的实现，欢迎提 Issue 或 PR。详见 [GitHub 仓库](https://github.com/songxychn/knife4j-next)。

--- a/front/vue3/package.json
+++ b/front/vue3/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "check:i18n": "bun scripts/check-i18n.mjs",
+    "check:search-menu": "bun scripts/check-search-menu.mjs",
     "build": "vite build",
     "build:SpringDocOpenApi": "cross-env VITE_RELEASE_APP_TYPE=SpringDocOpenApi vite build",
     "build:Knife4jSpringUi": "cross-env VITE_RELEASE_APP_TYPE=Knife4jSpringUi vite build",

--- a/front/vue3/scripts/check-search-menu.mjs
+++ b/front/vue3/scripts/check-search-menu.mjs
@@ -1,0 +1,89 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { KNIFE4J_ROUTE_PROXY_HEADER } from '../src/core/routeProxyHeader.js'
+import { filterMenuBySearchKey } from '../src/core/searchMenu.js'
+import KUtils from '../src/core/utils.js'
+
+const failures = []
+const vue3SrcRoot = join(dirname(fileURLToPath(import.meta.url)), '../src')
+const typoHeader = 'knfie4j-gateway-request'
+const sourceFiles = [
+  'core/Knife4jAsync.js',
+  'core/routeProxyHeader.js',
+  'core/searchMenu.js',
+  'layouts/BasicLayout.vue',
+  'views/api/Debug.vue',
+]
+
+if (KNIFE4J_ROUTE_PROXY_HEADER !== 'knife4j-gateway-request') {
+  failures.push(`route proxy header must be knife4j-gateway-request, got ${KNIFE4J_ROUTE_PROXY_HEADER}`)
+}
+
+for (const relativePath of sourceFiles) {
+  const source = await readFile(join(vue3SrcRoot, relativePath), 'utf8')
+  if (source.includes(typoHeader)) {
+    failures.push(`${relativePath} still contains ${typoHeader}`)
+  }
+}
+
+const menus = [
+  {
+    groupName: 'default',
+    groupId: 'default',
+    key: 'tag-user',
+    name: '用户管理',
+    icon: 'user',
+    path: '/tag-user',
+    hasNew: false,
+    authority: null,
+    children: [
+      { url: '/pets', name: 'listPets', description: 'list pets' },
+      { url: '/orders', name: 'listOrders', description: 'list orders' },
+    ],
+  },
+  {
+    groupName: 'default',
+    groupId: 'default',
+    key: 'tag-order',
+    name: '订单',
+    icon: 'order',
+    path: '/tag-order',
+    hasNew: false,
+    authority: null,
+    children: [
+      { url: '/checkout', name: 'checkout', description: 'pay now' },
+    ],
+  },
+]
+
+const tagMatch = filterMenuBySearchKey(menus, '用户', KUtils)
+if (!tagMatch || tagMatch.length !== 1 || tagMatch[0].key !== 'tag-user' || tagMatch[0].children.length !== 2) {
+  failures.push('Tag name match must include every child of that Tag')
+}
+
+const childMatch = filterMenuBySearchKey(menus, 'checkout', KUtils)
+if (!childMatch || childMatch.length !== 1 || childMatch[0].key !== 'tag-order' || childMatch[0].children.length !== 1) {
+  failures.push('child url/name/description match must keep only matching children')
+}
+
+const descriptionMatch = filterMenuBySearchKey(menus, 'list pets', KUtils)
+if (!descriptionMatch || descriptionMatch.length !== 1 || descriptionMatch[0].children[0].url !== '/pets') {
+  failures.push('child description match must still work when Tag name does not match')
+}
+
+const emptyMatch = filterMenuBySearchKey(menus, 'zzz-not-found', KUtils)
+if (!emptyMatch || emptyMatch.length !== 0) {
+  failures.push('unrelated search key must hide every Tag')
+}
+
+if (filterMenuBySearchKey(menus, '', KUtils) !== null) {
+  failures.push('blank search key must leave menu filtering to searchClear')
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'))
+  process.exit(1)
+}
+
+console.log('vue3 search menu and gateway header check passed')

--- a/front/vue3/src/core/Knife4jAsync.js
+++ b/front/vue3/src/core/Knife4jAsync.js
@@ -35,6 +35,7 @@
 import { message } from 'ant-design-vue';
 import md5 from 'js-md5';
 import KUtils from './utils';
+import { KNIFE4J_ROUTE_PROXY_HEADER } from './routeProxyHeader.js';
 import { marked } from 'marked';
 import async from 'async';
 import Knife4jOAS3ResponseExampleReader from './oas3/OAS3ResponseExampleReader';
@@ -764,7 +765,7 @@ SwaggerBootstrapUi.prototype.analysisApi = function (instance, forceReload = fal
       }
       if (KUtils.checkUndefined(this.currentInstance.header)) {
         // Knife4j自研Aggreration微服务聚合组件请求头
-        reqHeaders = Object.assign({}, reqHeaders, { 'knfie4j-gateway-request': that.currentInstance.header });
+        reqHeaders = Object.assign({}, reqHeaders, { [KNIFE4J_ROUTE_PROXY_HEADER]: that.currentInstance.header });
       }
       if (KUtils.checkUndefined(this.currentInstance.basicAuth)) {
         reqHeaders = Object.assign({}, reqHeaders, { 'knife4j-gateway-basic-request': that.currentInstance.basicAuth });

--- a/front/vue3/src/core/routeProxyHeader.js
+++ b/front/vue3/src/core/routeProxyHeader.js
@@ -1,0 +1,1 @@
+export const KNIFE4J_ROUTE_PROXY_HEADER = 'knife4j-gateway-request'

--- a/front/vue3/src/core/searchMenu.js
+++ b/front/vue3/src/core/searchMenu.js
@@ -1,0 +1,53 @@
+function copyMenuWithChildren(menu, children) {
+  return {
+    groupName: menu.groupName,
+    groupId: menu.groupId,
+    key: menu.key,
+    name: menu.name,
+    icon: menu.icon,
+    path: menu.path,
+    hasNew: menu.hasNew,
+    authority: menu.authority,
+    children,
+  }
+}
+
+/**
+ * 当前分组侧边栏搜索，对齐 upstream Vue2：
+ * Tag 名称命中时展开该 Tag 下全部子接口；否则按 url / name / description 过滤子项。
+ */
+export function filterMenuBySearchKey(menus, key, utils) {
+  if (!utils.strNotBlank(key)) {
+    return null
+  }
+
+  const tmpMenu = []
+  const regx = '.*?' + key + '.*'
+  menus.forEach(function (menu) {
+    const tmpChildrens = []
+    const tagNameFlag = utils.searchMatch(regx, menu.name)
+    if (tagNameFlag) {
+      if (utils.arrNotEmpty(menu.children)) {
+        menu.children.forEach((children) => {
+          tmpChildrens.push(children)
+        })
+      }
+    } else if (utils.arrNotEmpty(menu.children)) {
+      menu.children.forEach(function (children) {
+        const urlflag = utils.searchMatch(regx, children.url)
+        const sumflag = utils.searchMatch(regx, children.name)
+        const desflag = utils.searchMatch(regx, children.description)
+        if (urlflag || sumflag || desflag) {
+          tmpChildrens.push(children)
+        }
+      })
+    }
+    if (tmpChildrens.length > 0) {
+      const tmpObj = copyMenuWithChildren(menu, tmpChildrens)
+      if (tmpMenu.filter((t) => t.key === tmpObj.key).length == 0) {
+        tmpMenu.push(tmpObj)
+      }
+    }
+  })
+  return tmpMenu
+}

--- a/front/vue3/src/layouts/BasicLayout.vue
+++ b/front/vue3/src/layouts/BasicLayout.vue
@@ -55,6 +55,7 @@ const logo = './knife4j-next-mark.svg';
 import GlobalHeader from "@/components/GlobalHeader/index.vue";
 import GlobalFooter from "@/components/GlobalFooter/index.vue";
 import KUtils from "@/core/utils";
+import { filterMenuBySearchKey } from "@/core/searchMenu.js";
 import SwaggerBootstrapUi from "@/core/Knife4jAsync.js";
 import { findComponentsByPath, findMenuByKey } from "@/components/utils/Knife4jUtils";
 import { urlToList } from "@/components/utils/pathTools";
@@ -451,42 +452,10 @@ onUpdated(() => {
 })
 
 function searchKey(key) {
-  //根据输入搜索
-  if (KUtils.strNotBlank(key)) {
-    const tmpMenu = []
-    const regx = ".*?" + key + ".*"
-    //console.log(this.cacheMenuData);
-    cacheMenuData.value.forEach(function (menu) {
-      if (KUtils.arrNotEmpty(menu.children)) {
-        //遍历children
-        const tmpChildrens = []
-        menu.children.forEach(function (children) {
-          const urlflag = KUtils.searchMatch(regx, children.url)
-          const sumflag = KUtils.searchMatch(regx, children.name)
-          const desflag = KUtils.searchMatch(regx, children.description)
-          if (urlflag || sumflag || desflag) {
-            tmpChildrens.push(children);
-          }
-        });
-        if (tmpChildrens.length > 0) {
-          const tmpObj = {
-            groupName: menu.groupName,
-            groupId: menu.groupId,
-            key: menu.key,
-            name: menu.name,
-            icon: menu.icon,
-            path: menu.path,
-            hasNew: menu.hasNew,
-            authority: menu.authority,
-            children: tmpChildrens
-          }
-          if (tmpMenu.filter(t => t.key === tmpObj.key).length == 0) {
-            tmpMenu.push(tmpObj);
-          }
-        }
-      }
-    });
-    state.localMenuData = tmpMenu;
+  //根据输入搜索，Tag 名称命中时展开全部子接口，对齐 Vue2
+  const tmpMenu = filterMenuBySearchKey(cacheMenuData.value, key, KUtils)
+  if (tmpMenu) {
+    state.localMenuData = tmpMenu
   }
 }
 

--- a/front/vue3/src/views/api/Debug.vue
+++ b/front/vue3/src/views/api/Debug.vue
@@ -270,6 +270,7 @@
 <script>
 import qs from "qs"
 import KUtils from "@/core/utils";
+import { KNIFE4J_ROUTE_PROXY_HEADER } from "@/core/routeProxyHeader.js";
 import KEnvironment from "@/core/Environment"
 import constant from "@/store/constants";
 /* import EditorDebugShow from "./EditorDebugShow";
@@ -2128,7 +2129,7 @@ export default {
       // 判断是否routeProxy请求，基于Knife4j自研aggre聚合组件请求header
       // add by xiaoymin 2020年11月13日 21:33:18
       if (KUtils.checkUndefined(this.routeHeader)) {
-        headers["knfie4j-gateway-request"] = this.routeHeader;
+        headers[KNIFE4J_ROUTE_PROXY_HEADER] = this.routeHeader;
       }
       // Knife4jAggregationDesktop组件header
       if (this.swaggerInstance.desktop) {
@@ -3000,7 +3001,7 @@ export default {
       // 设置请求头
       var headers = this.debugHeaders();
       var ignoreHeaders = [];
-      ignoreHeaders.push("knfie4j-gateway-request");
+      ignoreHeaders.push(KNIFE4J_ROUTE_PROXY_HEADER);
       ignoreHeaders.push("knife4j-gateway-code");
       ignoreHeaders.push("Request-Origion");
       if (KUtils.checkUndefined(headers)) {

--- a/tools/test-vue3.sh
+++ b/tools/test-vue3.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")/../front/vue3"
 
 bun install --frozen-lockfile
 bun run check:i18n
+bun run check:search-menu
 bun run build:Knife4jSpringUi
 
 required_files=(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 关联 issue

无独立 issue；三项相关修复合入同一 PR。

## 变更摘要

对照当前 `master` 核实 Vue2-baseline 审计假设后，一次修三件事：

1. **fix(vue3): 网关路由头拼写**  
   Vue3 误用 `knfie4j-gateway-request`（缺字母）。Vue2、React 与 Java `RouteDispatcher` 使用的正确头是 `knife4j-gateway-request`。已改 `Knife4jAsync.js`、`Debug.vue` 全部出现处，并抽出常量。

2. **fix(vue3): 恢复 Tag 名称搜索展开**  
   Vue2 `searchKey`：Tag `name` 命中时纳入该 Tag 全部子接口。Vue3 只按子项 url/name/description 过滤，丢失该行为。现抽出 `filterMenuBySearchKey`，对齐 Vue2，不改空白搜索 / `searchClear` / 当前分组范围。

3. **docs: 以 Vue2 为能力基线重写缺口表述**  
   Vue3 与 React 都是维护者重写，不能互相当基线。已纠正过时说法：
   - React `enable-version` / `enable-request-cache` 已实现（NEW / 变化标记，UX 不同于 Vue2 小蓝点）
   - 三端都没有独立 Postman Collection 导出器；真实能力是 OpenAPI 复制/下载（React 另有 YAML / 单接口闭包）
   - 跨分组搜索不是 Vue2 能力（当前分组搜索；Vue2 只多 Tag 名称展开）
   - afterScript / `enable-reload-cache-parameter` 写 Vue2/Vue3，不再写成「仅 Vue3」
   - 记录本次修复的 Vue3 网关头拼写与 Tag 搜索回归

## 契约边界

- 支持版本 / 规范：OAS2 Vue3 兼容维护；文档相对 Vue2（`legacy/vue2`）描述缺口
- 范围内模块与外部行为：`front/vue3` 聚合路由头与侧边栏搜索；用户文档缺口表述
- 明确非目标：不改 React / Java 头契约，不给 Vue3 加新功能，不发明 Postman Collection 导出，不改 `legacy/`
- 范围外后续 issue：无

## 复现与验证

- 基线复现：`master` 上 Vue3 源码为 `knfie4j-gateway-request`；`BasicLayout.vue` `searchKey` 无 Tag 名称展开分支
- 自动验证：`./tools/test-vue3.sh` 通过（含 `check:search-menu` 与 Knife4jSpringUi 构建）；`./tools/test-docs.sh` 通过
- 当前 head SHA：`99d85df8787f85c8a56dbf2c137314d0509c2e0b`
- PR CI：当前 head 全绿（changes / java-build-test / vue3-test / docs-build）

## 独立审查

- Reviewer：独立 agent
- 全量审查 head：`6689c537ec20575e0ef539872a249490fe7567c4`，结论 revise
- Finding 处置：
  - 当前契约缺陷：`getting-started.md` / `migration.md` 仍称 React 缺 `enable-version`；已在 `99d85df8` 收口，并补 FAQ 已接入列表
  - 无效 / 拒绝：无
  - 范围外后续：无
- 定向复核 head：`99d85df8787f85c8a56dbf2c137314d0509c2e0b`，结论 approve

本地验证、独立审查与当前 head CI 均已具备，可维护者合并。

## 风险

- Vue3 搜索只恢复 Vue2 已有行为；网关头与后端契约对齐，错误拼写的旧请求不会被服务端识别
- 回滚：还原本分支提交即可

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c58420d0-e500-52a5-b3aa-4ae4af720a08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c58420d0-e500-52a5-b3aa-4ae4af720a08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

